### PR TITLE
Read gymBattles flag from Poracle and act accordingly

### DIFF
--- a/server/src/services/api/resolveQuickHook.js
+++ b/server/src/services/api/resolveQuickHook.js
@@ -2,9 +2,9 @@
 const fetchJson = require('./fetchJson')
 const config = require('../config')
 
-const getWildCards = (category) => {
+const getWildCards = (category, gymBattles) => {
   switch (category) {
-    case 'gym': return { team: 4, slot_changes: true, battle_changes: true }
+    case 'gym': return { team: 4, slot_changes: true, battle_changes: gymBattles }
     case 'egg':
     case 'raid': return { level: 90 }
     default: return {}
@@ -22,7 +22,7 @@ module.exports = async function resolveQuickHook(category, discordId, webhookNam
             method: 'POST',
             body: JSON.stringify({
               ...webhook.client.info[subCategory].defaults,
-              ...getWildCards(subCategory),
+              ...getWildCards(subCategory, webhook.client.gymBattles),
               gym_id: data.id,
             }),
             headers: {

--- a/server/src/services/initWebhooks.js
+++ b/server/src/services/initWebhooks.js
@@ -20,8 +20,8 @@ module.exports = async function initWebhooks(config) {
         }
         const [major, minor, patch] = hookConfig.version.split('.').map(x => parseInt(x))
 
-        if (major < 4 || (major === 4 && minor < 5) || (major === 4 && minor === 5 && patch < 0)) {
-          throw new Error(`Poracle must be at least version 4.5.0, current version is ${hookConfig.version}`)
+        if (major < 4 || (major === 4 && minor < 5) || (major === 4 && minor === 5 && patch < 1)) {
+          throw new Error(`Poracle must be at least version 4.5.1, current version is ${hookConfig.version}`)
         }
 
         const baseSettings = {
@@ -33,7 +33,6 @@ module.exports = async function initWebhooks(config) {
           valid: Boolean(hookConfig),
           pvp: 'rdm',
           everything: hookConfig.everythingFlagPermissions === 'allow-any',
-          gymBattles: hookConfig.gymBattles ?? false,
         }
         if (hookConfig?.pvpLittleLeagueAllowed) {
           baseSettings.leagues.push({ name: 'little', cp: 500, min: hookConfig.pvpFilterLittleMinCP })

--- a/server/src/services/initWebhooks.js
+++ b/server/src/services/initWebhooks.js
@@ -33,6 +33,7 @@ module.exports = async function initWebhooks(config) {
           valid: Boolean(hookConfig),
           pvp: 'rdm',
           everything: hookConfig.everythingFlagPermissions === 'allow-any',
+          gymBattles: hookConfig.gymBattles ?? false,
         }
         if (hookConfig?.pvpLittleLeagueAllowed) {
           baseSettings.leagues.push({ name: 'little', cp: 500, min: hookConfig.pvpFilterLittleMinCP })

--- a/server/src/services/ui/webhook.js
+++ b/server/src/services/ui/webhook.js
@@ -196,7 +196,7 @@ module.exports = function webhookUi(provider, hookConfig, pvp, leagues) {
               ],
               booleans: [
                 { name: 'clean', xs: 4, sm: 4 },
-                { name: 'battle_changes', xs: 6, sm: 4 },
+                ...( hookConfig.gymBattles ? [{ name: 'battle_changes', xs: 6, sm: 4 }] : []),
                 { name: 'slot_changes', xs: 6, sm: 4 },
               ],
               autoComplete: [{ name: 'gymName', label: 'gym', searchCategory: 'gyms', xs: 12, sm: 12 }],


### PR DESCRIPTION
Requires Poracle PR676, might work without it also, I didn't test it.

Hides In battle switch from gym alarm selection and based on the value received alters the quick add gym alarm -functionality.
I guess it's still possible for users to inject the `battle_changes` flag from frontend, but that isn't a major concern.

And again a warning, I still learning JS, so make sure this makes sense!