### PR TITLE
SQL Area Restrictions

### DIFF
--- a/server/src/configs/config.example.json
+++ b/server/src/configs/config.example.json
@@ -81,6 +81,16 @@
     "allowedGuilds": [],
     "blockedGuilds": [],
     "allowedUsers": [],
+    "areaRestrictions": {
+      "rule1": {
+          "roles": [],
+          "areas": []
+      },
+      "rule2": {
+          "roles": [],
+          "areas": []
+      }
+    },
     "perms": {
       "map": {
         "enabled": true,

--- a/server/src/configs/config.example.json
+++ b/server/src/configs/config.example.json
@@ -81,16 +81,16 @@
     "allowedGuilds": [],
     "blockedGuilds": [],
     "allowedUsers": [],
-    "areaRestrictions": {
-      "rule1": {
-          "roles": [],
-          "areas": []
+    "areaRestrictions": [
+      {
+        "roles": [],
+        "areas": []
       },
-      "rule2": {
-          "roles": [],
-          "areas": []
+      {
+        "roles": [],
+        "areas": []
       }
-    },
+    ],
     "perms": {
       "map": {
         "enabled": true,

--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -236,16 +236,7 @@
     "allowedGuilds": [],
     "blockedGuilds": [],
     "allowedUsers": [],
-    "areaRestrictions": {
-      "rule1": {
-          "roles": [],
-          "areas": []
-      },
-      "rule2": {
-          "roles": [],
-          "areas": []
-      }
-    },
+    "areaRestrictions": [],
     "perms": {
       "map": {
         "enabled": true,

--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -236,6 +236,16 @@
     "allowedGuilds": [],
     "blockedGuilds": [],
     "allowedUsers": [],
+    "areaRestrictions": {
+      "rule1": {
+          "roles": [],
+          "areas": []
+      },
+      "rule2": {
+          "roles": [],
+          "areas": []
+      }
+    },
     "perms": {
       "map": {
         "enabled": true,

--- a/server/src/db/initialization.js
+++ b/server/src/db/initialization.js
@@ -15,7 +15,6 @@ const connections = Object.values(schemas).map(schema => Knex({
   pool: {
     afterCreate(conn, done) {
       conn.query('SET time_zone="+00:00";', (err) => done(err, conn))
-      console.log('Timezone Set')
     },
   },
 }))

--- a/server/src/models/Gym.js
+++ b/server/src/models/Gym.js
@@ -3,6 +3,7 @@ const { Model, raw } = require('objection')
 const fetchRaids = require('../services/functions/fetchRaids')
 const { pokemon: masterfile } = require('../data/masterfile.json')
 const dbSelection = require('../services/functions/dbSelection')
+const getAreaSql = require('../services/functions/getAreaSql')
 
 class Gym extends Model {
   static get tableName() {
@@ -16,7 +17,7 @@ class Gym extends Model {
 
   static async getAllGyms(args, perms, isMad) {
     const ts = Math.floor((new Date()).getTime() / 1000)
-    const { gyms, raids } = perms
+    const { gyms, raids, areaRestrictions } = perms
     const {
       onlyGyms, onlyRaids, onlyExEligible, onlyInBattle, onlyArEligible,
     } = args.filters
@@ -153,6 +154,9 @@ class Gym extends Model {
         })
       }
     })
+    if (areaRestrictions.length > 0) {
+      getAreaSql(query, areaRestrictions, isMad)
+    }
 
     const secondaryFilter = queryResults => {
       const { length } = queryResults

--- a/server/src/models/Pokemon.js
+++ b/server/src/models/Pokemon.js
@@ -165,7 +165,6 @@ class Pokemon extends Model {
     query.where(isMad ? 'disappear_time' : 'expire_timestamp', '>=', isMad ? this.knex().fn.now() : ts)
       .andWhereBetween(isMad ? 'pokemon.latitude' : 'lat', [args.minLat, args.maxLat])
       .andWhereBetween(isMad ? 'pokemon.longitude' : 'lon', [args.minLon, args.maxLon])
-      // .andWhereRaw(getAreaSql(areaRestrictions))
       .andWhere(ivOr => {
         for (const [pkmn, filter] of Object.entries(args.filters)) {
           if (pkmn.includes('-')) {

--- a/server/src/models/Pokemon.js
+++ b/server/src/models/Pokemon.js
@@ -192,7 +192,7 @@ class Pokemon extends Model {
             .andWhere('weight', '<=', 2.40625)
         }
         if (onlyZeroIv && ivs) {
-          ivOr.orWhere('iv', 0)
+          ivOr.orWhere(isMad ? raw(ivCalc) : 'iv', 0)
         }
       })
     if (areaRestrictions.length > 0) {

--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -3,6 +3,7 @@ const { Model, raw } = require('objection')
 const { pokemon: masterfile } = require('../data/masterfile.json')
 const fetchQuests = require('../services/functions/fetchQuests')
 const dbSelection = require('../services/functions/dbSelection')
+const getAreaSql = require('../services/functions/getAreaSql')
 
 class Pokestop extends Model {
   static get tableName() {
@@ -17,7 +18,7 @@ class Pokestop extends Model {
   static async getAllPokestops(args, perms, isMad) {
     const ts = Math.floor((new Date()).getTime() / 1000)
     const {
-      lures: lurePerms, quests: questPerms, invasions: invasionPerms, pokestops: pokestopPerms,
+      lures: lurePerms, quests: questPerms, invasions: invasionPerms, pokestops: pokestopPerms, areaRestrictions,
     } = perms
     const {
       onlyAllPokestops, onlyLures, onlyQuests, onlyInvasions, onlyArEligible,
@@ -60,6 +61,9 @@ class Pokestop extends Model {
     query.whereBetween(isMad ? 'latitude' : 'lat', [args.minLat, args.maxLat])
       .andWhereBetween(isMad ? 'longitude' : 'lon', [args.minLon, args.maxLon])
       .andWhere(isMad ? 'enabled' : 'deleted', isMad)
+    if (areaRestrictions.length > 0) {
+      getAreaSql(query, areaRestrictions, isMad)
+    }
 
     const parseRewards = pokestop => {
       if (pokestop.quest_reward_type) {

--- a/server/src/models/Portal.js
+++ b/server/src/models/Portal.js
@@ -1,8 +1,20 @@
 const { Model } = require('objection')
+const getAreaSql = require('../services/functions/getAreaSql')
 
 class Portal extends Model {
   static get tableName() {
     return 'ingress_portals'
+  }
+
+  static async getAllPortals(args, perms) {
+    const { areaRestrictions } = perms
+    const query = this.query()
+      .whereBetween('lat', [args.minLat, args.maxLat])
+      .andWhereBetween('lon', [args.minLon, args.maxLon])
+    if (areaRestrictions.length > 0) {
+      getAreaSql(query, areaRestrictions)
+    }
+    return query
   }
 }
 

--- a/server/src/models/S2cell.js
+++ b/server/src/models/S2cell.js
@@ -1,6 +1,7 @@
 const { Model, ref } = require('objection')
 const dbSelection = require('../services/functions/dbSelection')
 const getPolyVector = require('../services/functions/getPolyVector')
+const getAreaSql = require('../services/functions/getAreaSql')
 
 class S2cell extends Model {
   static get tableName() {
@@ -8,13 +9,18 @@ class S2cell extends Model {
       ? 'trs_s2cells' : 's2cell'
   }
 
-  static async getAllCells(args, isMad) {
-    const results = await this.query()
+  static async getAllCells(args, perms, isMad) {
+    const { areaRestrictions } = perms
+    const query = this.query()
       .select(['*', ref('id')
         .castTo('CHAR')
         .as('id')])
       .whereBetween(`center_lat${isMad ? 'itude' : ''}`, [args.minLat - 0.01, args.maxLat + 0.01])
       .andWhereBetween(`center_lon${isMad ? 'gitude' : ''}`, [args.minLon - 0.01, args.maxLon + 0.01])
+    if (areaRestrictions.length > 0) {
+      getAreaSql(query, areaRestrictions, isMad, 's2cell')
+    }
+    const results = await query
     return results.map(cell => ({
       ...cell,
       polygon: getPolyVector(cell.id, 'polygon'),

--- a/server/src/schema/schema.js
+++ b/server/src/schema/schema.js
@@ -16,7 +16,6 @@ const ScanAreaType = require('./scanArea')
 const SpawnpointType = require('./spawnpoint')
 const WeatherType = require('./weather')
 const Utility = require('../services/Utility')
-const getAreaSql = require('../services/functions/getAreaSql')
 
 const {
   Device, Gym, Pokemon, Pokestop, Portal, S2cell, Spawnpoint, Weather, Nest,
@@ -189,13 +188,7 @@ const RootQuery = new GraphQLObjectType({
       async resolve(parent, args, req) {
         const perms = req.user ? req.user.perms : req.session.perms
         if (perms.portals) {
-          const query = Portal.query()
-            .whereBetween('lat', [args.minLat, args.maxLat])
-            .andWhereBetween('lon', [args.minLon, args.maxLon])
-          if (perms.areaRestrictions.length > 0) {
-            getAreaSql(query, perms.areaRestrictions)
-          }
-          return query
+          return Portal.getAllPortals(args, perms)
         }
       },
     },

--- a/server/src/services/areas.js
+++ b/server/src/services/areas.js
@@ -1,21 +1,19 @@
 /* eslint-disable no-restricted-syntax */
 const fs = require('fs')
 const path = require('path')
-const config = require('./config.js')
+const { discord: { areaRestrictions } } = require('./config.js')
 
 const loadAreas = () => {
   let areas = {}
-  let showWarning = false
-
   const areasFilePath = path.resolve(__dirname, '../configs/areas.json')
   try {
     const data = fs.readFileSync(areasFilePath, 'utf8')
     areas = JSON.parse(data)
   } catch (err) {
-    for (const role of Object.values(config.discord.areaRestrictions)) {
-      if (role.roles.length !== 0) showWarning = true
+    const showWarning = areaRestrictions.some(rule => rule.roles.length > 0)
+    if (showWarning) {
+      console.warn('[Area Restrictions] Disabled - `areas.json` file is missing or broken.')
     }
-    if (showWarning) console.warn('[Area Restrictions] Disabled - `areas.json` file is missing or broken.')
   }
   return areas
 }
@@ -24,16 +22,18 @@ const parseAreas = (areasObj) => {
   let names = {}
   const polygons = {}
 
-  if (Object.keys(areasObj).length === 0) return { names, polygons }
+  if (Object.keys(areasObj).length === 0) {
+    return { names, polygons }
+  }
 
-  for (const feature of areasObj.features) {
+  areasObj.features.forEach(feature => {
     if (feature.geometry.type == 'Polygon' && feature.properties.name) {
       polygons[feature.properties.name] = []
       for (const polygonCoordinates of feature.geometry.coordinates) {
         polygons[feature.properties.name].push(...polygonCoordinates)
       }
     }
-  }
+  })
   names = Object.keys(polygons)
   return { names, polygons }
 }

--- a/server/src/services/areas.js
+++ b/server/src/services/areas.js
@@ -1,0 +1,48 @@
+/* eslint-disable no-restricted-syntax */
+const fs = require('fs')
+const path = require('path')
+const config = require('./config.js')
+
+const loadAreas = () => {
+  let areas = {}
+  let showWarning = false
+
+  const areasFilePath = path.resolve(__dirname, '../configs/areas.json')
+  try {
+    const data = fs.readFileSync(areasFilePath, 'utf8')
+    areas = JSON.parse(data)
+  } catch (err) {
+    for (const role of Object.values(config.discord.areaRestrictions)) {
+      if (role.roles.length !== 0) showWarning = true
+    }
+    if (showWarning) console.warn('[Area Restrictions] Disabled - `areas.json` file is missing or broken.')
+  }
+  return areas
+}
+
+const parseAreas = (areasObj) => {
+  let names = {}
+  const polygons = {}
+
+  if (Object.keys(areasObj).length === 0) return { names, polygons }
+
+  for (const feature of areasObj.features) {
+    if (feature.geometry.type == 'Polygon' && feature.properties.name) {
+      polygons[feature.properties.name] = []
+      for (const polygonCoordinates of feature.geometry.coordinates) {
+        polygons[feature.properties.name].push(...polygonCoordinates)
+      }
+    }
+  }
+  names = Object.keys(polygons)
+  return { names, polygons }
+}
+
+const raw = loadAreas()
+const { names, polygons } = parseAreas(raw)
+
+module.exports = {
+  raw,
+  names,
+  polygons,
+}

--- a/server/src/services/functions/getAreaSql.js
+++ b/server/src/services/functions/getAreaSql.js
@@ -1,0 +1,24 @@
+const areas = require('../areas.js')
+
+module.exports = function getAreaRestrictionSql(query, areaRestrictions, isMad, category) {
+  let columns = ['lat', 'lon']
+  if (isMad && category !== 'device') {
+    columns = ['latitude', 'longitude']
+  }
+  if (isMad && category === 'pokemon') {
+    columns = columns.map(each => `pokemon.${each}`)
+  }
+  if (category === 's2cell') {
+    columns = columns.map(each => `center_${each}`)
+  }
+  if (category === 'device') {
+    columns = columns.map(each => `last_${each}`)
+  }
+
+  query.andWhere(restrictions => {
+    areaRestrictions.forEach(area => {
+      const polygon = areas.polygons[area].map(e => e.join(' ')).join()
+      restrictions.orWhereRaw(`ST_CONTAINS(ST_GeomFromText("POLYGON((${polygon}))"), POINT(${columns[1]}, ${columns[0]}))`)
+    })
+  })
+}

--- a/server/src/services/functions/getAreaSql.js
+++ b/server/src/services/functions/getAreaSql.js
@@ -2,17 +2,20 @@ const areas = require('../areas.js')
 
 module.exports = function getAreaRestrictionSql(query, areaRestrictions, isMad, category) {
   let columns = ['lat', 'lon']
-  if (isMad && category !== 'device') {
-    columns = ['latitude', 'longitude']
-  }
-  if (isMad && category === 'pokemon') {
-    columns = columns.map(each => `pokemon.${each}`)
+  if (isMad) {
+    if (category === 'device') {
+      columns = ['X(currentPos)', 'Y(currentPos)']
+    } else {
+      columns = ['latitude', 'longitude']
+    }
+    if (category === 'pokemon') {
+      columns = columns.map(each => `pokemon.${each}`)
+    }
+  } else if (category === 'device') {
+    columns = columns.map(each => `last_${each}`)
   }
   if (category === 's2cell') {
     columns = columns.map(each => `center_${each}`)
-  }
-  if (category === 'device') {
-    columns = columns.map(each => `last_${each}`)
   }
 
   query.andWhere(restrictions => {


### PR DESCRIPTION
Adds SQL Area Restrictions for:
- Devices
- Gyms
- Nests
- Pokemon
- Pokestops
- S2 Scan Cells
- Spawnpoints
- Unlimited number of rules can be set in the config

Partially authored by @Len for MapJS.

Co-Authored-By: Jakub <10072920+lenisko@users.noreply.github.com>