### PR TITLE
Proper Custom Code Injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,8 @@ Desktop.ini
 # Linux
 .directory
 *~
+
+# Custom Files
+src/**/*.custom.jsx
+src/**/*.custom.js
+src/**/*.custom.css

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -22,12 +22,13 @@ const isRelease = Boolean(process.argv.includes('--release'))
 
 const hasCustom = await (async function checkFolders(folder, isCustom = false) {
   for (const file of await fs.promises.readdir(folder)) {
+    if (isCustom) return true
     if (file.startsWith('.')) continue
     if (!file.includes('.')) isCustom = await checkFolders(`${folder}/${file}`, isCustom)
     if (/\.custom.(jsx?|css)$/.test(file)) return true
   }
   return isCustom
-}(`${__dirname}/src`))
+}(path.resolve(__dirname, 'src')))
 
 if (await fs.existsSync(path.resolve(__dirname, 'dist'))) {
   console.log('Cleaning up old build')

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -10,7 +10,7 @@ import './services/i18n'
 if (inject) {
   const {
     GOOGLE_ANALYTICS_ID, ANALYTICS_DEBUG_MODE, TITLE, VERSION,
-    SENTRY_DSN, SENTRY_TRACES_SAMPLE_RATE, DEVELOPMENT,
+    SENTRY_DSN, SENTRY_TRACES_SAMPLE_RATE, DEVELOPMENT, CUSTOM,
   } = inject
   if (GOOGLE_ANALYTICS_ID) {
     ReactGA.initialize(GOOGLE_ANALYTICS_ID, { debug: ANALYTICS_DEBUG_MODE })
@@ -26,11 +26,7 @@ if (inject) {
     environment: DEVELOPMENT ? 'development' : 'production',
     debug: DEVELOPMENT,
     beforeSend(event) {
-      if (event?.exception?.values?.[0]?.stacktrace?.frames?.some(f => f.filename.includes('node_modules'))) {
-        // do nothing for external libraries
-        return null
-      }
-      return event
+      return CUSTOM ? null : event
     },
   })
   // eslint-disable-next-line no-console

--- a/src/services/i18n.js
+++ b/src/services/i18n.js
@@ -9,7 +9,7 @@ export default i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
-    supportedLngs: ['de', 'en', 'es', 'fr', 'it', 'ja', 'ko', 'nl', 'pl', 'pt-br', 'ru', 'sv', 'th', 'zh-tw'],
+    supportedLngs: inject.LOCALES || ['en'],
     fallbackLng: 'en',
     debug: false,
     joinArrays: '\n',


### PR DESCRIPTION
**== This PR adds a feature that will never be officially supported ==** 

- Don't like my implementation?
- Too lazy to write a configurable PR?
- Want to maintain custom files while keeping it git friendly?

This PR enables you to replace every single file in the root `src` folder with your own implementation!

For example, if you want to customize the Pokestop marker:
1. Copy `src/components/markers/pokestop.jsx`
2. Name new file to `src/components/markers/pokestop.custom.jsx`
3. Make your changes
4. Recompile
5. Celebrate that you're no longer limited to my opinions and praise how generous I am

**F.A.Q.**
Q. But Turtle, why would I want to write a custom component instead of relying on the config? 
-  The config is massive and overwhelming at this point. Most of the options only cater to a small handful of people. 
- We all have opinions, just write your own code, please leave me alone.
- Performance. All of these unnecessary calculations for things like icon placement starts to impact performance when multiplying it by thousands. 

Q. What do you mean this will never be officially supported?
- If you are writing custom files, it is imperative that you keep an eye on PRs to make sure that they don't break your custom implementations.
- I will not provide help with your custom implementations.

Q. How can you rudely break my custom component if it's git friendly?
- Custom components still rely on the props being passed through, using the example above:
```js
export default function pokestopMarker(pokestop, hasQuest, hasLure, hasInvasion, filters, Icons, userSettings)
```
- You are still reliant on me passing all of these properties to the Pokestop marker, even in your custom implementation. If the inputs change, you must adjust your custom components. 
- I will do my best to inform people of changes that can affect custom components

Q. What files can I edit?
- Any `.css`, `.js`, or `.jsx` file in the root `src` folder. This PR does not apply to files in the `server` or `public` folders.

Q. How does this inject custom code while maintaining git friendly-ness??
- All files with the `.custom.[js,jsx,css]` ending are git ignored. The compiler checks if a custom file exists during the loading process, if it does, it replaces the contents of the standard file with the custom. Maintaining the original in the file structure while loading your custom file into the end bundle. Magic.

In Closing:
- With the addition of this functionality, I may start to trim back the config. This is the number 1 way that we can start to claw back some performance gains that we've sacrificed due to the obscene config. 
- Don't think of it as losing config options. **Think of it as you just gained a config for every single aspect of the map.**