### PR TITLE
Add Query Limits

### DIFF
--- a/server/scripts/configMigration.js
+++ b/server/scripts/configMigration.js
@@ -47,6 +47,7 @@ const convertMapObject = (obj) => obj ? ({
     enableTutorial: obj?.enableTutorial,
     enableUserProfile: obj?.enableUserProfile,
     enableQuestSetSelector: obj?.enableQuestSetSelector,
+    noScanAreaOverlay: obj?.noScanAreaOverlay,
   },
   theme: obj?.theme,
   clustering: {

--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -23,7 +23,8 @@
       "nests": false
     },
     "queryLimits": {
-      "pokemon": 20000,
+      "pokemon": 10000,
+      "pokemonPvp": 25000,
       "pokestops": 5000,
       "gyms": 5000,
       "portals": 5000,

--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -1,6 +1,7 @@
 {
   "interface": "0.0.0.0",
   "port": 8080,
+  "packageSource": "git",
   "devOptions": {
     "enabled": false,
     "graphiql": false,
@@ -20,6 +21,15 @@
       "quests": true,
       "raids": true,
       "nests": false
+    },
+    "queryLimits": {
+      "pokemon": 20000,
+      "pokestops": 5000,
+      "gyms": 5000,
+      "portals": 5000,
+      "spawnpoints": 10000,
+      "nests": 2500,
+      "scanCells": 5000
     },
     "pvp": {
       "leagues": [
@@ -98,7 +108,8 @@
       "forceTutorial": true,
       "enableTutorial": true,
       "enableUserProfile": true,
-      "enableQuestSetSelector": false
+      "enableQuestSetSelector": false,
+      "noScanAreaOverlay": false
     },
     "theme": {
       "style": "dark",

--- a/server/src/configs/local.example.json
+++ b/server/src/configs/local.example.json
@@ -1,6 +1,7 @@
 {
   "interface": "0.0.0.0",
   "port": 8080,
+  "packageSource": "git/docker",
   "api": {
     "sessionSecret": "98ki^e72~!@#(85o3kXLI*#c9wu5l!Zx",
     "reactMapSecret": "You Should Change Me",

--- a/server/src/models/Gym.js
+++ b/server/src/models/Gym.js
@@ -5,7 +5,7 @@ const fetchRaids = require('../services/api/fetchRaids')
 const { pokemon: masterfile } = require('../data/masterfile.json')
 const dbSelection = require('../services/functions/dbSelection')
 const getAreaSql = require('../services/functions/getAreaSql')
-const { api: { searchResultsLimit } } = require('../services/config')
+const { api: { searchResultsLimit, queryLimits } } = require('../services/config')
 
 module.exports = class Gym extends Model {
   static get tableName() {
@@ -197,7 +197,7 @@ module.exports = class Gym extends Model {
       }
       return filteredResults
     }
-    return secondaryFilter(await query)
+    return secondaryFilter(await query.limit(queryLimits.gyms))
   }
 
   static async getAvailableRaidBosses(isMad) {

--- a/server/src/models/Nest.js
+++ b/server/src/models/Nest.js
@@ -3,7 +3,7 @@ const i18next = require('i18next')
 const { pokemon: masterfile } = require('../data/masterfile.json')
 const getAreaSql = require('../services/functions/getAreaSql')
 const { pokemon: masterPkmn } = require('../data/masterfile.json')
-const { api: { searchResultsLimit } } = require('../services/config')
+const { api: { searchResultsLimit, queryLimits } } = require('../services/config')
 
 module.exports = class Nest extends Model {
   static get tableName() {
@@ -29,7 +29,7 @@ module.exports = class Nest extends Model {
     if (areaRestrictions?.length) {
       getAreaSql(query, areaRestrictions)
     }
-    const results = await query
+    const results = await query.limit(queryLimits.nests)
 
     const fixedForms = queryResults => {
       const returnedResults = []

--- a/server/src/models/Pokemon.js
+++ b/server/src/models/Pokemon.js
@@ -4,7 +4,7 @@ const Ohbem = require('ohbem')
 const { pokemon: masterfile } = require('../data/masterfile.json')
 const legacyFilter = require('../services/legacyFilter')
 const {
-  api: { pvp: { minCp: pvpMinCp, leagues, reactMapHandlesPvp, levels } },
+  api: { pvp: { minCp: pvpMinCp, leagues, reactMapHandlesPvp, levels }, queryLimits },
 } = require('../services/config')
 const dbSelection = require('../services/functions/dbSelection')
 const getAreaSql = require('../services/functions/getAreaSql')
@@ -258,7 +258,7 @@ module.exports = class Pokemon extends Model {
       getAreaSql(query, areaRestrictions, isMad, 'pokemon')
     }
 
-    const results = await query
+    const results = await query.limit(queryLimits.pokemon)
     const finalResults = []
     const pvpResults = []
     const listOfIds = []
@@ -319,7 +319,7 @@ module.exports = class Pokemon extends Model {
       if (areaRestrictions?.length) {
         getAreaSql(pvpQuery, areaRestrictions, isMad, 'pokemon')
       }
-      pvpResults.push(...await pvpQuery)
+      pvpResults.push(...await pvpQuery.limit(queryLimits.pokemon - results.length))
     }
 
     // filter pokes with pvp data

--- a/server/src/models/Pokemon.js
+++ b/server/src/models/Pokemon.js
@@ -319,7 +319,7 @@ module.exports = class Pokemon extends Model {
       if (areaRestrictions?.length) {
         getAreaSql(pvpQuery, areaRestrictions, isMad, 'pokemon')
       }
-      pvpResults.push(...await pvpQuery.limit(queryLimits.pokemon - results.length))
+      pvpResults.push(...await pvpQuery.limit(queryLimits.pokemonPvp - results.length))
     }
 
     // filter pokes with pvp data

--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -6,7 +6,7 @@ const fetchQuests = require('../services/api/fetchQuests')
 const dbSelection = require('../services/functions/dbSelection')
 const getAreaSql = require('../services/functions/getAreaSql')
 const {
-  api: { searchResultsLimit },
+  api: { searchResultsLimit, queryLimits },
   database: { settings },
   map,
 } = require('../services/config')
@@ -112,7 +112,7 @@ module.exports = class Pokestop extends Model {
 
     // returns everything if all pokestops are on
     if (onlyAllPokestops && pokestopPerms) {
-      const results = await query
+      const results = await query.limit(queryLimits.pokestops)
       const normalized = isMad ? this.mapMAD(results, safeTs) : this.mapRDM(results, safeTs)
       return this.secondaryFilter(normalized, args.filters, isMad, midnight)
     }
@@ -247,7 +247,7 @@ module.exports = class Pokestop extends Model {
         })
       }
     })
-    const results = await query
+    const results = await query.limit(queryLimits.pokestops)
     const normalized = isMad ? this.mapMAD(results, safeTs) : this.mapRDM(results, safeTs)
     return this.secondaryFilter(normalized, args.filters, isMad, midnight)
   }

--- a/server/src/models/Portal.js
+++ b/server/src/models/Portal.js
@@ -1,7 +1,7 @@
 const { Model } = require('objection')
 const getAreaSql = require('../services/functions/getAreaSql')
 const {
-  api: { searchResultsLimit, portalUpdateLimit },
+  api: { searchResultsLimit, portalUpdateLimit, queryLimits },
 } = require('../services/config')
 
 module.exports = class Portal extends Model {
@@ -18,7 +18,7 @@ module.exports = class Portal extends Model {
     if (areaRestrictions?.length) {
       getAreaSql(query, areaRestrictions)
     }
-    return query
+    return query.limit(queryLimits.portals)
   }
 
   static async search(args, perms, isMad, distance) {

--- a/server/src/models/ScanCell.js
+++ b/server/src/models/ScanCell.js
@@ -2,6 +2,7 @@ const { Model, ref } = require('objection')
 const dbSelection = require('../services/functions/dbSelection')
 const getPolyVector = require('../services/functions/getPolyVector')
 const getAreaSql = require('../services/functions/getAreaSql')
+const { api: { queryLimits } } = require('../services/config')
 
 module.exports = class ScanCell extends Model {
   static get tableName() {
@@ -20,7 +21,7 @@ module.exports = class ScanCell extends Model {
     if (areaRestrictions?.length) {
       getAreaSql(query, areaRestrictions, isMad, 's2cell')
     }
-    const results = await query
+    const results = await query.limit(queryLimits.scanCells)
     return results.map(cell => ({
       ...cell,
       polygon: getPolyVector(cell.id, 'polygon'),

--- a/server/src/models/Spawnpoint.js
+++ b/server/src/models/Spawnpoint.js
@@ -1,6 +1,7 @@
 const { Model, raw } = require('objection')
 const dbSelection = require('../services/functions/dbSelection')
 const getAreaSql = require('../services/functions/getAreaSql')
+const { api: { queryLimits } } = require('../services/config')
 
 module.exports = class Spawnpoint extends Model {
   static get tableName() {
@@ -32,6 +33,6 @@ module.exports = class Spawnpoint extends Model {
     if (areaRestrictions?.length) {
       getAreaSql(query, areaRestrictions, isMad)
     }
-    return query
+    return query.limit(queryLimits.spawnpoints)
   }
 }

--- a/server/src/services/checkForUpdates.js
+++ b/server/src/services/checkForUpdates.js
@@ -2,6 +2,8 @@
 const { exec } = require('child_process')
 const fs = require('fs')
 
+let isDocker = false
+
 try {
   exec('git branch --show-current', async (err, stdout) => {
     try {
@@ -9,6 +11,9 @@ try {
 
       if (!gitRef && (err || typeof stdout !== 'string' || !stdout.trim())) {
         throw new Error('Unable to get current branch', err)
+      }
+      if (typeof gitRef === 'string' && gitRef.trim()) {
+        isDocker = true
       }
       const branch = typeof gitRef === 'string' && gitRef.trim()
         ? gitRef.split('/')[2].trim()
@@ -33,7 +38,7 @@ try {
               const remoteSha = stdout3.split('\t')[0]
 
               if (remoteSha !== sha) {
-                console.log('There is a new version available:', remoteSha)
+                console.log('There is a new version available: ', remoteSha, isDocker ? 'docker-compose pull' : 'git pull', ' to update')
               }
             } catch (e) {
               console.warn('Unable to get remote SHA', e.message, 'Branch:', branch, 'Local SHA:', sha)

--- a/server/src/services/config.js
+++ b/server/src/services/config.js
@@ -46,9 +46,6 @@ config.authMethods = [...new Set(config.authentication.strategies
   })),
 ]
 
-// Auto check for scan overlay settings
-config.map.noScanAreaOverlay = Boolean(config.manualAreas.length)
-
 // initialize webhooks
 if (config.webhooks.length) {
   (async () => {


### PR DESCRIPTION
- Query limits for Gyms, Nests, Pokemon, Pokestops, Portals, ScanCells, and Spawnpoints
- Due to PVP filtering being done in JS compared to SQL, I caution against setting Pokemon too low
- checkForUpdates adds instruction updates to console
- Re-introduction of noScanAreaOverlay to config
- packageSource added to config