### PR TITLE
Add option to offset raid boss/egg/quest rewards on markers

### DIFF
--- a/public/base-locales/fr.json
+++ b/public/base-locales/fr.json
@@ -222,7 +222,7 @@
   "adminOptions": "Options Admin",
   "clustering": "Clustering",
   "prioritizePvpInfo": "Prioriser info PVP",
-  "glow": "Aura",
+  "glow": "Halo",
   "legacyFilter": "Filtre Legacy",
   "raidTimers": "Tous les Timers Raid",
   "invasionTimers": "Tous les Timers Invasion",

--- a/public/base-locales/fr.json
+++ b/public/base-locales/fr.json
@@ -1,6 +1,6 @@
 {
   "login": "Connexion",
-  "clickOnce": "Ne cliquer Connexion qu'une fois",
+  "clickOnce": "Ne cliquer 'Connexion' qu'une fois",
   "save": "Enregistrer",
   "reset": "Réinitialiser",
   "close": "Fermer",
@@ -74,7 +74,7 @@
   "tileServers": "Type de Carte",
   "icons": "Icônes",
   "navigation": "Navigation",
-  "drawer": "Drawer",
+  "drawer": "Menu",
   "tileServersDefault": "Défaut",
   "tileServersOSM": "OSM",
   "tileServersDarkMatter": "Dark Matter",

--- a/public/base-locales/fr.json
+++ b/public/base-locales/fr.json
@@ -220,7 +220,7 @@
   "nestsOptions": "Options Nids",
   "wayfarerOptions": "Options Wayfarer",
   "adminOptions": "Options Admin",
-  "clustering": "Clustering",
+  "clustering": "Regrouper",
   "prioritizePvpInfo": "Prioriser info PVP",
   "glow": "Halo",
   "legacyFilter": "Filtre Legacy",

--- a/public/base-locales/fr.json
+++ b/public/base-locales/fr.json
@@ -236,7 +236,7 @@
   "ivCircles": "Indicateurs d'IV",
   "minIvCircle": "Seuil étiquette IV",
   "interactionRanges": "Portée d'interaction",
-  "cannotConnect": "\nImpossible de se connecter au serveur.\nRé-essayer immédiatement ne ferait que surcharger le serveur.\nEssayez à nouveau dans quelques minutes.\n\n- Merci",
+  "cannotConnect": "\nImpossible de se connecter au serveur.\nRé-essayer immédiatement ne ferait que surcharger le serveur.\nEssayez à nouveau dans quelques minutes.\n\n- Merci -",
   "madQuestText": "Quêtes Directes",
   "primary": "Primaire",
   "secondary": "Secondaire"

--- a/public/base-locales/fr.json
+++ b/public/base-locales/fr.json
@@ -239,5 +239,6 @@
   "cannotConnect": "\nImpossible de se connecter au serveur.\nRé-essayer immédiatement ne ferait que surcharger le serveur.\nEssayez à nouveau dans quelques minutes.\n\n- Merci -",
   "madQuestText": "Quêtes Directes",
   "primary": "Primaire",
-  "secondary": "Secondaire"
+  "secondary": "Secondaire",
+  "zeroIv": "IV 0%"
 }

--- a/public/base-locales/fr.json
+++ b/public/base-locales/fr.json
@@ -235,7 +235,7 @@
   "arEligible": "RA Actif",
   "ivCircles": "Indicateurs d'IV",
   "minIvCircle": "Seuil étiquette IV",
-  "interactionRanges": "Portée de capture",
+  "interactionRanges": "Portée d'interaction",
   "cannotConnect": "\nImpossible de se connecter au serveur.\nRé-essayer immédiatement ne ferait que surcharger le serveur.\nEssayez à nouveau dans quelques minutes.\n\n- Merci",
   "madQuestText": "Quêtes Directes",
   "primary": "Primaire",

--- a/public/base-locales/fr.json
+++ b/public/base-locales/fr.json
@@ -233,6 +233,11 @@
   "items": "Objets",
   "energy": "Énergie",
   "arEligible": "RA Actif",
+  "ivCircles": "Indicateurs d'IV",
+  "minIvCircle": "Seuil étiquette IV",
+  "interactionRanges": "Portée de capture",
+  "cannotConnect": "\nImpossible de se connecter au serveur.\nRé-essayer immédiatement ne ferait que surcharger le serveur.\nEssayez à nouveau dans quelques minutes.\n\n- Merci",
+  "madQuestText": "Quêtes Directes",
   "primary": "Primaire",
   "secondary": "Secondaire"
 }

--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -95,6 +95,17 @@
         "lg": 2,
         "xl": 3
       }
