### PR TITLE
Only Show Requested Data

### DIFF
--- a/server/src/models/Gym.js
+++ b/server/src/models/Gym.js
@@ -83,14 +83,28 @@ class Gym extends Model {
 
     const secondaryFilter = queryResults => {
       const { length } = queryResults
+      const filteredResults = []
+
       for (let i = 0; i < length; i += 1) {
         const gym = queryResults[i]
+
         if (gym.raid_pokemon_form === 0 && gym.raid_pokemon_id > 0) {
           const formId = masterfile[gym.raid_pokemon_id].default_form_id
-          if (formId) queryResults[i].raid_pokemon_form = formId
+          if (formId) gym.raid_pokemon_form = formId
+        }
+        if (args.filters[`p${gym.raid_pokemon_id}-${gym.raid_pokemon_form}`]
+          || args.filters[`e${gym.raid_level}`]) {
+          filteredResults.push(gym)
+        } else {
+          gym.raid_end_timestamp = null
+          gym.raid_spawn_timestamp = null
+          gym.raid_battle_timestamp = null
+          gym.raid_pokemon_id = null
+          gym.raid_level = null
+          filteredResults.push(gym)
         }
       }
-      return queryResults
+      return filteredResults
     }
 
     const results = await eval(query)

--- a/server/src/schema/pokestop.js
+++ b/server/src/schema/pokestop.js
@@ -29,5 +29,11 @@ module.exports = new GraphQLObjectType({
     first_seen_timestamp: { type: GraphQLInt },
     sponsor_id: { type: GraphQLInt },
     quest_pokemon_id: { type: GraphQLInt },
+    quest_form_id: { type: GraphQLInt },
+    quest_gender_id: { type: GraphQLInt },
+    quest_costume_id: { type: GraphQLInt },
+    quest_shiny: { type: GraphQLInt },
+    mega_pokemon_id: { type: GraphQLInt },
+    mega_amount: { type: GraphQLInt },
   }),
 })

--- a/src/components/markers/quest.js
+++ b/src/components/markers/quest.js
@@ -3,45 +3,24 @@ import Utility from '../../services/Utility'
 import { useStore, useMasterfile } from '../../hooks/useStore'
 
 export default function questMarker(pokestop) {
-  const rewards = JSON.parse(pokestop.quest_rewards)
   let iconUrl = '/images/pokestop/0.png'
-  const { type, info } = rewards ? rewards[0] : ''
 
-  if (type === 1 && info !== undefined && info.amount !== undefined) {
-    // XP
-    iconUrl = '/images/item/-2.png'
-  } else if (type === 2) {
-    // Item
-    const item = info && info.item_id
-    iconUrl = `/images/item/${item}.png`
-  } else if (type === 3) {
-    // Stardust
-    iconUrl = '/images/item/-1.png'
-  } else if (type === 4) {
-    // Candy
-    iconUrl = '/images/item/-3.png'
-  } else if (type === 5) {
-    // Avatar clothing
-    iconUrl = '/images/item/-4.png'
-  } else if (type === 6) {
-    // Quest
-    iconUrl = '/images/item/-5.png'
-  } else if (type === 7 && info !== undefined) {
-    // Pokemon
-    const { path } = useStore(state => state.settings).icons
-    const availableForms = useMasterfile(state => state.availableForms)
-    iconUrl = `${path}/${Utility.getPokemonIcon(availableForms, info.pokemon_id, info.form_id, 0, info.gender_id, info.costume_id, info.shiny)}.png`
-  } else if (type === 8) {
-    // Pokecoin
-    iconUrl = '/images/item/-6.png'
-  } else if (type === 11) {
-    // Sticker
-    iconUrl = '/images/item/-7.png'
-  } else if (type === 12) {
-    // Mega resource
-    iconUrl = '/images/item/-8.png'
-  } else {
-    iconUrl = '/images/item/-0.png'
+  switch (pokestop.quest_reward_type) {
+    default: iconUrl = '/images/item/-0.png'; break
+    case 1: iconUrl = '/images/item/-2.png'; break
+    case 2: iconUrl = `/images/item/${pokestop.quest_item_id}.png`; break
+    case 3: iconUrl = '/images/item/-1.png'; break
+    case 4: iconUrl = '/images/item/-3.png'; break
+    case 5: iconUrl = '/images/item/-4.png'; break
+    case 6: iconUrl = '/images/item/-5.png'; break
+    case 7: {
+      const { path } = useStore(state => state.settings).icons
+      const availableForms = useMasterfile(state => state.availableForms)
+      iconUrl = `${path}/${Utility.getPokemonIcon(availableForms, pokestop.quest_pokemon_id, pokestop.quest_form_id, 0, pokestop.quest_gender_id, pokestop.quest_costume_id, pokestop.quest_shiny)}.png`
+    } break
+    case 8: iconUrl = '/images/item/-6.png'; break
+    case 11: iconUrl = '/images/item/-7.png'; break
+    case 12: iconUrl = '/images/item/-8.png'; break
   }
 
   return new Icon({

--- a/src/components/popups/Gym.jsx
+++ b/src/components/popups/Gym.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 export default function GymPopup({ gym }) {
+  console.log(gym)
   return (
     <>
       {gym.name}

--- a/src/components/tiles/Pokestop.jsx
+++ b/src/components/tiles/Pokestop.jsx
@@ -9,7 +9,7 @@ const PokestopTile = ({ item, ts }) => (
     position={[item.lat, item.lon]}
     icon={stopMarker(item, ts)}
   >
-    {(item.quest_rewards || item.quest_pokemon_id)
+    {(item.quest_item_id || item.quest_pokemon_id || item.mega_amount)
       && (
         <Marker
           position={[item.lat, item.lon]}

--- a/src/services/queries/pokestop.js
+++ b/src/services/queries/pokestop.js
@@ -19,8 +19,15 @@ const lure = gql`
 
 const quest = gql`
   fragment Quest on Pokestop {
-    quest_rewards
+    quest_reward_type
+    quest_item_id
     quest_pokemon_id
+    quest_form_id
+    quest_gender_id
+    quest_costume_id
+    quest_shiny
+    mega_pokemon_id
+    mega_amount
   }
 `
 


### PR DESCRIPTION
- If a user wants to see specific rockets and specific quests, rockets will no longer show quests if they are not included in the list of desired quests.
- Example: a user has ultra balls and fire type rockets on. If a stop has a fire type rocket and an ultra ball, it will show both, otherwise it will only show the fire rocket. No pokeballs, pinaps, etc.