### PR TITLE
fixes docker-compose example

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -3,7 +3,7 @@ services:
   reactmap:
     image: ghcr.io/watwowmap/reactmap:main #pr-10
     container_name: reactmap
-    command: sh -c "yarn migrate:latest && start"
+    command: sh -c "yarn migrate:latest && yarn start"
     restart: unless-stopped
     volumes:
       - ./server/src/configs/areas.json:/home/node/server/src/configs/areas.json


### PR DESCRIPTION
when introducing "yarn migrate:latest" into docker missed the "yarn start" part, it was only command "start", sorry for that.