+    },
+    "iconOffsets": {
+      "gyms": {
+        "offsetX": 0,
+        "offsetY": 0
+      },
+      "pokestops": {
+        "offsetX": 0,
+        "offsetY": 0,
+        "sizeMultiplier": 0
+      }
     }
   },
   "clientSideOptions": {
@@ -123,7 +134,7 @@
       "glow": [
         {"name": "Hundo", "perm": "iv", "num": 100, "value": "#ff1744", "op": "=" },
         {"name": "Top 3 Ranks", "perm": "pvp", "num": 3, "value": "#0000ff", "op": "<=" },
-        {"name": "Multiple", "perm": "pvp", "value": "#800080" }    
+        {"name": "Multiple", "perm": "pvp", "value": "#800080" }
       ]
     },
     "wayfarer": {
@@ -340,7 +351,7 @@
   "navigation": {
     "GoogleMaps": {
       "url": "https://www.google.com/maps/place/{x},{y}"
-    }, 
+    },
     "AppleMaps": {
       "url": "https://maps.apple.com/maps?daddr={x},{y}"
     },

--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -75,18 +75,13 @@
         "sm": 20,
         "md": 35,
         "lg": 50,
-        "xl": 65,
-        "offsetX": 0,
-        "offsetY": 0
+        "xl": 65
       },
       "pokestops": {
         "sm": 15,
         "md": 25,
         "lg": 35,
-        "xl": 45,
-        "offsetX": 0,
-        "offsetY": 0,
-        "sizeMultiplier": 0
+        "xl": 45
       },
       "pokemon": {
         "sm": 20,
@@ -358,7 +353,18 @@
   },
   "icons": {
     "Default": {
-      "path": "https://mygod.github.io/pokicons/v2"
+      "path": "https://mygod.github.io/pokicons/v2",
+      "iconModifiers": {
+        "gyms": {
+          "offsetX": 0,
+          "offsetY": 0
+        },
+        "pokestops": {
+          "offsetX": 0,
+          "offsetY": 0,
+          "sizeMultiplier": 0
+        }
+      }
     }
   },
   "rarity": {

--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -75,13 +75,18 @@
         "sm": 20,
         "md": 35,
         "lg": 50,
-        "xl": 65
+        "xl": 65,
+        "offsetX": 0,
+        "offsetY": 0
       },
       "pokestops": {
         "sm": 15,
         "md": 25,
         "lg": 35,
-        "xl": 45
+        "xl": 45,
+        "offsetX": 0,
+        "offsetY": 0,
+        "sizeMultiplier": 0
       },
       "pokemon": {
         "sm": 20,
@@ -94,17 +99,6 @@
         "md": 1,
         "lg": 2,
         "xl": 3
-      }
-    },
-    "iconOffsets": {
-      "gyms": {
-        "offsetX": 0,
-        "offsetY": 0
-      },
-      "pokestops": {
-        "offsetX": 0,
-        "offsetY": 0,
-        "sizeMultiplier": 0
       }
     }
   },

--- a/src/components/Clustering.jsx
+++ b/src/components/Clustering.jsx
@@ -16,7 +16,7 @@ const getId = (component, item) => {
 
 export default function Clustering({
   category, renderedData, userSettings, zoomLevel, staticUserSettings, params,
-  filters, map, path, availableForms, perms, tileStyle, config,
+  filters, map, path, iconModifiers, availableForms, perms, tileStyle, config,
 }) {
   const Component = index[category]
   const hideList = useStatic(state => state.hideList)
@@ -44,6 +44,7 @@ export default function Clustering({
               iconSizes={config.iconSizes[category]}
               showTimer={timerList.includes(each.id)}
               path={path}
+              iconModifiers={iconModifiers}
               availableForms={availableForms}
               perms={perms}
               zoom={currentZoom}

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -97,7 +97,7 @@ export default function Map({ serverSettings: { config: { map: config, tileServe
               availableForms={availableForms}
               path={icons[userIcons].path}
               iconModifiers={icons[userIcons].iconModifiers ? icons[userIcons].iconModifiers[category]
-                : { "offsetX": 0, "offsetY": 0, "sizeMultiplier": 0 }}
+                : { offsetX: 0, offsetY: 0, sizeMultiplier: 0 }}
               staticFilters={staticFilters[category].filter}
               userSettings={userSettings[userSettingsCategory(category)] || {}}
               filters={filters[category]}

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -96,6 +96,7 @@ export default function Map({ serverSettings: { config: { map: config, tileServe
               available={available[category]}
               availableForms={availableForms}
               path={icons[userIcons].path}
+              iconModifiers={icons[userIcons].iconModifiers[category]}
               staticFilters={staticFilters[category].filter}
               userSettings={userSettings[userSettingsCategory(category)] || {}}
               filters={filters[category]}

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -96,7 +96,8 @@ export default function Map({ serverSettings: { config: { map: config, tileServe
               available={available[category]}
               availableForms={availableForms}
               path={icons[userIcons].path}
-              iconModifiers={icons[userIcons].iconModifiers[category]}
+              iconModifiers={icons[userIcons].iconModifiers ? icons[userIcons].iconModifiers[category]
+                : { "offsetX": 0, "offsetY": 0, "sizeMultiplier": 0 }}
               staticFilters={staticFilters[category].filter}
               userSettings={userSettings[userSettingsCategory(category)] || {}}
               filters={filters[category]}

--- a/src/components/QueryData.jsx
+++ b/src/components/QueryData.jsx
@@ -19,7 +19,7 @@ const getPolling = category => {
 export default function QueryData({
   bounds, onMove, map, tileStyle, zoomLevel, config, params,
   category, available, filters, staticFilters, staticUserSettings,
-  userSettings, perms, path, availableForms,
+  userSettings, perms, path, iconModifiers, availableForms,
 }) {
   const trimFilters = useCallback(requestedFilters => {
     const trimmed = {
@@ -95,6 +95,7 @@ export default function QueryData({
           config={config}
           filters={filters}
           path={path}
+          iconModifiers={iconModifiers}
           tileStyle={tileStyle}
           perms={perms}
           availableForms={availableForms}

--- a/src/components/markers/gym.js
+++ b/src/components/markers/gym.js
@@ -53,7 +53,7 @@ export default function gymMarker(gym, ts, hasRaid, iconSizes, filters, path, av
       <div class="marker-image-holder top-overlay" 
         style="width:${raidSize}px;
           height:${raidSize}px;
-          left:${iconSizes.offsetX ? iconSizes.offsetX * 10 : 50}%;
+          left:${iconSizes.offsetX ? iconSizes.offsetX * 100 : 50}%;
           transform:translateX(-50%);
           top:${offsetY}px;"
       >

--- a/src/components/markers/gym.js
+++ b/src/components/markers/gym.js
@@ -2,7 +2,7 @@
 import L from 'leaflet'
 import Utility from '../../services/Utility'
 
-export default function gymMarker(gym, ts, hasRaid, iconSizes, filters, path, availableForms) {
+export default function gymMarker(gym, ts, hasRaid, iconSizes, filters, path, iconModifiers, availableForms) {
   const {
     in_battle, team_id, availble_slots, raid_level,
   } = gym
@@ -47,13 +47,13 @@ export default function gymMarker(gym, ts, hasRaid, iconSizes, filters, path, av
     } else if (raid_battle_timestamp < ts) {
       raidIcon = `/images/unknown_egg/${raid_level}.png`
     }
-    const offsetY = iconSizes.offsetY ? -gymSize * iconSizes.offsetY
+    const offsetY = iconModifiers.offsetY ? -gymSize * iconModifiers.offsetY
       : gymSize * 0.269 - raidSize - filledSlots
     iconHtml += `
       <div class="marker-image-holder top-overlay" 
         style="width:${raidSize}px;
           height:${raidSize}px;
-          left:${iconSizes.offsetX ? iconSizes.offsetX * 100 : 50}%;
+          left:${iconModifiers.offsetX ? iconModifiers.offsetX * 100 : 50}%;
           transform:translateX(-50%);
           top:${offsetY}px;"
       >

--- a/src/components/markers/gym.js
+++ b/src/components/markers/gym.js
@@ -1,7 +1,8 @@
 /* eslint-disable camelcase */
 import L from 'leaflet'
 import Utility from '../../services/Utility'
-const { map: { iconOffsets } } = require('./config')
+
+const { map: { iconOffsets } } = require('../config')
 
 export default function gymMarker(gym, ts, hasRaid, iconSizes, filters, path, availableForms) {
   const {
@@ -48,12 +49,13 @@ export default function gymMarker(gym, ts, hasRaid, iconSizes, filters, path, av
     } else if (raid_battle_timestamp < ts) {
       raidIcon = `/images/unknown_egg/${raid_level}.png`
     }
-    const offsetY = iconOffsets.gyms.offsetY ? -gymSize * iconOffsets.gyms.offsetY : gymSize * 0.269 - raidSize - filledSlots
+    const offsetY = iconOffsets.gyms.offsetY ? -gymSize * iconOffsets.gyms.offsetY :
+        gymSize * 0.269 - raidSize - filledSlots
     iconHtml += `
       <div class="marker-image-holder top-overlay" 
         style="width:${raidSize}px;
           height:${raidSize}px;
-          left:${conOffsets.gyms.offsetX ? iconOffsets.gyms.offsetX * 10 : 50}%;
+          left:${iconOffsets.gyms.offsetX ? iconOffsets.gyms.offsetX * 10 : 50}%;
           transform:translateX(-50%);
           top:${offsetY}px;"
       >

--- a/src/components/markers/gym.js
+++ b/src/components/markers/gym.js
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 import L from 'leaflet'
 import Utility from '../../services/Utility'
+const { map: { iconOffsets } } = require('./config')
 
 export default function gymMarker(gym, ts, hasRaid, iconSizes, filters, path, availableForms) {
   const {
@@ -47,12 +48,12 @@ export default function gymMarker(gym, ts, hasRaid, iconSizes, filters, path, av
     } else if (raid_battle_timestamp < ts) {
       raidIcon = `/images/unknown_egg/${raid_level}.png`
     }
-    const offsetY = gymSize * 0.269 - raidSize - filledSlots
+    const offsetY = iconOffsets.gyms.offsetY ? -gymSize * iconOffsets.gyms.offsetY : gymSize * 0.269 - raidSize - filledSlots
     iconHtml += `
       <div class="marker-image-holder top-overlay" 
         style="width:${raidSize}px;
           height:${raidSize}px;
-          left:50%;
+          left:${conOffsets.gyms.offsetX ? iconOffsets.gyms.offsetX * 10 : 50}%;
           transform:translateX(-50%);
           top:${offsetY}px;"
       >

--- a/src/components/markers/gym.js
+++ b/src/components/markers/gym.js
@@ -2,8 +2,6 @@
 import L from 'leaflet'
 import Utility from '../../services/Utility'
 
-const { map: { iconOffsets } } = require('../../config')
-
 export default function gymMarker(gym, ts, hasRaid, iconSizes, filters, path, availableForms) {
   const {
     in_battle, team_id, availble_slots, raid_level,
@@ -49,13 +47,13 @@ export default function gymMarker(gym, ts, hasRaid, iconSizes, filters, path, av
     } else if (raid_battle_timestamp < ts) {
       raidIcon = `/images/unknown_egg/${raid_level}.png`
     }
-    const offsetY = iconOffsets.gyms.offsetY ? -gymSize * iconOffsets.gyms.offsetY
+    const offsetY = iconSizes.offsetY ? -gymSize * iconSizes.offsetY
       : gymSize * 0.269 - raidSize - filledSlots
     iconHtml += `
       <div class="marker-image-holder top-overlay" 
         style="width:${raidSize}px;
           height:${raidSize}px;
-          left:${iconOffsets.gyms.offsetX ? iconOffsets.gyms.offsetX * 10 : 50}%;
+          left:${iconSizes.offsetX ? iconSizes.offsetX * 10 : 50}%;
           transform:translateX(-50%);
           top:${offsetY}px;"
       >

--- a/src/components/markers/gym.js
+++ b/src/components/markers/gym.js
@@ -2,7 +2,7 @@
 import L from 'leaflet'
 import Utility from '../../services/Utility'
 
-const { map: { iconOffsets } } = require('../config')
+const { map: { iconOffsets } } = require('../../config')
 
 export default function gymMarker(gym, ts, hasRaid, iconSizes, filters, path, availableForms) {
   const {
@@ -49,8 +49,8 @@ export default function gymMarker(gym, ts, hasRaid, iconSizes, filters, path, av
     } else if (raid_battle_timestamp < ts) {
       raidIcon = `/images/unknown_egg/${raid_level}.png`
     }
-    const offsetY = iconOffsets.gyms.offsetY ? -gymSize * iconOffsets.gyms.offsetY :
-        gymSize * 0.269 - raidSize - filledSlots
+    const offsetY = iconOffsets.gyms.offsetY ? -gymSize * iconOffsets.gyms.offsetY
+      : gymSize * 0.269 - raidSize - filledSlots
     iconHtml += `
       <div class="marker-image-holder top-overlay" 
         style="width:${raidSize}px;

--- a/src/components/markers/pokestop.js
+++ b/src/components/markers/pokestop.js
@@ -2,8 +2,6 @@
 import L from 'leaflet'
 import Utility from '../../services/Utility'
 
-const { map: { iconOffsets } } = require('../../config')
-
 export default function stopMarker(pokestop, hasQuest, hasLure, hasInvasion, filters, iconSizes, path, availableForms) {
   const { grunt_type, lure_id } = pokestop
 
@@ -79,22 +77,22 @@ export default function stopMarker(pokestop, hasQuest, hasLure, hasInvasion, fil
           <img 
             src=${path}/${Utility.getPokemonIcon(availableForms, megaId, 0, 1)}.png 
             style="bottom: 15px; 
-              width:${iconOffsets.pokestops.sizeMultiplier ? iconSizes[filters.filter[filterId].size] * iconOffsets.pokestops.sizeMultiplier : iconSizes[filters.filter[filterId].size]}px; 
-              height:${iconOffsets.pokestops.sizeMultiplier ? iconSizes[filters.filter[filterId].size] * iconOffsets.pokestops.sizeMultiplier : iconSizes[filters.filter[filterId].size]}px;"
+              width:${iconSizes.sizeMultiplier ? iconSizes[filters.filter[filterId].size] * iconSizes.sizeMultiplier : iconSizes[filters.filter[filterId].size]}px; 
+              height:${iconSizes.sizeMultiplier ? iconSizes[filters.filter[filterId].size] * iconSizes.sizeMultiplier : iconSizes[filters.filter[filterId].size]}px;"
           />`
         if (megaAmount > 1) {
           iconHtml += `<div class="amount-holder"><div>${megaAmount}</div></div>`
         } break
     }
     const questSize = (filters.filter[filterId] ? iconSizes[filters.filter[filterId].size]
-      : iconSizes.md) * (iconOffsets.pokestops.sizeMultiplier ? iconOffsets.pokestops.sizeMultiplier : 1)
-    const offsetY = iconOffsets.pokestops.offsetY ? -stopSize * iconOffsets.pokestops.offsetY : 0 - questSize
+      : iconSizes.md) * (iconSizes.sizeMultiplier ? iconSizes.sizeMultiplier : 1)
+    const offsetY = iconSizes.offsetY ? -stopSize * iconSizes.offsetY : 0 - questSize
     iconHtml = `
       <div 
         class="marker-image-holder top-overlay" 
         style="width:${questSize}px;
         height:${questSize}px;
-        left:${iconOffsets.pokestops.offsetX ? iconOffsets.pokestops.offsetX * 10 : 50}%;
+        left:${iconSizes.offsetX ? iconSizes.offsetX * 10 : 50}%;
         transform:translateX(-50%);
         top:${offsetY}px;"
       >

--- a/src/components/markers/pokestop.js
+++ b/src/components/markers/pokestop.js
@@ -2,7 +2,7 @@
 import L from 'leaflet'
 import Utility from '../../services/Utility'
 
-const { map: { iconOffsets } } = require('../config')
+const { map: { iconOffsets } } = require('../../config')
 
 export default function stopMarker(pokestop, hasQuest, hasLure, hasInvasion, filters, iconSizes, path, availableForms) {
   const { grunt_type, lure_id } = pokestop
@@ -86,8 +86,8 @@ export default function stopMarker(pokestop, hasQuest, hasLure, hasInvasion, fil
           iconHtml += `<div class="amount-holder"><div>${megaAmount}</div></div>`
         } break
     }
-    const questSize = (filters.filter[filterId] ? iconSizes[filters.filter[filterId].size] :
-        iconSizes.md) * (iconOffsets.pokestops.sizeMultiplier ? iconOffsets.pokestops.sizeMultiplier : 1)
+    const questSize = (filters.filter[filterId] ? iconSizes[filters.filter[filterId].size]
+      : iconSizes.md) * (iconOffsets.pokestops.sizeMultiplier ? iconOffsets.pokestops.sizeMultiplier : 1)
     const offsetY = iconOffsets.pokestops.offsetY ? -stopSize * iconOffsets.pokestops.offsetY : 0 - questSize
     iconHtml = `
       <div 

--- a/src/components/markers/pokestop.js
+++ b/src/components/markers/pokestop.js
@@ -2,7 +2,7 @@
 import L from 'leaflet'
 import Utility from '../../services/Utility'
 
-export default function stopMarker(pokestop, hasQuest, hasLure, hasInvasion, filters, iconSizes, path, availableForms) {
+export default function stopMarker(pokestop, hasQuest, hasLure, hasInvasion, filters, iconSizes, path, iconModifiers, availableForms) {
   const { grunt_type, lure_id } = pokestop
 
   let iconType = 'pokestop/0'
@@ -77,22 +77,22 @@ export default function stopMarker(pokestop, hasQuest, hasLure, hasInvasion, fil
           <img 
             src=${path}/${Utility.getPokemonIcon(availableForms, megaId, 0, 1)}.png 
             style="bottom: 15px; 
-              width:${iconSizes.sizeMultiplier ? iconSizes[filters.filter[filterId].size] * iconSizes.sizeMultiplier : iconSizes[filters.filter[filterId].size]}px; 
-              height:${iconSizes.sizeMultiplier ? iconSizes[filters.filter[filterId].size] * iconSizes.sizeMultiplier : iconSizes[filters.filter[filterId].size]}px;"
+              width:${iconModifiers.sizeMultiplier ? iconSizes[filters.filter[filterId].size] * iconModifiers.sizeMultiplier : iconSizes[filters.filter[filterId].size]}px; 
+              height:${iconModifiers.sizeMultiplier ? iconSizes[filters.filter[filterId].size] * iconModifiers.sizeMultiplier : iconSizes[filters.filter[filterId].size]}px;"
           />`
         if (megaAmount > 1) {
           iconHtml += `<div class="amount-holder"><div>${megaAmount}</div></div>`
         } break
     }
     const questSize = (filters.filter[filterId] ? iconSizes[filters.filter[filterId].size]
-      : iconSizes.md) * (iconSizes.sizeMultiplier ? iconSizes.sizeMultiplier : 1)
-    const offsetY = iconSizes.offsetY ? -stopSize * iconSizes.offsetY : 0 - questSize
+      : iconSizes.md) * (iconModifiers.sizeMultiplier ? iconModifiers.sizeMultiplier : 1)
+    const offsetY = iconModifiers.offsetY ? -stopSize * iconModifiers.offsetY : 0 - questSize
     iconHtml = `
       <div 
         class="marker-image-holder top-overlay" 
         style="width:${questSize}px;
         height:${questSize}px;
-        left:${iconSizes.offsetX ? iconSizes.offsetX * 100 : 50}%;
+        left:${iconModifiers.offsetX ? iconModifiers.offsetX * 100 : 50}%;
         transform:translateX(-50%);
         top:${offsetY}px;"
       >

--- a/src/components/markers/pokestop.js
+++ b/src/components/markers/pokestop.js
@@ -3,7 +3,7 @@ import L from 'leaflet'
 import Utility from '../../services/Utility'
 
 export default function stopMarker(pokestop, hasQuest, hasLure, hasInvasion, filters,
-                                   iconSizes, path, iconModifiers, availableForms) {
+  iconSizes, path, iconModifiers, availableForms) {
   const { grunt_type, lure_id } = pokestop
 
   let iconType = 'pokestop/0'

--- a/src/components/markers/pokestop.js
+++ b/src/components/markers/pokestop.js
@@ -92,7 +92,7 @@ export default function stopMarker(pokestop, hasQuest, hasLure, hasInvasion, fil
         class="marker-image-holder top-overlay" 
         style="width:${questSize}px;
         height:${questSize}px;
-        left:${iconSizes.offsetX ? iconSizes.offsetX * 10 : 50}%;
+        left:${iconSizes.offsetX ? iconSizes.offsetX * 100 : 50}%;
         transform:translateX(-50%);
         top:${offsetY}px;"
       >

--- a/src/components/markers/pokestop.js
+++ b/src/components/markers/pokestop.js
@@ -2,7 +2,8 @@
 import L from 'leaflet'
 import Utility from '../../services/Utility'
 
-export default function stopMarker(pokestop, hasQuest, hasLure, hasInvasion, filters, iconSizes, path, iconModifiers, availableForms) {
+export default function stopMarker(pokestop, hasQuest, hasLure, hasInvasion, filters,
+                                   iconSizes, path, iconModifiers, availableForms) {
   const { grunt_type, lure_id } = pokestop
 
   let iconType = 'pokestop/0'

--- a/src/components/markers/pokestop.js
+++ b/src/components/markers/pokestop.js
@@ -78,8 +78,8 @@ export default function stopMarker(pokestop, hasQuest, hasLure, hasInvasion, fil
           <img 
             src=${path}/${Utility.getPokemonIcon(availableForms, megaId, 0, 1)}.png 
             style="bottom: 15px; 
-              width:${iconOffsets.pokestops.sizeMultiplier ? iconSizes[filters.filter[filterId].size * iconOffsets.pokestops.sizeMultiplier : iconSizes[filters.filter[filterId].size]}px; 
-              height:${iconOffsets.pokestops.sizeMultiplier ? iconSizes[filters.filter[filterId].size * iconOffsets.pokestops.sizeMultiplier : iconSizes[filters.filter[filterId].size]}px;"
+              width:${iconOffsets.pokestops.sizeMultiplier ? iconSizes[filters.filter[filterId].size] * iconOffsets.pokestops.sizeMultiplier : iconSizes[filters.filter[filterId].size]}px; 
+              height:${iconOffsets.pokestops.sizeMultiplier ? iconSizes[filters.filter[filterId].size] * iconOffsets.pokestops.sizeMultiplier : iconSizes[filters.filter[filterId].size]}px;"
           />`
         if (megaAmount > 1) {
           iconHtml += `<div class="amount-holder"><div>${megaAmount}</div></div>`

--- a/src/components/markers/pokestop.js
+++ b/src/components/markers/pokestop.js
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 import L from 'leaflet'
 import Utility from '../../services/Utility'
+const { map: { iconOffsets } } = require('./config')
 
 export default function stopMarker(pokestop, hasQuest, hasLure, hasInvasion, filters, iconSizes, path, availableForms) {
   const { grunt_type, lure_id } = pokestop
@@ -77,21 +78,21 @@ export default function stopMarker(pokestop, hasQuest, hasLure, hasInvasion, fil
           <img 
             src=${path}/${Utility.getPokemonIcon(availableForms, megaId, 0, 1)}.png 
             style="bottom: 15px; 
-              width:${iconSizes[filters.filter[filterId].size]}px; 
-              height:${iconSizes[filters.filter[filterId].size]}px;"
+              width:${iconOffsets.pokestops.sizeMultiplier ? iconSizes[filters.filter[filterId].size * iconOffsets.pokestops.sizeMultiplier : iconSizes[filters.filter[filterId].size]}px; 
+              height:${iconOffsets.pokestops.sizeMultiplier ? iconSizes[filters.filter[filterId].size * iconOffsets.pokestops.sizeMultiplier : iconSizes[filters.filter[filterId].size]}px;"
           />`
         if (megaAmount > 1) {
           iconHtml += `<div class="amount-holder"><div>${megaAmount}</div></div>`
         } break
     }
-    const questSize = filters.filter[filterId] ? iconSizes[filters.filter[filterId].size] : iconSizes.md
-    const offsetY = 0 - questSize
+    const questSize = (filters.filter[filterId] ? iconSizes[filters.filter[filterId].size] : iconSizes.md) * (iconOffsets.pokestops.sizeMultiplier ? iconOffsets.pokestops.sizeMultiplier : 1)
+    const offsetY = iconOffsets.pokestops.offsetY ? -stopSize * iconOffsets.pokestops.offsetY : 0 - questSize
     iconHtml = `
       <div 
         class="marker-image-holder top-overlay" 
         style="width:${questSize}px;
         height:${questSize}px;
-        left:50%;
+        left:${conOffsets.pokestops.offsetX ? iconOffsets.pokestops.offsetX * 10 : 50}%;
         transform:translateX(-50%);
         top:${offsetY}px;"
       >

--- a/src/components/markers/pokestop.js
+++ b/src/components/markers/pokestop.js
@@ -2,8 +2,8 @@
 import L from 'leaflet'
 import Utility from '../../services/Utility'
 
-export default function stopMarker(pokestop, hasQuest, hasLure, hasInvasion, filters,
-  iconSizes, path, iconModifiers, availableForms) {
+export default function stopMarker(pokestop, hasQuest, hasLure, hasInvasion, filters, iconSizes, path, iconModifiers,
+  availableForms) {
   const { grunt_type, lure_id } = pokestop
 
   let iconType = 'pokestop/0'
@@ -85,8 +85,8 @@ export default function stopMarker(pokestop, hasQuest, hasLure, hasInvasion, fil
           iconHtml += `<div class="amount-holder"><div>${megaAmount}</div></div>`
         } break
     }
-    const questSize = (filters.filter[filterId] ? iconSizes[filters.filter[filterId].size]
-      : iconSizes.md) * (iconModifiers.sizeMultiplier ? iconModifiers.sizeMultiplier : 1)
+    const questSize = (filters.filter[filterId] ? iconSizes[filters.filter[filterId].size] : iconSizes.md)
+      * (iconModifiers.sizeMultiplier ? iconModifiers.sizeMultiplier : 1)
     const offsetY = iconModifiers.offsetY ? -stopSize * iconModifiers.offsetY : 0 - questSize
     iconHtml = `
       <div 

--- a/src/components/markers/pokestop.js
+++ b/src/components/markers/pokestop.js
@@ -1,7 +1,8 @@
 /* eslint-disable camelcase */
 import L from 'leaflet'
 import Utility from '../../services/Utility'
-const { map: { iconOffsets } } = require('./config')
+
+const { map: { iconOffsets } } = require('../config')
 
 export default function stopMarker(pokestop, hasQuest, hasLure, hasInvasion, filters, iconSizes, path, availableForms) {
   const { grunt_type, lure_id } = pokestop
@@ -85,14 +86,15 @@ export default function stopMarker(pokestop, hasQuest, hasLure, hasInvasion, fil
           iconHtml += `<div class="amount-holder"><div>${megaAmount}</div></div>`
         } break
     }
-    const questSize = (filters.filter[filterId] ? iconSizes[filters.filter[filterId].size] : iconSizes.md) * (iconOffsets.pokestops.sizeMultiplier ? iconOffsets.pokestops.sizeMultiplier : 1)
+    const questSize = (filters.filter[filterId] ? iconSizes[filters.filter[filterId].size] :
+        iconSizes.md) * (iconOffsets.pokestops.sizeMultiplier ? iconOffsets.pokestops.sizeMultiplier : 1)
     const offsetY = iconOffsets.pokestops.offsetY ? -stopSize * iconOffsets.pokestops.offsetY : 0 - questSize
     iconHtml = `
       <div 
         class="marker-image-holder top-overlay" 
         style="width:${questSize}px;
         height:${questSize}px;
-        left:${conOffsets.pokestops.offsetX ? iconOffsets.pokestops.offsetX * 10 : 50}%;
+        left:${iconOffsets.pokestops.offsetX ? iconOffsets.pokestops.offsetX * 10 : 50}%;
         transform:translateX(-50%);
         top:${offsetY}px;"
       >

--- a/src/components/tiles/Gym.jsx
+++ b/src/components/tiles/Gym.jsx
@@ -18,7 +18,8 @@ const getColor = team => {
 }
 
 const GymTile = ({
-  item, ts, showTimer, iconSizes, filters, path, iconModfiers, availableForms, excludeList, userSettings, params, showCircles,
+  item, ts, showTimer, iconSizes, filters, path, iconModifiers, availableForms,
+                   excludeList, userSettings, params, showCircles,
 }) => {
   const [done, setDone] = useState(false)
   const markerRefs = useRef({})
@@ -52,7 +53,7 @@ const GymTile = ({
             }
           }}
           position={[item.lat, item.lon]}
-          icon={gymMarker(item, ts, hasRaid, iconSizes, filters, path, iconModfiers, availableForms, excludeList)}
+          icon={gymMarker(item, ts, hasRaid, iconSizes, filters, path, iconModifiers, availableForms, excludeList)}
         >
           <Popup position={[item.lat, item.lon]} onClose={() => delete params.id}>
             <PopupContent

--- a/src/components/tiles/Gym.jsx
+++ b/src/components/tiles/Gym.jsx
@@ -18,8 +18,8 @@ const getColor = team => {
 }
 
 const GymTile = ({
-  item, ts, showTimer, iconSizes, filters, path, iconModifiers, availableForms,
-                   excludeList, userSettings, params, showCircles,
+  item, ts, showTimer, iconSizes, filters, path, iconModifiers, availableForms, excludeList,
+  userSettings, params, showCircles,
 }) => {
   const [done, setDone] = useState(false)
   const markerRefs = useRef({})

--- a/src/components/tiles/Gym.jsx
+++ b/src/components/tiles/Gym.jsx
@@ -18,7 +18,7 @@ const getColor = team => {
 }
 
 const GymTile = ({
-  item, ts, showTimer, iconSizes, filters, path, availableForms, excludeList, userSettings, params, showCircles,
+  item, ts, showTimer, iconSizes, filters, path, iconModfiers, availableForms, excludeList, userSettings, params, showCircles,
 }) => {
   const [done, setDone] = useState(false)
   const markerRefs = useRef({})
@@ -52,7 +52,7 @@ const GymTile = ({
             }
           }}
           position={[item.lat, item.lon]}
-          icon={gymMarker(item, ts, hasRaid, iconSizes, filters, path, availableForms, excludeList)}
+          icon={gymMarker(item, ts, hasRaid, iconSizes, filters, path, iconModfiers, availableForms, excludeList)}
         >
           <Popup position={[item.lat, item.lon]} onClose={() => delete params.id}>
             <PopupContent

--- a/src/components/tiles/Gym.jsx
+++ b/src/components/tiles/Gym.jsx
@@ -18,8 +18,8 @@ const getColor = team => {
 }
 
 const GymTile = ({
-  item, ts, showTimer, iconSizes, filters, path, iconModifiers, availableForms, excludeList,
-  userSettings, params, showCircles,
+  item, ts, showTimer, iconSizes, filters, path, iconModifiers, availableForms, excludeList, userSettings, params,
+  showCircles,
 }) => {
   const [done, setDone] = useState(false)
   const markerRefs = useRef({})

--- a/src/components/tiles/Pokestop.jsx
+++ b/src/components/tiles/Pokestop.jsx
@@ -9,7 +9,8 @@ import stopMarker from '../markers/pokestop'
 import Timer from './Timer'
 
 const PokestopTile = ({
-  item, ts, showTimer, filters, iconSizes, path, iconModifiers, availableForms, perms, excludeList, userSettings, params, showCircles,
+  item, ts, showTimer, filters, iconSizes, path, iconModifiers, availableForms,
+                        perms, excludeList, userSettings, params, showCircles,
 }) => {
   const [done, setDone] = useState(false)
   const markerRefs = useRef({})
@@ -52,7 +53,8 @@ const PokestopTile = ({
               }
             }}
             position={[item.lat, item.lon]}
-            icon={stopMarker(item, hasQuest, hasLure, hasInvasion, filters, iconSizes, path, iconModifiers, availableForms)}
+            icon={stopMarker(item, hasQuest, hasLure, hasInvasion, filters, iconSizes, path,
+                iconModifiers, availableForms)}
           >
             <Popup position={[item.lat, item.lon]} onClose={() => delete params.id}>
               <PopupContent

--- a/src/components/tiles/Pokestop.jsx
+++ b/src/components/tiles/Pokestop.jsx
@@ -9,8 +9,8 @@ import stopMarker from '../markers/pokestop'
 import Timer from './Timer'
 
 const PokestopTile = ({
-  item, ts, showTimer, filters, iconSizes, path, iconModifiers, availableForms, perms, excludeList,
-  userSettings, params, showCircles,
+  item, ts, showTimer, filters, iconSizes, path, iconModifiers, availableForms, perms, excludeList, userSettings,
+  params, showCircles,
 }) => {
   const [done, setDone] = useState(false)
   const markerRefs = useRef({})

--- a/src/components/tiles/Pokestop.jsx
+++ b/src/components/tiles/Pokestop.jsx
@@ -9,7 +9,7 @@ import stopMarker from '../markers/pokestop'
 import Timer from './Timer'
 
 const PokestopTile = ({
-  item, ts, showTimer, filters, iconSizes, path, availableForms, perms, excludeList, userSettings, params, showCircles,
+  item, ts, showTimer, filters, iconSizes, path, iconModifiers, availableForms, perms, excludeList, userSettings, params, showCircles,
 }) => {
   const [done, setDone] = useState(false)
   const markerRefs = useRef({})
@@ -52,7 +52,7 @@ const PokestopTile = ({
               }
             }}
             position={[item.lat, item.lon]}
-            icon={stopMarker(item, hasQuest, hasLure, hasInvasion, filters, iconSizes, path, availableForms)}
+            icon={stopMarker(item, hasQuest, hasLure, hasInvasion, filters, iconSizes, path, iconModifiers, availableForms)}
           >
             <Popup position={[item.lat, item.lon]} onClose={() => delete params.id}>
               <PopupContent

--- a/src/components/tiles/Pokestop.jsx
+++ b/src/components/tiles/Pokestop.jsx
@@ -9,8 +9,8 @@ import stopMarker from '../markers/pokestop'
 import Timer from './Timer'
 
 const PokestopTile = ({
-  item, ts, showTimer, filters, iconSizes, path, iconModifiers, availableForms,
-                        perms, excludeList, userSettings, params, showCircles,
+  item, ts, showTimer, filters, iconSizes, path, iconModifiers, availableForms, perms, excludeList,
+  userSettings, params, showCircles,
 }) => {
   const [done, setDone] = useState(false)
   const markerRefs = useRef({})
@@ -53,8 +53,8 @@ const PokestopTile = ({
               }
             }}
             position={[item.lat, item.lon]}
-            icon={stopMarker(item, hasQuest, hasLure, hasInvasion, filters, iconSizes, path,
-                iconModifiers, availableForms)}
+            icon={stopMarker(item, hasQuest, hasLure, hasInvasion, filters, iconSizes, path, iconModifiers,
+              availableForms)}
           >
             <Popup position={[item.lat, item.lon]} onClose={() => delete params.id}>
               <PopupContent


### PR DESCRIPTION
Adds advanced config options to allow offsetting the raid boss/egg on gym marker, and the quest reward on pokestop marker.
This gives option to replace the icon set and have markers nicely arranged.
Example with :
```
      "iconModifiers": {
        "gyms": {
          "offsetX": 0.2,
          "offsetY": 0.3
        },
        "pokestops": {
          "offsetX": 0.2,
          "offsetY": 0.1,
          "sizeMultiplier": 0.7
        }
      }
```
![Capture d’écran 2021-06-11 à 10 19 40](https://user-images.githubusercontent.com/47784174/121655339-d1e4ac00-ca9e-11eb-874c-e109211a9a29.png)
![Capture d’écran 2021-06-11 à 10 33 01](https://user-images.githubusercontent.com/47784174/121657588-d27e4200-caa0-11eb-91a6-44001809acaf.png)
