### PR TITLE
Timer CSS/Toggle & Mui Overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ If you're using Chuck to parse Pokemon you can add any number of leagues to the 
   }
 ```
 
+- A note on the `useFor` fields for each schema. These fields represent model names, not table names. They can be moved between schemas to accommodate any number of databases you wish to use, but they cannot be duplicated and must be spelled exactly the way they are in the config example.
+
 ## Coming Soon
 - Built in event viewer
 - Expand the help modals

--- a/public/base-locales/en.json
+++ b/public/base-locales/en.json
@@ -236,5 +236,7 @@
   "minIvCircle": "Minimum Circle IV",
   "interactionRanges": "Interaction Ranges",
   "cannotConnect": "\nUnable to connect to the server at this time.\nTrying again immediately will only cause more issues.\nPlease try again in a few minutes.\n\n- Map Admin Team",
-  "madQuestText": "Native Quests"
+  "madQuestText": "Native Quests",
+  "primary": "Primary",
+  "secondary": "Secondary"
 }

--- a/src/assets/mui/theme.js
+++ b/src/assets/mui/theme.js
@@ -37,5 +37,26 @@ export default function createTheme(theme, darkMode) {
         disableRipple: true,
       },
     },
+    overrides: {
+      MuiAccordion: {
+        root: {
+          '&$expanded': {
+            margin: '1px 0',
+          },
+        },
+      },
+      MuiAccordionSummary: {
+        root: {
+          '&$expanded': {
+            minHeight: 10,
+          },
+        },
+        content: {
+          '&$expanded': {
+            margin: '10px 0',
+          },
+        },
+      },
+    },
   }))
 }

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -45,6 +45,13 @@ body {
   height: 50px;
 }
 
+.leaflet-tooltip {
+  font-weight: bold;
+  border: none;
+  max-height: 15px;
+  padding: 0px 2px !important;
+  border-radius: .5rem !important;
+}
 
 .leaflet-popup-tip-container .leaflet-popup-tip {
   background-color: rgb(33, 37, 31);

--- a/src/components/layout/dialogs/filters/SlotSelection.jsx
+++ b/src/components/layout/dialogs/filters/SlotSelection.jsx
@@ -72,7 +72,7 @@ export default function SlotSelection({ teamId, toggleSlotsMenu, tempFilters }) 
   return (
     <>
       <DialogTitle className={classes.filterHeader}>
-        {t(`team${teamId}`)} {t('slotSelection')}
+        {t(`team_${teamId}`)} {t('slotSelection')}
         <IconButton
           onClick={toggleSlotsMenu(false)}
           style={{ position: 'absolute', right: 5, top: 5 }}

--- a/src/components/layout/drawer/WithSliders.jsx
+++ b/src/components/layout/drawer/WithSliders.jsx
@@ -105,7 +105,7 @@ export default function WithSliders({
               style={{ backgroundColor: '#424242' }}
             >
               {Object.keys(context.sliders).map(slider => (
-                <Tab label={slider} key={slider} style={{ width: 5, minWidth: 5 }} />
+                <Tab label={t(slider)} key={slider} style={{ width: 5, minWidth: 5 }} />
               ))}
             </Tabs>
           </AppBar>

--- a/src/components/popups/Gym.jsx
+++ b/src/components/popups/Gym.jsx
@@ -167,7 +167,11 @@ const Header = ({
 
   const handleTimer = () => {
     setAnchorEl(null)
-    setTimerList([...timerList, id])
+    if (timerList.includes(id)) {
+      setTimerList(timerList.filter(x => x !== id))
+    } else {
+      setTimerList([...timerList, id])
+    }
   }
 
   const options = [

--- a/src/components/popups/Gym.jsx
+++ b/src/components/popups/Gym.jsx
@@ -389,7 +389,7 @@ const RaidInfo = ({ gym, t }) => {
 
   const getRaidName = (raidLevel, id) => {
     if (id) {
-      return pokemon[raid_pokemon_id].name
+      return t(`poke_${raid_pokemon_id}`)
     }
     return `${t('tier')} ${raidLevel}`
   }

--- a/src/components/popups/Gym.jsx
+++ b/src/components/popups/Gym.jsx
@@ -351,7 +351,7 @@ const GymInfo = ({ gym, t }) => {
       </Grid>
       <Grid item xs={12}>
         <Typography variant="subtitle1" align="center">
-          {t('slots')} {availble_slots}
+          {availble_slots} {t('slots')}
         </Typography>
       </Grid>
       {ex_raid_eligible && (

--- a/src/components/popups/Pokemon.jsx
+++ b/src/components/popups/Pokemon.jsx
@@ -143,7 +143,11 @@ const Header = ({
 
   const handleTimer = () => {
     setAnchorEl(null)
-    setTimerList([...timerList, id])
+    if (timerList.includes(id)) {
+      setTimerList(timerList.filter(x => x !== id))
+    } else {
+      setTimerList([...timerList, id])
+    }
   }
 
   const options = [

--- a/src/components/popups/Pokestop.jsx
+++ b/src/components/popups/Pokestop.jsx
@@ -212,7 +212,11 @@ const Header = ({
 
   const handleTimer = () => {
     setAnchorEl(null)
-    setTimerList([...timerList, id])
+    if (timerList.includes(id)) {
+      setTimerList(timerList.filter(x => x !== id))
+    } else {
+      setTimerList([...timerList, id])
+    }
   }
 
   const options = [


### PR DESCRIPTION
- Reduces the footprints of timers
- Fixes timers from not being able to toggle
- Reduces the footprint of the accordions
- Adds a couple of missing translation keys
- Timers can be toggled
- Update readme
- Reverses Gym Slot for better grammar
- Fixes Raid bosses not being translated