### PR TITLE
Fixes grey screen if map is not included

### DIFF
--- a/server/src/routes/rootRouter.js
+++ b/server/src/routes/rootRouter.js
@@ -47,16 +47,15 @@ rootRouter.get('/logout', (req, res) => {
 rootRouter.get('/settings', async (req, res) => {
   try {
     if (!config.discord.enabled) {
-      req.session.perms = {}
+      req.session.perms = { areaRestrictions: [] }
       Object.keys(config.discord.perms).forEach(perm => req.session.perms[perm] = config.discord.perms[perm].enabled)
-      req.session.perms.areaRestrictions = []
       req.session.save()
     } else if (config.alwaysEnabledPerms.length > 0) {
-      req.session.perms = {}
+      req.session.perms = { areaRestrictions: [] }
       config.alwaysEnabledPerms.forEach(perm => req.session.perms[perm] = config.discord.perms[perm].enabled)
-      req.session.perms.areaRestrictions = []
       req.session.save()
     }
+
     const getUser = () => {
       if (config.discord.enabled) {
         if (req.user || config.alwaysEnabledPerms.length === 0) {

--- a/src/components/Auth.jsx
+++ b/src/components/Auth.jsx
@@ -6,7 +6,7 @@ import Login from './Login'
 import WebhookQuery from './WebhookQuery'
 
 const Auth = ({ serverSettings, match }) => {
-  if (serverSettings.discord && !serverSettings.user) {
+  if ((serverSettings.discord && !serverSettings.user) || !serverSettings.user.perms.map) {
     if (match.params.category || match.params.lat) {
       localStorage.setItem('params', JSON.stringify(match.params))
     }


### PR DESCRIPTION
- Previously grey screened if `map` was not included in the `alwaysAvailable` array but other perms were.
- Now redirects to login page if it's missing