### PR TITLE
Update ConfigSettings.jsx

### DIFF
--- a/src/components/ConfigSettings.jsx
+++ b/src/components/ConfigSettings.jsx
@@ -77,6 +77,9 @@ export default function ConfigSettings({
   setMenus(updateObjState(serverSettings.menus, 'menus'))
   setStaticMenus(serverSettings.menus)
 
+  if (localState?.state?.filters?.pokemon?.standard) {
+    delete localState.state.filters.pokemon.standard
+  }
   setFilters(updateObjState(serverSettings.defaultFilters, 'filters'))
   setStaticFilters(serverSettings.defaultFilters)
 


### PR DESCRIPTION
Clears cached standard filter for comparing on the backend. Fixes #176, since no one tested :angryeyes: