### PR TITLE
Min & Max PVP Ranks

### DIFF
--- a/server/src/models/Filters.js
+++ b/server/src/models/Filters.js
@@ -20,7 +20,7 @@ class PokemonFilter extends GenericFilter {
   }
 
   pvp(values) {
-    leagues.forEach(league => this[league.name] = values || [1, 100])
+    leagues.forEach(league => this[league.name] = values || [(league.minRank || 1), (league.maxRank || 100)])
   }
 }
 

--- a/server/src/services/ui/primary.js
+++ b/server/src/services/ui/primary.js
@@ -35,7 +35,7 @@ module.exports = function generateUi(filters, perms) {
             ],
           }
           leagues.forEach(league => sliders.primary.push({
-            name: league.name, label: 'rank', min: 1, max: 100, perm: 'pvp', color: 'primary',
+            name: league.name, label: 'rank', min: (league.minRank || 1), max: (league.maxRank || 100), perm: 'pvp', color: 'primary',
           })); break
         case 'submissionCells':
         case 'portals':


### PR DESCRIPTION
Unfortunately, at least for now, this has to be server side/configured by the admin in order to stay in sync with the server when requesting data
- Set min rank (defaults to 0)
- Set max rank (defaults to 100)

Settings found in database => settings 
```json
      "leagues": [
        {
          "name": "great",
          "cp": 1500,
          "maxRank": 150
        },
        {
          "name": "ultra",
          "cp": 2500,
          "minRank": 5
        },
        {
          "name": "little",
          "cp": 500,
          "minRank": 10,
          "maxRank": 150
        }
      ],
```

Great defaults to a min of 1 and sets the max to 150
Ultra sets the min to 5 and defaults to a max of 100
Little is set to 10 - 150