### PR TITLE
Make available optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,43 +24,52 @@
 1. Clone the repo
 2. Open up the directory (`cd ReactMap`)
 3. `yarn install`
-4. Generate Masterfile `yarn generate` (You will want to do this whenever new Pokemon/assets are released)
-5. Create your config (`cp server/src/configs/config.example.json server/src/configs/config.json`)
+4. Create your config (`cp server/src/configs/config.example.json server/src/configs/config.json`)
 - There are additional configs options available in `server/src/configs/default.json` that can be utilized by copying them over into your config file. Be sure to maintain the same object structure when copying options over
-6. Run your migrations (`yarn migrate:latest`)
+5. Run your migrations (`yarn migrate:latest`)
 - This will create a `users` table, would recommend putting this in your manual db that has nests/portals/sessions/etc 
 - A sessions table will automatically be created in the specified db after the next step, be sure you've selected the correct db in the config!
 - `yarn migrate:rollback` will rollback any migrations, be sure you know what you're doing to avoid data loss!
-7. `yarn start`
+6. `yarn start`
 ## Dev Instructions
 1. Follow steps 1-6 above
 2. Open two consoles
 3. `yarn dev` in one, starts the server with nodemon
 4. `yarn watch` in the other, this automatically re-compiles your bundle for faster development.
+- `yarn generate` if you want to experiment with the masterfile generator
+- `yarn build` to only build and not run the server
+- `yarn server` to only start the server without recompiling webpack
+- `yarn console` repl server for running code/playing with the ORM
+- `yarn migrate:make addNewFeature` to generate a new migration file called 'addNewFeature'
 
 ## PM2 Ecosystem Sample
 ```js
-  {
+module.exports = {
+  apps: [
+    {
       name: 'ReactMap',
-      script: 'index.js',
-      cwd: '/home/test/ReactMap/server/src',
+      script: 'yarn run server',
+      cwd: '/home/ReactMap/',
       instances: 1,
       autorestart: true,
       watch: ['configs/', 'dist/'],
       max_memory_restart: '1G',
-      out_file: 'NULL'
-  }
+      out_file: 'NULL',
+    }
+  ]
+}
 ```
 
 ## Updating
 1. `git pull`
 2. `yarn install`
-3. `yarn generate`
+
 Without PM2:
-- `yarn start`
+3. `yarn start`
+
 With PM2: 
-- `yarn build`
-- `pm2 restart ReactMap`
+3. `yarn build`
+4. `pm2 restart ReactMap`
 
 ## Coming Soon
 - Scan Areas

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 - `yarn migrate:make addNewFeature` to generate a new migration file called 'addNewFeature'
 
 ## PM2 Ecosystem Sample
+You can copy and paste the following code into an existing PM2 ecosystem file or start a new one with `touch ecosystem.config.js`.
 ```js
 module.exports = {
   apps: [
@@ -59,7 +60,7 @@ module.exports = {
   ]
 }
 ```
-
+`pm2 start ecosystem.config.js`
 ## Updating
 1. `git pull`
 2. `yarn install`
@@ -69,7 +70,7 @@ Without PM2:
 
 With PM2: 
 3. `yarn build`
-4. `pm2 restart ReactMap`
+4. `pm2 restart ReactMap` (If you opted out of watching the `dist/` folder)
 
 ## Coming Soon
 - Scan Areas

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "start": "webpack --env prod && node server/src/index.js",
-    "server": "node server/src/index.js",
+    "start": "webpack --env prod && node server/src/services/generateMasterfile.js && node server/src/index.js",
+    "server": "node server/src/services/generateMasterfile.js && node server/src/index.js",
     "dev": "nodemon server/src/index.js --watch server",
     "build": "webpack --env prod",
     "watch": "webpack --watch --env dev",

