### PR TITLE
Don't push forked repos to docker package container

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,28 +1,15 @@
 name: Docker
-on: [push, pull_request]
+on: [push, release]
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  Deploy:
+  Docker:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [12.x]
     steps:
     - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-
-    - name: Test the Testcases
-      run: 
-        npm install -g yarn
-        yarn install
-        yarn build
 
     - name: Log in to the Container registry
       uses: docker/login-action@v1
@@ -30,13 +17,13 @@ jobs:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-        
+
     - name: Extract metadata (tags, labels) for Docker
       id: meta
       uses: docker/metadata-action@v3
       with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}    
-        
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
     - name: Build and push Docker image
       uses: docker/build-push-action@v2
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Lint
+on: [push, pull_request]
+
+jobs:
+  Lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Test the Testcases
+      run:
+        npm install -g yarn
+        yarn install
+        yarn build


### PR DESCRIPTION
AKA fix the CI/CD failures

External forks can't push to this organization container registry.
Github does this for security reasons. Running the test cases are nice
so they have been moved to the lint workflow.

More information: https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token