### PR TITLE
Breaking change - Include only 'en' in default `localeSelection`

### DIFF
--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -1,7 +1,7 @@
 {
   "interface": "0.0.0.0",
   "port": 8080,
-  "localeSelection": ["en", "de", "pl" ,"es" ,"fr", "it"],
+  "localeSelection": ["en"],
   "devOptions": {
     "enabled": false,
     "graphiql": false,


### PR DESCRIPTION
Include only `english` (as it's a base language) in `default.json` configuration file.
Due to the way configuration is extended those values can't be removed from `Locale Selection` by removing them in `localeSelection` array under `config.json`.

Users who want to include other languages than `english` have to enable them in `config.json` by adding `"localeSelection": ["en", ...]` array.