### PR TITLE
Migrate MotD

### DIFF
--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -89,7 +89,7 @@
         "parentStyle": {},
         "permanent": false
       },
-      "messages": [],
+      "components": [],
       "footerButtons": []
     },
     "donationPage": {

--- a/server/src/services/config.js
+++ b/server/src/services/config.js
@@ -24,6 +24,28 @@ try {
   console.error('Failed to initialize a strategy', e)
 }
 
+if (target.map.messageOfTheDay.messages) {
+  console.warn('You are using an old API endpoint in the message of the day section, the [messages] array should be renamed to [components]! \n They have been migrated for you in the meantime but you should update your config.json file.')
+
+  const updateFieldRec = (messages) => messages.map(message => {
+    if (message.messages) {
+      message.components = updateFieldRec(message.messages)
+      delete message.messages
+    }
+    return message
+  })
+
+  target.map.messageOfTheDay.components = target.map.messageOfTheDay.messages.map(m => {
+    if (m.type !== 'parent') return m
+    if (m.messages) {
+      m.components = m.components || updateFieldRec(m.messages)
+      delete m.messages
+    }
+    return m
+  })
+  delete target.map.messageOfTheDay.messages
+}
+
 if (target.icons.defaultIcons.misc) {
   console.warn('Warning: Setting the misc category to anything does not have an impact on the icons.')
 }

--- a/src/components/layout/Nav.jsx
+++ b/src/components/layout/Nav.jsx
@@ -48,7 +48,7 @@ export default function Nav({
     type: '',
   })
   const [motd, setMotd] = useState(
-    (messageOfTheDay.index > motdIndex && messageOfTheDay.messages.length)
+    (messageOfTheDay.index > motdIndex && messageOfTheDay.components.length)
     || messageOfTheDay.settings.permanent,
   )
   const [donorPage, setDonorPage] = useState(false)

--- a/src/components/layout/auth/Login.jsx
+++ b/src/components/layout/auth/Login.jsx
@@ -25,7 +25,6 @@ const Login = ({ clickedTwice, location, serverSettings }) => {
           key={i}
           block={block}
           defaultReturn={null}
-          childrenKey="messages"
         />
       ))}
     </Grid>

--- a/src/components/layout/custom/CustomTile.jsx
+++ b/src/components/layout/custom/CustomTile.jsx
@@ -6,7 +6,7 @@ import Utility from '@services/Utility'
 
 import Generator from './Generator'
 
-export default function CustomTile({ block, defaultReturn, childrenKey }) {
+export default function CustomTile({ block, defaultReturn }) {
   return (
     <Grid
       item
@@ -16,7 +16,6 @@ export default function CustomTile({ block, defaultReturn, childrenKey }) {
       <Generator
         block={block}
         defaultReturn={defaultReturn}
-        childrenKey={childrenKey}
       />
     </Grid>
   )

--- a/src/components/layout/custom/Generator.jsx
+++ b/src/components/layout/custom/Generator.jsx
@@ -11,7 +11,7 @@ import CustomButton from './CustomButton'
 import CustomImg from './CustomImg'
 import Telegram from '../auth/Telegram'
 
-export default function Generator({ block = {}, defaultReturn = null, childrenKey = 'components' }) {
+export default function Generator({ block = {}, defaultReturn = null }) {
   const isMuiColor = block.color === 'primary' || block.color === 'secondary'
   switch (block.type) {
     case 'img': return <CustomImg block={block} />
@@ -30,7 +30,7 @@ export default function Generator({ block = {}, defaultReturn = null, childrenKe
         alignItems={block.alignItems}
         justifyContent={block.justifyContent}
       >
-        {block[childrenKey].map((subBlock, i) => (
+        {block.components.map((subBlock, i) => (
           <Grid
             key={i}
             item

--- a/src/components/layout/dialogs/DonorPage.jsx
+++ b/src/components/layout/dialogs/DonorPage.jsx
@@ -22,7 +22,6 @@ export default function DonorPage({ donorPage, handleDonorClose }) {
             <CustomTile
               key={i}
               block={block}
-              childrenKey="components"
             />
           )
         })

--- a/src/components/layout/dialogs/Motd.jsx
+++ b/src/components/layout/dialogs/Motd.jsx
@@ -16,7 +16,7 @@ export default function Motd({ motd, handleMotdClose }) {
       defaultTitle="message_of_the_day"
       handleClose={handleMotdClose}
       contentBody={
-        motd.messages.map((block, i) => {
+        motd.components.map((block, i) => {
           if (block.donorOnly && !perms.donor) return null
           if (block.freeloaderOnly && perms.donor) return null
           return (
@@ -24,7 +24,6 @@ export default function Motd({ motd, handleMotdClose }) {
               key={i}
               block={block}
               defaultReturn={block.type ? null : <DefaultMotD block={block} />}
-              childrenKey="messages"
             />
           )
         })


### PR DESCRIPTION
- Migrate MotD to use a "components" array instead of "messages", to align with the other custom config objects
- Automatically migrates in RAM but needs to be renamed in the config manually