--- a/server/src/configs/config.example.json
+++ b/server/src/configs/config.example.json
@@ -3,7 +3,12 @@
   "port": 8080,
   "api": {
     "sessionSecret": "98ki^e72~!@#(85o3kXLI*#c9wu5l!Z",
-    "maxSessions": 5
+    "maxSessions": 5,
+    "queryAvailable": {
+      "pokemon": true,
+      "quests": false,
+      "raids": false
+    }
   },
   "map": {
     "title": "ReactMap",

--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -16,6 +16,11 @@
     "pvpMinCp": {
       "gl": 1400,
       "ul": 2400
+    },
+    "queryAvailable": {
+      "pokemon": true,
+      "quests": false,
+      "raids": false
     }
   },
   "map": {

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -32,6 +32,7 @@ const rateLimitOptions = {
   },
   /* eslint-disable no-unused-vars */
   onLimitReached: (req, res, options) => {
+    // eslint-disable-next-line no-console
     console.warn('user is being rate limited')
     res.redirect('/429')
   },

--- a/server/src/models/Gym.js
+++ b/server/src/models/Gym.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-syntax */
 const { Model } = require('objection')
+const fetchRaids = require('../services/functions/fetchRaids')
 const { pokemon: masterfile } = require('../data/masterfile.json')
 
 class Gym extends Model {
@@ -145,6 +146,9 @@ class Gym extends Model {
       .andWhere('raid_level', '>', 0)
       .groupBy('raid_pokemon_id', 'raid_pokemon_form', 'raid_level')
       .orderBy('raid_pokemon_id', 'asc')
+    if (results.length === 0) {
+      return fetchRaids()
+    }
     return results.map(pokemon => {
       if (pokemon.raid_pokemon_id === 0) {
         return `e${pokemon.raid_level}`

--- a/server/src/routes/rootRouter.js
+++ b/server/src/routes/rootRouter.js
@@ -58,13 +58,16 @@ rootRouter.get('/settings', async (req, res) => {
         }
       })
 
-      serverSettings.defaultFilters = await Utility.buildDefaultFilters(serverSettings.user.perms)
+      serverSettings.defaultFilters = Utility.buildDefaultFilters(serverSettings.user.perms)
+
+      const { pokemon, quests, raids } = config.api.queryAvailable
 
       serverSettings.available = {
-        pokemon: await Pokemon.getAvailablePokemon(),
-        gyms: await Gym.getAvailableRaidBosses(),
-        pokestops: await Pokestop.getAvailableQuests(),
+        pokemon: pokemon ? await Pokemon.getAvailablePokemon() : [],
+        gyms: raids ? await Gym.getAvailableRaidBosses() : await Utility.fetchRaids(),
+        pokestops: quests ? await Pokestop.getAvailableQuests() : await Utility.fetchQuests(),
       }
+
       serverSettings.ui = Utility.generateUi(serverSettings.defaultFilters, serverSettings.user.perms)
 
       serverSettings.menus = Utility.buildMenus()

--- a/server/src/services/Utility.js
+++ b/server/src/services/Utility.js
@@ -5,6 +5,9 @@ const buildDefaultFilters = require('./defaultFilters/buildDefaultFilters')
 const generateUi = require('./ui')
 const updateAvailableForms = require('./functions/updateAvailableForms')
 const buildMenus = require('./buildMenus')
+const fetchJson = require('./functions/fetchJson')
+const fetchRaids = require('./functions/fetchRaids')
+const fetchQuests = require('./functions/fetchQuests')
 
 class Utility {
   static getPolyVector(s2cellId, type) {
@@ -23,7 +26,7 @@ class Utility {
     return updateAvailableForms(icons)
   }
 
-  static async buildDefaultFilters(perms) {
+  static buildDefaultFilters(perms) {
     return buildDefaultFilters(perms)
   }
 
@@ -33,6 +36,18 @@ class Utility {
 
   static buildMenus() {
     return buildMenus()
+  }
+
+  static async fetchJson(url) {
+    return fetchJson(url)
+  }
+
+  static async fetchRaids() {
+    return fetchRaids()
+  }
+
+  static async fetchQuests() {
+    return fetchQuests()
   }
 }
 

--- a/server/src/services/defaultFilters/buildDefaultFilters.js
+++ b/server/src/services/defaultFilters/buildDefaultFilters.js
@@ -4,7 +4,7 @@ const buildPokestops = require('./buildPokestops.js')
 const buildGyms = require('./buildGyms')
 const { GenericFilter, PokemonFilter } = require('../../models/index')
 
-module.exports = async function buildDefault(perms) {
+module.exports = function buildDefault(perms) {
   const stopReducer = perms.pokestops || perms.lures || perms.quests || perms.invasions
   const gymReducer = perms.gyms || perms.raids
   const pokemonReducer = perms.iv || perms.stats || perms.pvp

--- a/server/src/services/functions/fetchJson.js
+++ b/server/src/services/functions/fetchJson.js
@@ -1,0 +1,9 @@
+const Fetch = require('node-fetch')
+
+module.exports = function fetchJson(url) {
+  return new Promise(resolve => {
+    Fetch(url)
+      .then(res => res.json())
+      .then(json => resolve(json))
+  })
+}

--- a/server/src/services/functions/fetchQuests.js
+++ b/server/src/services/functions/fetchQuests.js
@@ -1,0 +1,26 @@
+const fetchJson = require('./fetchJson')
+
+module.exports = async function fetchQuests() {
+  const quests = await fetchJson('https://raw.githubusercontent.com/ccev/pogoinfo/v2/active/quests.json')
+  const grunts = await fetchJson('https://raw.githubusercontent.com/ccev/pogoinfo/v2/active/grunts.json')
+  const questsInfo = []
+  Object.values(quests).forEach(questType => {
+    questType.forEach(task => {
+      const megaAmount = task.task.includes('5') ? 10 : 20
+      task.rewards.forEach(reward => {
+        switch (reward.type) {
+          default: questsInfo.push(`${reward.reward.id}-${reward.reward.form || 0}`); break
+          case 'stardust': questsInfo.push(`d${reward.amount}`); break
+          case 'item': questsInfo.push(`q${reward.id}`); break
+          case 'energy': questsInfo.push(`m${reward.reward.id}-${megaAmount}`); break
+        }
+      })
+    })
+  })
+  Object.keys(grunts).forEach(grunt => {
+    if (grunts[grunt].active) {
+      questsInfo.push(`i${grunt}`)
+    }
+  })
+  return questsInfo
+}

--- a/server/src/services/functions/fetchRaids.js
+++ b/server/src/services/functions/fetchRaids.js
@@ -1,0 +1,12 @@
+const fetchJson = require('./fetchJson')
+
+module.exports = async function fetchRaids() {
+  const pogoInfoResults = await fetchJson('https://raw.githubusercontent.com/ccev/pogoinfo/v2/active/raids.json')
+  const raidsInfo = []
+  Object.entries(pogoInfoResults).forEach(raidTier => {
+    const [egg, bosses] = raidTier
+    raidsInfo.push(`e${egg}`)
+    bosses.forEach(boss => raidsInfo.push(`${boss.id}-${boss.form || 0}`))
+  })
+  return raidsInfo
+}

--- a/src/services/functions/menuFilter.js
+++ b/src/services/functions/menuFilter.js
@@ -44,7 +44,7 @@ export default function menuFilter(tempFilters, menus, search, type) {
     const questCheck = (!Number.isNaN(parseInt(id.charAt(0))) || id.startsWith('m') || id.startsWith('q') || id.startsWith('d')) && stopPerms.quests
     const invasionsCheck = id.startsWith('i') && stopPerms.invasions
 
-    if ((stopCheck || lureCheck || questCheck || invasionsCheck) && stop) {
+    if ((stopCheck || lureCheck || questCheck || invasionsCheck) && stop.name) {
       show += 1
       let urlBuilder
       switch (id.charAt(0)) {
@@ -64,7 +64,7 @@ export default function menuFilter(tempFilters, menus, search, type) {
   const addGym = (id, gym) => {
     const raidCheck = (!Number.isNaN(parseInt(id.charAt(0))) && gymPerms.raids) || (id.startsWith('e') && gymPerms.raids)
     const gymCheck = (id.startsWith('g') && gymPerms.gyms) || (id.startsWith('t') && gymPerms.gyms)
-    if ((raidCheck || gymCheck) && gym) {
+    if ((raidCheck || gymCheck) && gym.name) {
       show += 1
       let urlBuilder
       switch (id.charAt(0)) {
@@ -123,21 +123,20 @@ export default function menuFilter(tempFilters, menus, search, type) {
         switch (id.charAt(0)) {
           default: pokestop.category = 'pokestops'; break
           case 'i':
-            pokestop = masterfile.invasions[id.slice(1)]
+            pokestop = masterfile.invasions[id.slice(1)] || {}
             pokestop.category = 'invasions'
             pokestop.name = pokestop.type; break
           case 'd':
-            pokestop = { name: `x${id.slice(1)}` }
+            pokestop = { name: `x${id.slice(1)}` } || {}
             pokestop.category = 'items'; break
           case 'm':
-            pokestop = { name: `${masterfile.pokemon[id.slice(1).split('-')[0]].name} x${id.split('-')[1]}` }
+            pokestop = { name: `${masterfile.pokemon[id.slice(1).split('-')[0]].name} x${id.split('-')[1]}` } || {}
             pokestop.category = 'energy'; break
           case 'q':
-            pokestop = masterfile.items[id.slice(1)]
+            pokestop = masterfile.items[id.slice(1)] || {}
             pokestop.category = 'items'; break
           case 'l':
-            pokestop = masterfile.items[id.slice(1)]
-            pokestop.name = id === 'l501' ? 'Lure' : pokestop.name
+            pokestop = masterfile.items[id.slice(1)] || {}
             pokestop.category = 'lures'; break
         }
         switch (switchKey) {
@@ -180,7 +179,7 @@ export default function menuFilter(tempFilters, menus, search, type) {
         && Number.isNaN(parseInt(id.charAt(0)))
         && !id.startsWith('g')) {
         total += 1
-        const gym = masterfile.gyms[id]
+        const gym = masterfile.gyms[id] || {}
         switch (switchKey) {
           default:
             if (categories[gym.category]) {


### PR DESCRIPTION
- Add config options to skip querying db in favor of fetching active quests/invasions/raid bosses from Pogo Info repo
- Add check to fetch these repos if the db query returns empty (at night when Raids end or if quests are cleared due to a reroll)
- Compares invasions and returns latest if new lineups are available
- Change startup scripts to generate the masterfile at restart
- Update readme

Thanks @ccev