### PR TITLE
Areas.json optional

### DIFF
--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -38,6 +38,7 @@
     "startZoom": 12,
     "minZoom": 10,
     "maxZoom": 18,
+    "noScanAreaOverlay": false,
     "scanAreasZoom": 12,
     "scanCellsZoom": 13,
     "submissionZoom": 15,
@@ -354,5 +355,5 @@
     "regional": [],
     "event": []
   },
-  "manualAreas": null
+  "manualAreas": {}
 }

--- a/server/src/services/defaultFilters/buildDefaultFilters.js
+++ b/server/src/services/defaultFilters/buildDefaultFilters.js
@@ -1,4 +1,3 @@
-const fs = require('fs')
 const { defaultFilters } = require('../config.js')
 const buildPokemon = require('./buildPokemon.js')
 const buildPokestops = require('./buildPokestops.js')
@@ -64,7 +63,7 @@ module.exports = function buildDefault(perms) {
         new: new GenericFilter(),
       },
     } : undefined,
-    scanAreas: perms.scanAreas && fs.existsSync('server/src/configs/areas.json') ? {
+    scanAreas: perms.scanAreas ? {
       enabled: defaultFilters.scanAreas.enabled,
       filter: {},
     } : undefined,

--- a/src/components/layout/drawer/Areas.jsx
+++ b/src/components/layout/drawer/Areas.jsx
@@ -6,12 +6,10 @@ import {
 import center from '@turf/center'
 import { useMap } from 'react-leaflet'
 
-import { useStatic } from '@hooks/useStore'
 import Utility from '@services/Utility'
 import Query from '@services/Query'
 
-export default function AreaDropDown() {
-  const { map: { scanAreasZoom }, manualAreas } = useStatic(state => state.config)
+export default function AreaDropDown({ scanAreasZoom, manualAreas }) {
   const { data } = useQuery(Query.scanAreas())
   const map = useMap()
 

--- a/src/components/layout/drawer/Drawer.jsx
+++ b/src/components/layout/drawer/Drawer.jsx
@@ -19,7 +19,7 @@ export default function DrawerMenu({
   const ui = useStatic(state => state.ui)
   const staticUserSettings = useStatic(state => state.userSettings)
   const { drawer: drawerStyle } = useStore(state => state.settings)
-  const { map: { title } } = useStatic(state => state.config)
+  const { map: { title, scanAreasZoom, noScanAreaOverlay }, manualAreas } = useStatic(state => state.config)
   const { t } = useTranslation()
   const [expanded, setExpanded] = useState('')
 
@@ -39,6 +39,7 @@ export default function DrawerMenu({
               filters={filters}
               setFilters={setFilters}
               subItem={subItem}
+              noScanAreaOverlay={noScanAreaOverlay}
             />
           ))
         ); break
@@ -107,7 +108,12 @@ export default function DrawerMenu({
                   </Button>
                 </Grid>
               )}
-            {category === 'scanAreas' && <Areas />}
+            {category === 'scanAreas' && (
+            <Areas
+              scanAreasZoom={scanAreasZoom}
+              manualAreas={manualAreas}
+            />
+            )}
           </Grid>
         </AccordionDetails>
       </Accordion>

--- a/src/components/layout/drawer/WithSubItems.jsx
+++ b/src/components/layout/drawer/WithSubItems.jsx
@@ -5,10 +5,14 @@ import {
 import { useTranslation } from 'react-i18next'
 
 export default function WithSubItems({
-  category, filters, setFilters, subItem,
+  category, filters, setFilters, subItem, noScanAreaOverlay,
 }) {
   const { t } = useTranslation()
   let filterCategory
+
+  if (category === 'scanAreas' && noScanAreaOverlay) {
+    return null
+  }
 
   if (category === 'wayfarer' || category === 'admin') {
     filterCategory = (


### PR DESCRIPTION
- Removes a check that required the areas.json file, even if you were using manual areas
- Makes the "enabled" button optional via the config. If you are only using the manual areas, this switch does nothing, so it's best to disable it entirely so you don't confuse users. 
- If you are using manual areas for the list but still want to use your areas.json for the overlay, then leave this new config option false.