### PR TITLE
Remove ESLintPlugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -119,10 +119,6 @@ module.exports = (env) => {
           filename: isDevelopment ? '[name].css' : '[name]-[contenthash:8].css',
           chunkFilename: isDevelopment ? '[id].css' : '[id].[contenthash:8].css',
         }),
-        new ESLintPlugin({
-          context: 'src',
-          extensions: ['js', 'jsx'],
-        }),
         new ProgressBarPlugin({
           format: `Bundling application... ${emoji.get(
             'package',
@@ -132,6 +128,12 @@ module.exports = (env) => {
           clear: false,
         }),
       ];
+      if (isDevelopment) {
+        plugins.push(new ESLintPlugin({
+          context: 'src',
+          extensions: ['js', 'jsx'],
+        }))
+      }
       return plugins;
     })(),
     optimization: {


### PR DESCRIPTION
`ESLintPlugin` slows down `yarn start` by 3x, wasting CPU cycles and time while achieving absolutely nothing. We should disable it at least for end users.