### PR TITLE
Fix Hundo on Top

### DIFF
--- a/src/components/tiles/Pokemon.jsx
+++ b/src/components/tiles/Pokemon.jsx
@@ -87,7 +87,7 @@ const PokemonTile = ({
               userSettings={userSettings}
             />
           </Popup>
-          {showTimer && (
+          {(showTimer || userSettings.pokemonTimers) && (
             <Timer
               timestamp={item.expire_timestamp}
               direction="center"

--- a/src/components/tiles/Pokemon.jsx
+++ b/src/components/tiles/Pokemon.jsx
@@ -74,6 +74,7 @@ const PokemonTile = ({
               setDone(true)
             }
           }}
+          zIndexOffset={item.iv * 100}  ** Fix so that hundos will be always on top **
           position={[item.lat, item.lon]}
           icon={(pvpCheck || glowStatus || ivCircle)
             ? fancyMarker(iconUrl, item, filters, iconSizes, glowStatus, ivCircle)
@@ -86,7 +87,7 @@ const PokemonTile = ({
               userSettings={userSettings}
             />
           </Popup>
-          {(showTimer || userSettings.pokemonTimers) && (
+          {showTimer && (
             <Timer
               timestamp={item.expire_timestamp}
               direction="center"


### PR DESCRIPTION
This change will make it possible to always some 100 IV (Hundos) on Top of all other pokémon on the map. Before the hundo could hide behind other pokémons.