### PR TITLE
Refine raid timers

### DIFF
--- a/src/components/popups/Gym.jsx
+++ b/src/components/popups/Gym.jsx
@@ -472,28 +472,23 @@ const RaidInfo = ({ gym, t }) => {
 }
 
 const Timer = ({ gym, start, t }) => {
-  const { raid_battle_timestamp, raid_end_timestamp } = gym
-  const startTime = new Date(raid_battle_timestamp * 1000)
-  const endTime = new Date(raid_end_timestamp * 1000)
-
-  const [raidStart, setRaidStart] = useState(Utility.getTimeUntil(startTime, true))
-  const [raidEnd, setRaidEnd] = useState(Utility.getTimeUntil(endTime, true))
+  const target = (start ? gym.raid_battle_timestamp : gym.raid_end_timestamp) * 1000
+  const update = () => start || gym.raid_pokemon_id ? Utility.getTimeUntil(target, true)
+    : Utility.formatInterval(target - gym.raid_battle_timestamp * 1000)
+  const [display, setDisplay] = useState(update)
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setRaidStart(Utility.getTimeUntil(startTime, true))
-      setRaidEnd(Utility.getTimeUntil(endTime, true))
-    }, 1000)
+    const timer = setTimeout(() => setDisplay(update()), 1000)
     return () => clearTimeout(timer)
   })
 
   return (
     <Grid item xs={start ? 6 : 12} style={{ textAlign: 'center' }}>
       <Typography variant="subtitle1">
-        {t(start ? 'starts' : 'ends')}: {(start ? startTime : endTime).toLocaleTimeString(localStorage.getItem('i18nextLng'))}
+        {t(start ? 'starts' : 'ends')}: {new Date(target).toLocaleTimeString(localStorage.getItem('i18nextLng'))}
       </Typography>
       <Typography variant="h6">
-        {(start ? raidStart : raidEnd).str}
+        {display.str}
       </Typography>
     </Grid>
   )

--- a/src/components/tiles/Gym.jsx
+++ b/src/components/tiles/Gym.jsx
@@ -31,8 +31,7 @@ const GymTile = ({
     && (raid_battle_timestamp >= ts
       ? !excludeList.includes(`e${raid_level}`)
       : !excludeList.includes(`${raid_pokemon_id}-${raid_pokemon_form}`)))
-  const timerToDisplay = (raid_battle_timestamp >= ts && raid_pokemon_id === 0)
-    ? raid_battle_timestamp : raid_end_timestamp
+  const timerToDisplay = raid_battle_timestamp >= ts && !raid_pokemon_id ? raid_battle_timestamp : raid_end_timestamp
 
   useEffect(() => {
     const { id } = params

--- a/src/services/Utility.js
+++ b/src/services/Utility.js
@@ -3,7 +3,6 @@ import getPokemonIcon from './functions/getPokemonIcon'
 import getProperName from './functions/getProperName'
 import menuFilter from './functions/menuFilter'
 import checkAdvFilter from './functions/checkAdvFilter'
-import getTimers from './functions/getTimeUntil'
 import dayCheck from './functions/dayCheck'
 import parseQuestConditions from './functions/parseConditions'
 
@@ -29,7 +28,7 @@ class Utility {
   }
 
   static getTimeUntil(date, until) {
-    return getTimers(date, until)
+    return formatInterval(until ? date - Date.now() : Date.now() - date)
   }
 
   static dayCheck(ts, desiredStamp) {

--- a/src/services/Utility.js
+++ b/src/services/Utility.js
@@ -1,3 +1,4 @@
+import formatInterval from './functions/formatInterval'
 import getPokemonIcon from './functions/getPokemonIcon'
 import getProperName from './functions/getProperName'
 import menuFilter from './functions/menuFilter'
@@ -21,6 +22,10 @@ class Utility {
 
   static checkAdvFilter(filter) {
     return checkAdvFilter(filter)
+  }
+
+  static formatInterval(intervalMs) {
+    return formatInterval(intervalMs)
   }
 
   static getTimeUntil(date, until) {

--- a/src/services/functions/formatInterval.js
+++ b/src/services/functions/formatInterval.js
@@ -4,17 +4,16 @@ export default function formatInterval(intervalMs) {
   const h = Math.floor(diff / 3600)
   const m = Math.floor((diff % 3600) / 60)
   const s = Math.floor(diff % 3600 % 60)
-  let str = ''
+  let str = []
 
+  // TODO: localize
   if (d > 0) {
-    str = `${d} Days`
-  } else if (h > 0) {
-    str = `${h}h ${m}m ${s}s`
-  } else if (m > 0) {
-    str = `${m}m ${s}s`
+    str = [`${d} Days`]
   } else {
-    str = `${s}s`
+    if (h > 0) str.push(`${h}h`)
+    if (m > 0) str.push(`${m}m`)
+    if (s > 0 || str.length === 0) str.push(`${s}s`)
   }
 
-  return { str, diff }
+  return { str: str.join(' '), diff }
 }

--- a/src/services/functions/formatInterval.js
+++ b/src/services/functions/formatInterval.js
@@ -1,0 +1,20 @@
+export default function formatInterval(intervalMs) {
+  const diff = Math.floor(intervalMs / 1000)
+  const d = Math.floor(diff / 86400)
+  const h = Math.floor(diff / 3600)
+  const m = Math.floor((diff % 3600) / 60)
+  const s = Math.floor(diff % 3600 % 60)
+  let str = ''
+
+  if (d > 0) {
+    str = `${d} Days`
+  } else if (h > 0) {
+    str = `${h}h ${m}m ${s}s`
+  } else if (m > 0) {
+    str = `${m}m ${s}s`
+  } else {
+    str = `${s}s`
+  }
+
+  return { str, diff }
+}

--- a/src/services/functions/getTimeUntil.js
+++ b/src/services/functions/getTimeUntil.js
@@ -1,5 +1,0 @@
-import formatInterval from '@services/functions/formatInterval';
-
-export default function getTimers(date, until) {
-  return formatInterval(until ? date - Date.now() : Date.now() - date)
-}

--- a/src/services/functions/getTimeUntil.js
+++ b/src/services/functions/getTimeUntil.js
@@ -1,20 +1,5 @@
+import formatInterval from '@services/functions/formatInterval';
+
 export default function getTimers(date, until) {
-  const diff = Math.round((until ? date - new Date() : new Date() - date) / 1000)
-  const d = Math.floor(diff / 86400)
-  const h = Math.floor(diff / 3600)
-  const m = Math.floor((diff % 3600) / 60)
-  const s = Math.floor(diff % 3600 % 60)
-  let str = ''
-
-  if (d > 0) {
-    str = `${d} Days`
-  } else if (h > 0) {
-    str = `${h}h ${m}m ${s}s`
-  } else if (m > 0) {
-    str = `${m}m ${s}s`
-  } else {
-    str = `${s}s`
-  }
-
-  return { str, diff }
+  return formatInterval(until ? date - Date.now() : Date.now() - date)
 }


### PR DESCRIPTION
* Egg timer tooltip now displays correctly.
* 3:00 will display as `3m` instead of `3m 0s`.
* Display raid duration when both start timer and end timer is on screen.

![image](https://user-images.githubusercontent.com/3511321/123562697-66792a80-d77e-11eb-8948-2113fa2f7c80.png)
![image](https://user-images.githubusercontent.com/3511321/123562701-6bd67500-d77e-11eb-94a4-f7ce86536add.png)
