### PR TITLE
Local UICONS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ server/src/strategies/*
 !server/src/strategies/discord.js
 !server/src/strategies/telegram.js
 
+# Local UICONS Repos
+public/images/uicons/*
+!public/images/uicons/.gitkeep
+
 # Ignore generated locales
 public/locales/*
 

--- a/src/services/Fetch.js
+++ b/src/services/Fetch.js
@@ -16,22 +16,24 @@ export default class Fetch {
     }
   }
 
-  static async getIcons(iconPath, name) {
+  static async getIcons(icon) {
     try {
-      const response = await fetch(`${iconPath}/index.json`)
+      const response = icon.local
+        ? await fetch(`/images/uicons/${icon.local}/index.json`)
+        : await fetch(`${icon.path}/index.json`)
       if (!response.ok) {
         throw new Error(`${response.status} (${response.statusText})`)
       }
       const body = await response.json()
-      localStorage.setItem(`${name}_icons`, JSON.stringify({ ...body, lastFetched: Date.now() }))
+      localStorage.setItem(`${icon.name}_icons`, JSON.stringify({ ...body, lastFetched: Date.now() }))
       return body
     } catch (error) {
-      console.error(error.message, `Unable to fetch ${iconPath} at this time, attempting to load from cache.`)
-      const cached = localStorage.getItem(`${name}_icons`)
+      console.error(error.message, `Unable to fetch ${icon.path} at this time, attempting to load from cache.`)
+      const cached = localStorage.getItem(`${icon.name}_icons`)
       if (cached) {
         return JSON.parse(cached)
       }
-      console.warn(`Cache does not exist for ${name}`)
+      console.warn(`Cache does not exist for ${icon.name}`)
     }
   }
 

--- a/src/services/Fetch.js
+++ b/src/services/Fetch.js
@@ -18,9 +18,9 @@ export default class Fetch {
 
   static async getIcons(icon) {
     try {
-      const response = icon.local
-        ? await fetch(`/images/uicons/${icon.local}/index.json`)
-        : await fetch(`${icon.path}/index.json`)
+      const response = icon.path.startsWith('http')
+        ? await fetch(`${icon.path}/index.json`)
+        : await fetch(`/images/uicons/${icon.path}/index.json`)
       if (!response.ok) {
         throw new Error(`${response.status} (${response.statusText})`)
       }

--- a/src/services/Icons.js
+++ b/src/services/Icons.js
@@ -48,7 +48,7 @@ export default class UIcons {
         const data = cachedIndex && cachedIndex.lastFetched + this.cacheMs > Date.now()
           ? cachedIndex
           // eslint-disable-next-line no-await-in-loop
-          : await Fetch.getIcons(icon.path, icon.name)
+          : await Fetch.getIcons(icon)
         if (data) {
           this[icon.name] = { indexes: Object.keys(data), ...icon }
 

--- a/src/services/Icons.js
+++ b/src/services/Icons.js
@@ -52,8 +52,8 @@ export default class UIcons {
         if (data) {
           this[icon.name] = { indexes: Object.keys(data), ...icon }
 
-          if (icon.local) {
-            this[icon.name].path = `/images/uicons/${icon.local}`
+          if (!icon.path.startsWith('http')) {
+            this[icon.name].path = `/images/uicons/${icon.path}`
           }
           if (!this[icon.name].modifiers) {
             this[icon.name].modifiers = {}

--- a/src/services/Icons.js
+++ b/src/services/Icons.js
@@ -51,6 +51,10 @@ export default class UIcons {
           : await Fetch.getIcons(icon.path, icon.name)
         if (data) {
           this[icon.name] = { indexes: Object.keys(data), ...icon }
+
+          if (icon.local) {
+            this[icon.name].path = `/images/uicons/${icon.local}`
+          }
           if (!this[icon.name].modifiers) {
             this[icon.name].modifiers = {}
           }


### PR DESCRIPTION
- Supports local folders
- Put the folder in the `public/images/uicons` folder
- Json index file must be in the root of each folder you have in the `uicons folder`
- See below example for substituting local over remote

```json
      {
        "name": "Default",
       // uses remote
        "path": "https://raw.githubusercontent.com/WatWowMap/wwm-uicons/main/",
       // uses local
        "path": "wwm-uicons",
        "modifiers": {
          "gym": {
            "0": 1,
            "1": 1,
            "2": 1,
            "3": 3,
            "4": 4,
            "5": 4,
            "6": 18,
            "sizeMultiplier": 1.2
          }
        }
      },
```
<img width="264" alt="Screen Shot 2021-12-29 at 3 07 39 PM" src="https://user-images.githubusercontent.com/58572875/147699589-0fd4921f-4908-48dc-bb76-c6da38781c24.png">

