### PR TITLE
Add Custom Migration Table Name

### DIFF
--- a/server/knexfile.cjs
+++ b/server/knexfile.cjs
@@ -1,5 +1,5 @@
 const path = require('path')
-const { database: { schemas } } = require('./src/services/config')
+const { database: { schemas, settings: { migrationTableName } } } = require('./src/services/config')
 
 const migrationUrl = 'src/db/migrations'
 
@@ -15,6 +15,7 @@ const connection = {
     database: schemas[selectedDb].database,
   },
   migrations: {
+    tableName: migrationTableName,
     directory: migrationUrl,
     extensions: 'cjs',
     stub: path.join(migrationUrl, 'migration.stub.cjs'),

--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -169,6 +169,7 @@
     "settings": {
       "userTableName": "users",
       "sessionTableName": "session",
+      "migrationTableName": "knex_migrations",
       "leagues": [],
       "reactMapHandlesPvp": false,
       "pvpLevels": []


### PR DESCRIPTION
New config value:
```json
      "migrationTableName": "knex_migrations",
```

Call it whatever you want if you have other applications (like Poracle) that use Knex to handle migrations and reduce interference.