### PR TITLE
Native MAD Quest Titles

### DIFF
--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -17,6 +17,7 @@ const questProps = {
   quest_reward_type: true,
   quest_item_id: true,
   quest_pokemon_id: true,
+  quest_title: true,
 }
 const questPropsAlt = {}
 const madQuestProps = {
@@ -281,7 +282,7 @@ class Pokestop extends Model {
             } else {
               this.parseRdmRewards(quest)
             }
-            const fields = ['quest_type', 'quest_timestamp', 'quest_target', 'quest_conditions', 'quest_task', 'quest_reward_type', 'quest_rewards', 'with_ar']
+            const fields = ['quest_type', 'quest_timestamp', 'quest_target', 'quest_conditions', 'quest_task', 'quest_reward_type', 'quest_rewards', 'with_ar', 'quest_title']
             switch (quest.quest_reward_type) {
               case 2:
                 newQuest.key = `q${quest.quest_item_id}`

--- a/server/src/schema/pokestop.js
+++ b/server/src/schema/pokestop.js
@@ -15,6 +15,7 @@ const quest = new GraphQLObjectType({
     quest_reward_type: { type: GraphQLInt },
     quest_task: { type: GraphQLString },
     quest_item_id: { type: GraphQLInt },
+    quest_title: { type: GraphQLString },
     item_amount: { type: GraphQLInt },
     stardust_amount: { type: GraphQLInt },
     quest_pokemon_id: { type: GraphQLInt },

--- a/src/components/popups/Pokestop.jsx
+++ b/src/components/popups/Pokestop.jsx
@@ -332,7 +332,25 @@ const QuestConditions = ({ quest, t, userSettings }) => {
     quest_type,
     quest_target,
     quest_conditions,
+    quest_title,
   } = quest
+
+  if (quest_title) {
+    return (
+      <Grid item xs={9} style={{ textAlign: 'center' }}>
+        <Typography variant="caption">
+          <Trans
+            defaults={quest_task}
+            i18nKey={quest_title.startsWith('quest_')
+              ? quest_title.replace('quest_', 'quest_title_').toLowerCase()
+              : `quest_title_${quest_title.toLowerCase()}`}
+          >
+            {{ amount_0: quest_target }}
+          </Trans>
+        </Typography>
+      </Grid>
+    )
+  }
 
   if (userSettings.madQuestText && quest_task) {
     return (

--- a/src/services/queries/pokestop.js
+++ b/src/services/queries/pokestop.js
@@ -29,6 +29,7 @@ const quest = gql`
       quest_reward_type
       quest_item_id
       quest_task
+      quest_title
       item_amount
       stardust_amount
       quest_pokemon_id


### PR DESCRIPTION
- Adds support for quest titles if parsed by the backend, currently only MAD supports
- Uses game assets to natively translate the quest text into every locale supported by pogo, providing a 1:1 experience for users