### PR TITLE
Better Database Management

### DIFF
--- a/server/scripts/console.js
+++ b/server/scripts/console.js
@@ -1,5 +1,5 @@
 const repl = require('repl')
-require('../src/db/initialization')
+const Db = require('../src/db/initialization')
 const models = require('../src/models/index')
 
 const replServer = repl.start({
@@ -7,3 +7,4 @@ const replServer = repl.start({
 })
 
 replServer.context.models = models
+replServer.context.Db = Db

--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -348,24 +348,19 @@
     },
     "schemas": [
       {
-        "type": "rdm",
         "host": "127.0.0.1",
         "port": 3306,
         "username": "user",
         "password": "pass123!",
         "database": "rdmdb",
-        "charset": "utf8mb4",
-        "hasAltQuests": false,
         "useFor": []
       },
       {
-        "type": "manual",
         "host": "127.0.0.1",
         "port": 3306,
         "username": "user",
         "password": "pass123!",
         "database": "manualdb",
-        "charset": "utf8mb4",
         "useFor": []
       }
     ]

--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -17,11 +17,16 @@
       "requests": 1000
     },
     "queryAvailable": {
-      "updateHours": 1,
       "pokemon": false,
       "quests": true,
       "raids": true,
       "nests": false
+    },
+    "queryUpdateHours": {
+      "pokemon": 0.5,
+      "quests": 1,
+      "raids": 0.5,
+      "nests": 12
     },
     "queryLimits": {
       "pokemon": 10000,

--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -17,6 +17,7 @@
       "requests": 1000
     },
     "queryAvailable": {
+      "updateHours": 1,
       "pokemon": false,
       "quests": true,
       "raids": true,

--- a/server/src/configs/local.example.json
+++ b/server/src/configs/local.example.json
@@ -40,10 +40,6 @@
       "minZoom": 10,
       "maxZoom": 18
     },
-    "links": {
-      "feedbackLink": "",
-      "statsLink": ""
-    },
     "misc": {
       "enableQuestSetSelector": true
     }
@@ -75,20 +71,13 @@
     }
   },
   "database": {
-    "settings": {
-      "userTableName": "users",
-      "sessionTableName": "session"
-    },
     "schemas": [
       {
-        "type": "rdm/chuck/cdc/mad/manual",
         "host": "127.0.0.1",
         "port": 3306,
-        "username": "user",
-        "password": "pass123!",
-        "database": "rdmdb",
-        "charset": "utf8mb4",
-        "hasAltQuests": false,
+        "username": "scanner_user",
+        "password": "scanner_paw",
+        "database": "scanner_db",
         "useFor": [
           "device",
           "gym",
@@ -100,13 +89,11 @@
         ]
       },
       {
-        "type": "manual",
         "host": "127.0.0.1",
         "port": 3306,
-        "username": "user",
-        "password": "pass123!",
-        "database": "manual_1",
-        "charset": "utf8mb4",
+        "username": "manual_user",
+        "password": "manual_pw",
+        "database": "manual_db",
         "useFor": [
           "session",
           "user",
@@ -283,24 +270,7 @@
       },
       {
         "name": "PMSF",
-        "path": "https://raw.githubusercontent.com/whitewillem/PogoAssets/main/uicons-outline/",
-        "modifiers": {
-          "reward": {
-            "offsetX": 0.2,
-            "offsetY": 0.5,
-            "sizeMultiplier": 1.15
-          },
-          "invasion": {
-            "offsetX": 0.05,
-            "offsetY": 0.7,
-            "sizeMultiplier": 1.5,
-            "removeQuest": true
-          },
-          "pokestop": {
-            "sizeMultiplier": 2,
-            "manualPopup": -100
-          }
-        }
+        "path": "https://raw.githubusercontent.com/whitewillem/PogoAssets/main/uicons-outline/"
       },
       {
         "name": "Home",
@@ -318,6 +288,9 @@
   },
   "manualAreas": [
     {
+      "name": "Remove all of these if you'd prefer the map to read directly from your Geojson"
+    },
+    {
       "name": "New York",
       "lat": 40.7481666,
       "lon": -74.0174788,
@@ -327,9 +300,6 @@
       "name": "San Francisco",
       "lat": 37.79539194255634,
       "lon": -122.39333173075096
-    },
-    {
-      "name": "Remove all of these if you'd prefer the map to read directly from your Geojson"
     }
   ]
 }

--- a/server/src/db/initialization.js
+++ b/server/src/db/initialization.js
@@ -1,41 +1,14 @@
-/* eslint-disable no-console */
-const Knex = require('knex')
-const { database: { schemas: exampleSchemas } } = require('../configs/local.example.json')
-const { database: { schemas, settings }, devOptions: { queryDebug } } = require('../services/config')
-const models = require('../models/index')
+const {
+  database: { schemas: exampleSchemas },
+} = require('../configs/local.example.json')
+const {
+  database,
+  devOptions: { queryDebug },
+  api,
+} = require('../services/config')
 
-// Establishes knex connections to each database listed in the config
-const connections = schemas.map(schema => Knex({
-  client: 'mysql2',
-  connection: {
-    host: schema.host,
-    port: schema.port,
-    user: schema.username,
-    password: schema.password,
-    database: schema.database,
-  },
-  debug: queryDebug,
-  pool: {
-    max: settings.maxConnections,
-    afterCreate(conn, done) {
-      conn.query('SET time_zone="+00:00";', (err) => done(err, conn))
-    },
-  },
-}))
+const DbCheck = require('../services/DbCheck')
 
-// Binds the models to the designated databases
-schemas.forEach((schema, index) => {
-  try {
-    schema.useFor.forEach(category => {
-      if (category === 'user') {
-        models.Badge.knex(connections[index])
-      }
-      const capital = `${category.charAt(0).toUpperCase()}${category.slice(1)}`
-      models[capital].knex(connections[index])
-    })
-  } catch (e) {
-    console.error(`
-    Only ${[exampleSchemas.flatMap(s => s.useFor)].join(', ')} are valid options in the useFor fields`, '\n\n', e)
-    process.exit(9)
-  }
-})
+const Db = new DbCheck(exampleSchemas, database, queryDebug, api)
+
+module.exports = Db

--- a/server/src/graphql/context.js
+++ b/server/src/graphql/context.js
@@ -1,5 +1,0 @@
-const DbCheck = require('../services/DbCheck')
-
-const DbClass = new DbCheck();
-
-module.exports = { DbClass }

--- a/server/src/graphql/resolvers.js
+++ b/server/src/graphql/resolvers.js
@@ -2,21 +2,22 @@
 const GraphQLJSON = require('graphql-type-json')
 
 const config = require('../services/config')
-const { Gym, User, Badge } = require('../models/index')
+const { User, Badge } = require('../models/index')
 const Utility = require('../services/Utility')
 const Fetch = require('../services/Fetch')
 
 module.exports = {
   JSON: GraphQLJSON,
   Query: {
-    badges: (_, args, { req }) => {
+    badges: async (_, args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       if (perms?.gymBadges) {
-        return Gym.getGymBadges(Utility.dbSelection('gym').type === 'mad', req?.user?.id)
+        const badges = await Badge.getAll(req.user?.id)
+        return Db.getBadges(badges)
       }
       return []
     },
-    devices: async (_, args, { req, Db }) => {
+    devices: (_, args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       if (perms?.devices) {
         return Db.getAll('Device', perms)
@@ -165,7 +166,7 @@ module.exports = {
       }
       return []
     },
-    searchQuest: async (_, args, { req, Db }) => {
+    searchQuest: (_, args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       const { category, search } = args
       if (perms?.[category] && /^[0-9\s\p{L}]+$/u.test(search)) {

--- a/server/src/graphql/resolvers.js
+++ b/server/src/graphql/resolvers.js
@@ -9,7 +9,7 @@ const Fetch = require('../services/Fetch')
 module.exports = {
   JSON: GraphQLJSON,
   Query: {
-    badges: async (_, args, { req, Db }) => {
+    badges: async (_, _args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       if (perms?.gymBadges) {
         const badges = await Badge.getAll(req.user?.id)
@@ -17,7 +17,7 @@ module.exports = {
       }
       return []
     },
-    devices: (_, args, { req, Db }) => {
+    devices: (_, _args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       if (perms?.devices) {
         return Db.getAll('Device', perms)
@@ -117,7 +117,7 @@ module.exports = {
       }
       return []
     },
-    scanAreas: (_, args, { req }) => {
+    scanAreas: (_, _args, { req }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       const scanAreas = config.scanAreas[req.headers.host]
         ? config.scanAreas[req.headers.host]
@@ -197,7 +197,7 @@ module.exports = {
       }
       return [{ placementCells: [], typeCells: [] }]
     },
-    weather: (_, args, { req, Db }) => {
+    weather: (_, _args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       if (perms?.weather) {
         return Db.getAll('Weather')
@@ -211,7 +211,7 @@ module.exports = {
       }
       return {}
     },
-    scanner: (parent, args, { req }) => {
+    scanner: (_, args, { req }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       const { category, method, data } = args
       if (category === 'getQueue') {

--- a/server/src/graphql/resolvers.js
+++ b/server/src/graphql/resolvers.js
@@ -1,11 +1,8 @@
 /* eslint-disable no-console */
 const GraphQLJSON = require('graphql-type-json')
-const { raw } = require('objection')
 
 const config = require('../services/config')
-const {
-  Device, Gym, Pokemon, Pokestop, Portal, ScanCell, Spawnpoint, Weather, Nest, User, Badge,
-} = require('../models/index')
+const { Gym, User, Badge } = require('../models/index')
 const Utility = require('../services/Utility')
 const Fetch = require('../services/Fetch')
 
@@ -19,10 +16,10 @@ module.exports = {
       }
       return []
     },
-    devices: (_, args, { req }) => {
+    devices: async (_, args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       if (perms?.devices) {
-        return Device.getAllDevices(perms, Utility.dbSelection('device').type === 'mad')
+        return Db.getAll('Device', perms)
       }
       return []
     },
@@ -36,110 +33,86 @@ module.exports = {
       }
       return []
     },
-    gyms: (_, args, { req }) => {
+    gyms: (_, args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       if (perms?.gyms || perms?.raids) {
-        return Gym.getAllGyms(args, perms, Utility.dbSelection('gym').type === 'mad', req?.user?.id)
+        return Db.getAll('Gym', perms, args, req?.user?.id)
       }
       return []
     },
-    gymsSingle: (_, args, { req }) => {
+    gymsSingle: (_, args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       if (perms?.[args.perm]) {
-        const query = Gym.query()
-          .findById(args.id)
-        if (Utility.dbSelection('gym').type === 'mad') {
-          query.select([
-            'latitude AS lat',
-            'longitude AS lon',
-          ])
-        }
-        return query || {}
+        return Db.getOne('Gym', args.id)
       }
       return {}
     },
-    nests: (_, args, { req }) => {
+    nests: (_, args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       if (perms?.nests) {
-        return Nest.getNestingSpecies(args, perms)
+        return Db.getAll('Nest', perms, args)
       }
       return []
     },
-    nestsSingle: (_, args, { req }) => {
+    nestsSingle: (_, args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       if (perms?.[args.perm]) {
-        return Nest.query().findById(args.id) || {}
+        return Db.getOne('Nest', args.id)
       }
       return {}
     },
-    pokestops: (_, args, { req }) => {
+    pokestops: (_, args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       if (perms?.pokestops
         || perms?.lures
         || perms?.quests
         || perms?.invasions) {
-        return Pokestop.getAllPokestops(args, perms, Utility.dbSelection('pokestop').type === 'mad')
+        return Db.getAll('Pokestop', perms, args)
       }
       return []
     },
-    pokestopsSingle: (_, args, { req }) => {
+    pokestopsSingle: (_, args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       if (perms?.[args.perm]) {
-        const query = Pokestop.query()
-          .findById(args.id)
-        if (Utility.dbSelection('pokestop').type === 'mad') {
-          query.select([
-            'latitude AS lat',
-            'longitude AS lon',
-          ])
-        }
-        return query || {}
+        return Db.getOne('Pokestop', args.id)
       }
       return {}
     },
-    pokemon: (_, args, { req, DbClass }) => {
+    pokemon: (_, args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       if (perms?.pokemon) {
-        const isMad = Utility.dbSelection('pokemon').type === 'mad'
         if (args.filters.onlyLegacy) {
-          return Pokemon.getLegacy(args, perms, isMad, DbClass.pvpV2)
+          return Db.getAll('Pokemon', perms, args, 0, 'getLegacy')
         }
-        return Pokemon.getPokemon(args, perms, isMad, DbClass.pvpV2)
+        return Db.getAll('Pokemon', perms, args)
       }
       return []
     },
-    pokemonSingle: (_, args, { req }) => {
+    pokemonSingle: (_, args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       if (perms?.[args.perm]) {
-        const query = Pokemon.query().findById(args.id)
-        if (Utility.dbSelection('pokemon').type === 'mad') {
-          query.select([
-            'latitude AS lat',
-            'longitude AS lon',
-          ])
-        }
-        return query || {}
+        return Db.getOne('Pokemon', args.id)
       }
       return {}
     },
-    portals: (_, args, { req }) => {
+    portals: (_, args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       if (perms?.portals) {
-        return Portal.getAllPortals(args, perms)
+        return Db.getAll('Portal', perms, args)
       }
       return []
     },
-    portalsSingle: (_, args, { req }) => {
+    portalsSingle: (_, args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       if (perms?.[args.perm]) {
-        return Portal.query().findById(args.id) || {}
+        return Db.getOne('Portal', args.id)
       }
       return {}
     },
-    scanCells: (_, args, { req }) => {
+    scanCells: (_, args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       if (perms?.scanCells && args.zoom >= config.map.scanCellsZoom) {
-        return ScanCell.getAllCells(args, perms, Utility.dbSelection('pokestop').type === 'mad')
+        return Db.getAll('ScanCell', perms, args)
       }
       return []
     },
@@ -158,23 +131,20 @@ module.exports = {
       }
       return [scanAreas]
     },
-    search: async (_, args, { req }) => {
+    search: async (_, args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       const { category, webhookName, search } = args
       if (perms?.[category] && /^[0-9\s\p{L}]+$/u.test(search)) {
-        const isMad = Utility.dbSelection(category.substring(0, category.length - 1)).type === 'mad'
-        const distance = raw(`ROUND(( 3959 * acos( cos( radians(${args.lat}) ) * cos( radians( ${isMad ? 'latitude' : 'lat'} ) ) * cos( radians( ${isMad ? 'longitude' : 'lon'} ) - radians(${args.lon}) ) + sin( radians(${args.lat}) ) * sin( radians( ${isMad ? 'latitude' : 'lat'} ) ) ) ),2)`).as('distance')
-
         if (!search || !search.trim()) {
           return []
         }
         switch (args.category) {
           case 'pokestops':
-            return Pokestop.search(args, perms, isMad, distance)
+            return Db.search('Pokestop', perms, args)
           case 'raids':
-            return Gym.searchRaids(args, perms, isMad, distance)
+            return Db.search('Gym', perms, args, 'searchRaids')
           case 'gyms': {
-            const results = await Gym.search(args, perms, isMad, distance)
+            const results = await Db.search('Gym', perms, args)
             const webhook = webhookName ? config.webhookObj[webhookName] : null
             if (webhook && results.length) {
               const withFormatted = await Promise.all(results.map(async result => ({
@@ -187,79 +157,36 @@ module.exports = {
             return results
           }
           case 'portals':
-            return Portal.search(args, perms, isMad, distance)
+            return Db.search('Portal', perms, args)
           case 'nests':
-            return Nest.search(args, perms, isMad, distance)
+            return Db.search('Nest', perms, args)
           default: return []
         }
       }
       return []
     },
-    searchQuest: async (_, args, { req }) => {
+    searchQuest: async (_, args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       const { category, search } = args
       if (perms?.[category] && /^[0-9\s\p{L}]+$/u.test(search)) {
-        const isMad = Utility.dbSelection(category.substring(0, category.length - 1)).type === 'mad'
-        const distance = raw(`ROUND(( 3959 * acos( cos( radians(${args.lat}) ) * cos( radians( ${isMad ? 'latitude' : 'lat'} ) ) * cos( radians( ${isMad ? 'longitude' : 'lon'} ) - radians(${args.lon}) ) + sin( radians(${args.lat}) ) * sin( radians( ${isMad ? 'latitude' : 'lat'} ) ) ) ),2)`).as('distance')
-
         if (!search || !search.trim()) {
           return []
         }
-        return Pokestop.searchQuests(args, perms, isMad, distance) || []
+        return Db.search('Pokestop', perms, args, 'searchQuests')
       }
       return []
     },
-    spawnpoints: (_, args, { req }) => {
+    spawnpoints: (_, args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       if (perms?.spawnpoints) {
-        return Spawnpoint.getAllSpawnpoints(args, perms, Utility.dbSelection('spawnpoint').type === 'mad')
+        return Db.getAll('Spawnpoint', perms, args)
       }
       return []
     },
-    submissionCells: async (_, args, { req }) => {
+    submissionCells: async (_, args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       if (perms?.submissionCells && args.zoom >= config.map.submissionZoom - 1) {
-        const isMadStops = Utility.dbSelection('pokestop').type === 'mad'
-        const isMadGyms = Utility.dbSelection('gym').type === 'mad'
-
-        const stopQuery = Pokestop.query()
-        if (isMadStops) {
-          stopQuery.select([
-            'pokestop_id AS id',
-            'latitude AS lat',
-            'longitude AS lon',
-          ])
-        } else {
-          stopQuery.select(['id', 'lat', 'lon'])
-            .andWhere(poi => {
-              poi.whereNull('sponsor_id')
-                .orWhere('sponsor_id', 0)
-            })
-        }
-
-        const gymQuery = Gym.query()
-        if (isMadGyms) {
-          gymQuery.select([
-            'gym_id AS id',
-            'latitude AS lat',
-            'longitude AS lon',
-          ])
-        } else {
-          gymQuery.select(['id', 'lat', 'lon'])
-            .where(poi => {
-              poi.whereNull('sponsor_id')
-                .orWhere('sponsor_id', 0)
-            })
-        }
-
-        [stopQuery, gymQuery].forEach((query, i) => {
-          const isMad = [isMadStops, isMadGyms]
-          query.whereBetween(`lat${isMad[i] ? 'itude' : ''}`, [args.minLat - 0.025, args.maxLat + 0.025])
-            .andWhereBetween(`lon${isMad[i] ? 'gitude' : ''}`, [args.minLon - 0.025, args.maxLon + 0.025])
-            .andWhere(isMad[i] ? 'enabled' : 'deleted', isMad[i])
-        })
-        const pokestops = await stopQuery
-        const gyms = await gymQuery
+        const [pokestops, gyms] = await Db.submissionCells(args)
         return [{
           placementCells: args.zoom >= config.map.submissionZoom
             ? Utility.getPlacementCells(args, pokestops, gyms)
@@ -269,10 +196,10 @@ module.exports = {
       }
       return [{ placementCells: [], typeCells: [] }]
     },
-    weather: (_, args, { req }) => {
+    weather: (_, args, { req, Db }) => {
       const perms = req.user ? req.user.perms : req.session.perms
       if (perms?.weather) {
-        return Weather.getAllWeather(Utility.dbSelection('weather').type === 'mad')
+        return Db.getAll('Weather')
       }
       return []
     },

--- a/server/src/graphql/scannerTypes.js
+++ b/server/src/graphql/scannerTypes.js
@@ -2,7 +2,7 @@ const { gql } = require('apollo-server-express')
 
 module.exports = gql`
   type Device {
-    uuid: ID
+    id: ID
     instance_name: String
     last_seen: Int
     last_lat: Float
@@ -46,7 +46,7 @@ module.exports = gql`
   }
 
   type Nest {
-    nest_id: ID
+    id: ID
     lat: Float
     lon: Float
     pokemon_id: Int

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-console */
 /* eslint-disable import/no-dynamic-require */
 /* eslint-disable global-require */
-require('./db/initialization')
 
 const path = require('path')
 const express = require('express')
@@ -15,13 +14,12 @@ const Backend = require('i18next-fs-backend')
 const { ValidationError } = require('apollo-server-core')
 const { ApolloServer } = require('apollo-server-express')
 
+const Db = require('./db/initialization')
 const config = require('./services/config')
-const { Pokemon } = require('./models/index')
 const { sessionStore } = require('./services/sessionStore')
 const rootRouter = require('./routes/rootRouter')
 const typeDefs = require('./graphql/typeDefs')
 const resolvers = require('./graphql/resolvers')
-const context = require('./graphql/context')
 
 if (!config.devOptions.skipUpdateCheck) {
   require('./services/checkForUpdates')
@@ -35,7 +33,7 @@ const server = new ApolloServer({
   resolvers,
   introspection: config.devOptions.enabled,
   debug: config.devOptions.queryDebug,
-  context: ({ req }) => ({ ...context, req }),
+  context: ({ req }) => ({ Db, req }),
   formatError: (e) => {
     if (e instanceof ValidationError) {
       console.warn('GraphQL Error:', e.message, '\nThis is very likely not a real issue and is caused by a user leaving an old browser session open, there is nothing you can do until they refresh.')
@@ -150,10 +148,6 @@ app.use((err, req, res, next) => {
       return res.redirect('/')
   }
 })
-
-if (config.api.pvp.reactMapHandlesPvp) {
-  Pokemon.initOhbem().then(() => console.log('Ohbem initialized'))
-}
 
 app.listen(config.port, config.interface, () => {
   console.log(`Server is now listening at http://${config.interface}:${config.port}`)

--- a/server/src/models/Badge.js
+++ b/server/src/models/Badge.js
@@ -31,4 +31,10 @@ module.exports = class Badge extends Model {
       },
     }
   }
+
+  static async getAll(userId) {
+    return this.query()
+      .where('userId', userId)
+      .andWhere('badge', '>', 0)
+  }
 }

--- a/server/src/models/Device.js
+++ b/server/src/models/Device.js
@@ -1,24 +1,19 @@
 const { Model, raw } = require('objection')
-const dbSelection = require('../services/functions/dbSelection')
 const getAreaSql = require('../services/functions/getAreaSql')
 
 module.exports = class Device extends Model {
   static get tableName() {
-    return dbSelection('device').type === 'mad' ? 'settings_device' : 'device'
+    return 'device'
   }
 
-  static get idColumn() {
-    return dbSelection('device').type === 'mad' ? 'device_id' : 'uuid'
-  }
-
-  static async getAllDevices(perms, isMad) {
+  static async getAll(perms, _args, settings) {
     const { areaRestrictions } = perms
     const query = this.query()
-    if (isMad) {
+    if (settings.isMad) {
       query.join('trs_status', 'settings_device.device_id', 'trs_status.device_id')
         .join('settings_area', 'trs_status.area_id', 'settings_area.area_id')
         .select([
-          'settings_device.name AS uuid',
+          'settings_device.name AS id',
           'settings_area.name AS instance_name',
           'mode AS type',
           raw('UNIX_TIMESTAMP(lastProtoDateTime)')
@@ -32,13 +27,20 @@ module.exports = class Device extends Model {
         ])
     } else {
       query.join('instance', 'device.instance_name', 'instance.name')
-        .select('uuid', 'last_seen', 'last_lat', 'last_lon', 'type', 'instance_name',
+        .select(
+          'uuid AS id',
+          'last_seen',
+          'last_lat',
+          'last_lon',
+          'type',
+          'instance_name',
           raw('json_extract(data, "$.area")')
-            .as('route'))
+            .as('route'),
+        )
     }
     if (areaRestrictions.length) {
-      getAreaSql(query, areaRestrictions, isMad, 'device')
+      getAreaSql(query, areaRestrictions, settings.isMad, 'device')
     }
-    return query
+    return query.from(settings.isMad ? 'settings_device' : 'device')
   }
 }

--- a/server/src/models/Gym.js
+++ b/server/src/models/Gym.js
@@ -6,11 +6,8 @@ const { pokemon: masterfile } = require('../data/masterfile.json')
 const getAreaSql = require('../services/functions/getAreaSql')
 const {
   api: { searchResultsLimit, queryLimits, gymValidDataLimit, hideOldGyms },
-  database: { schemas, settings: { gymBadgeTableName, joinGymBadgeTable } },
 } = require('../services/config')
 const Badge = require('./Badge')
-
-const gymBadgeDb = schemas.find(x => x.useFor.includes('user'))
 
 const coreFields = ['id', 'name', 'url', 'lat', 'lon', 'updated', 'last_modified_timestamp']
 
@@ -338,7 +335,7 @@ module.exports = class Gym extends Model {
     return query
   }
 
-  static async getGymBadges(isMad, userId) {
+  static async getBadges(userGyms, { isMad }) {
     const query = this.query()
       .select([
         '*',
@@ -352,18 +349,15 @@ module.exports = class Gym extends Model {
       query.leftJoin('gymdetails', 'gym.gym_id', 'gymdetails.gym_id')
     }
 
-    if (joinGymBadgeTable) {
-      query.leftJoin(`${gymBadgeDb.database}.${gymBadgeTableName}`, isMad ? 'gym.gym_id' : 'gym.id', `${gymBadgeTableName}.gymId`)
-        .where('userId', userId)
-        .andWhere('badge', '>', 0)
-        .orderBy('updatedAt')
-      const results = await query
-      return isMad ? results.map(gym => gym.deleted = !gym.enabled) : results
-    }
-
-    const userGyms = await Badge.query()
-      .where('userId', userId)
-      .andWhere('badge', '>', 0)
+    // Come back to this later, maybe
+    // if (joinGymBadgeTable) {
+    //   query.leftJoin(`${gymBadgeDb.database}.${gymBadgeTableName}`, isMad ? 'gym.gym_id' : 'gym.id', `${gymBadgeTableName}.gymId`)
+    //     .where('userId', userId)
+    //     .andWhere('badge', '>', 0)
+    //     .orderBy('updatedAt')
+    //   const results = await query
+    //   return isMad ? results.map(gym => gym.deleted = !gym.enabled) : results
+    // }
 
     const results = await query
       .whereIn(isMad ? 'gym.gym_id' : 'gym.id', userGyms.map(gym => gym.gymId))

--- a/server/src/models/Nest.js
+++ b/server/src/models/Nest.js
@@ -17,7 +17,7 @@ module.exports = class Nest extends Model {
     return 'nest_id'
   }
 
-  static async getNestingSpecies(args, perms) {
+  static async getAll(perms, args) {
     const { areaRestrictions } = perms
     const pokemon = []
     Object.keys(args.filters).forEach(pkmn => {
@@ -26,6 +26,7 @@ module.exports = class Nest extends Model {
       }
     })
     const query = this.query()
+      .select(['*', 'nest_id AS id'])
       .whereBetween('lat', [args.minLat, args.maxLat])
       .andWhereBetween('lon', [args.minLon, args.maxLon])
       .whereIn('pokemon_id', pokemon)
@@ -53,7 +54,7 @@ module.exports = class Nest extends Model {
     return fixedForms(results)
   }
 
-  static async getAvailableNestingSpecies() {
+  static async getAvailable() {
     const results = await this.query()
       .select(['pokemon_id', 'pokemon_form'])
       .groupBy('pokemon_id', 'pokemon_form')
@@ -67,7 +68,7 @@ module.exports = class Nest extends Model {
     })
   }
 
-  static async search(args, perms, isMad, distance) {
+  static async search(perms, args, { isMad }, distance) {
     const { search, locale } = args
     const pokemonIds = Object.keys(masterPkmn).filter(pkmn => (
       i18next.t(`poke_${pkmn}`, { lng: locale }).toLowerCase().includes(search)
@@ -89,5 +90,9 @@ module.exports = class Nest extends Model {
       getAreaSql(query, perms.areaRestrictions, isMad)
     }
     return query
+  }
+
+  static getOne(id) {
+    return this.query().findById(id).select(['lat', 'lon'])
   }
 }

--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -307,18 +307,17 @@ module.exports = class Pokestop extends Model {
     for (let i = 0; i < queryResults.length; i += 1) {
       const pokestop = queryResults[i]
       const filtered = {}
-      const global = filters.onlyAllPokestops || (pokestop.ar_scan_eligible && filters.onlyArEligible)
 
       this.fieldAssigner(filtered, pokestop, ['id', 'lat', 'lon', 'enabled', 'ar_scan_eligible', 'url', 'name', 'last_modified_timestamp', 'updated'])
 
-      if (global || filters.onlyInvasions) {
+      if (filters.onlyAllPokestops || filters.onlyInvasions) {
         filtered.invasions = pokestop.invasions.filter(invasion => filters[`i${invasion.grunt_type}`])
       }
-      if (global || (filters.onlyLures && filters[`l${pokestop.lure_id}`])) {
+      if (filters.onlyAllPokestops || (filters.onlyLures && filters[`l${pokestop.lure_id}`])) {
         this.fieldAssigner(filtered, pokestop, ['lure_id', 'lure_expire_timestamp'])
       }
 
-      if (global || filters.onlyQuests) {
+      if (filters.onlyAllPokestops || filters.onlyQuests) {
         filtered.quests = []
         pokestop.quests.forEach(quest => {
           if (quest.quest_reward_type && (
@@ -356,7 +355,7 @@ module.exports = class Pokestop extends Model {
               default:
                 newQuest.key = `u${quest.quest_reward_type}`
             }
-            if (quest.quest_timestamp >= midnight && (global || filters[newQuest.key]
+            if (quest.quest_timestamp >= midnight && (filters.onlyAllPokestops || filters[newQuest.key]
               || (filters[`u${quest.quest_reward_type}`] && map.enableQuestRewardTypeFilters))) {
               this.fieldAssigner(newQuest, quest, fields)
               filtered.quests.push(newQuest)
@@ -364,7 +363,10 @@ module.exports = class Pokestop extends Model {
           }
         })
       }
-      if (global || filtered.quests?.length || filtered.lure_id || filtered.invasions) {
+      if ((pokestop.ar_scan_eligible && filters.onlyArEligible)
+        || filtered.quests?.length
+        || filtered.lure_id
+        || filtered.invasions) {
         filteredResults.push(filtered)
       }
     }

--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -457,7 +457,6 @@ module.exports = class Pokestop extends Model {
         ...quests.items,
         ...await this.query()
           .select('alternative_quest_item_id AS quest_item_id')
-          .from('pokestop')
           .where('alternative_quest_reward_type', 2)
           .groupBy('alternative_quest_item_id'),
       ]
@@ -521,8 +520,8 @@ module.exports = class Pokestop extends Model {
         .where('alternative_quest_reward_type', 12)
       if (hasRewardAmount) {
         altMegaQuery
-          .distinct('quest_reward_amount AS amount')
-          .distinct('quest_pokemon_id AS id')
+          .distinct('alternative_quest_reward_amount AS amount')
+          .distinct('alternative_quest_pokemon_id AS id')
       } else {
         altMegaQuery
           .distinct(raw('json_extract(alternative_quest_rewards, "$[0].info.pokemon_id")')
@@ -543,7 +542,7 @@ module.exports = class Pokestop extends Model {
       quests.candy = [
         ...quests.candy,
         ...await this.query()
-          .distinct('alternative_quest_pokemon_id')
+          .distinct('alternative_quest_pokemon_id AS quest_pokemon_id')
           .where('alternative_quest_reward_type', 4),
       ]
     }
@@ -555,7 +554,7 @@ module.exports = class Pokestop extends Model {
       quests.xlCandy = [
         ...quests.xlCandy,
         ...await this.query()
-          .distinct('alternative_quest_pokemon_id')
+          .distinct('alternative_quest_pokemon_id AS quest_pokemon_id')
           .where('alternative_quest_reward_type', 9),
       ]
     }

--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -3,7 +3,6 @@ const { Model, raw } = require('objection')
 const i18next = require('i18next')
 const { pokemon: masterPkmn, items: masterItems, questRewardTypes } = require('../data/masterfile.json')
 const fetchQuests = require('../services/api/fetchQuests')
-const dbSelection = require('../services/functions/dbSelection')
 const getAreaSql = require('../services/functions/getAreaSql')
 const {
   api: { searchResultsLimit, queryLimits, stopValidDataLimit, hideOldPokestops },
@@ -40,19 +39,13 @@ const invasionProps = {
   incident_expire_timestamp: true,
   grunt_type: true,
 }
-const { type, hasAltQuests } = dbSelection('pokestop')
-const altQuestCheck = hasAltQuests && type !== 'mad'
 
 module.exports = class Pokestop extends Model {
   static get tableName() {
     return 'pokestop'
   }
 
-  static get idColumn() {
-    return type === 'mad' ? 'pokestop_id' : 'id'
-  }
-
-  static async getAllPokestops(args, perms, isMad) {
+  static async getAll(perms, args, { isMad, hasAltQuests, hasMultiInvasions, multiInvasionMs, hasRewardAmount }) {
     const { filters: {
       onlyLures, onlyQuests, onlyInvasions, onlyArEligible, onlyAllPokestops,
     }, ts, midnight: clientMidnight } = args
@@ -97,13 +90,15 @@ module.exports = class Pokestop extends Model {
     } else if (hideOldPokestops) {
       query.where('updated', '>', Date.now() / 1000 - (stopValidDataLimit * 86400))
     }
-    if (type === 'chuck') {
+    if (hasMultiInvasions) {
       query.join('incident', 'pokestop.id', 'incident.pokestop_id')
         .select([
           '*',
           'pokestop.id AS id',
           'incident.id AS incidentId',
-          raw('FLOOR(incident.expiration_ms / 1000) AS incident_expire_timestamp'),
+          raw(multiInvasionMs
+            ? 'FLOOR(incident.expiration_ms / 1000) AS incident_expire_timestamp'
+            : 'incident.expiration AS incident_expire_timestamp'),
           'incident.character AS grunt_type',
         ])
     }
@@ -160,19 +155,22 @@ module.exports = class Pokestop extends Model {
             .andWhere(questTypes => {
               questTypes.orWhereIn('quest_item_id', items)
                 .orWhereIn('quest_pokemon_id', pokemon)
-              if (altQuestCheck) {
+              if (hasAltQuests) {
                 questTypes.orWhereIn('alternative_quest_item_id', items)
                   .orWhereIn('alternative_quest_pokemon_id', pokemon)
               }
-              if (isMad) {
-                questTypes.orWhereIn('quest_stardust', stardust)
+              if (hasRewardAmount) {
+                questTypes.orWhereIn(isMad ? 'quest_stardust' : 'quest_reward_amount', stardust)
+                if (hasAltQuests) {
+                  questTypes.orWhereIn('alternative_quest_reward_amount', stardust)
+                }
               } else {
                 stardust.forEach(amount => {
                   questTypes.orWhere(dust => {
                     dust.where('quest_reward_type', 3)
                       .andWhere(raw(`json_extract(quest_rewards, "$[0].info.amount") = ${amount}`))
                   })
-                  if (altQuestCheck) {
+                  if (hasAltQuests) {
                     questTypes.orWhere(altDust => {
                       altDust.where('alternative_quest_reward_type', 3)
                         .andWhere(raw(`json_extract(alternative_quest_rewards, "$[0].info.amount") = ${amount}`))
@@ -182,48 +180,91 @@ module.exports = class Pokestop extends Model {
               }
               energy.forEach(megaEnergy => {
                 const [pokeId, amount] = megaEnergy.split('-')
-                questTypes.orWhere(mega => {
-                  mega.where('quest_reward_type', 12)
-                    .andWhere(raw(`json_extract(${isMad ? 'quest_reward' : 'quest_rewards'}, "$[0].${isMad ? 'mega_resource' : 'info'}.pokemon_id") = ${pokeId}`))
-                    .andWhere(raw(`json_extract(${isMad ? 'quest_reward' : 'quest_rewards'}, "$[0].${isMad ? 'mega_resource' : 'info'}.amount") = ${amount}`))
-                })
-                if (altQuestCheck) {
-                  questTypes.orWhere(altMega => {
-                    altMega.where('alternative_quest_reward_type', 12)
-                      .andWhere(raw(`json_extract(alternative_quest_rewards, "$[0].info.pokemon_id") = ${pokeId}`))
-                      .andWhere(raw(`json_extract(alternative_quest_rewards, "$[0].info.amount") = ${amount}`))
+                if (hasRewardAmount) {
+                  questTypes.orWhere(mega => {
+                    mega.where('quest_reward_type', 12)
+                      .andWhere(isMad ? 'quest_item_amount' : 'quest_reward_amount', amount)
+                      .andWhere('quest_pokemon_id', pokeId)
                   })
+                  if (hasAltQuests) {
+                    questTypes.orWhere(altMega => {
+                      altMega.where('alternative_quest_reward_type', 12)
+                        .andWhere('alternative_quest_reward_amount', amount)
+                        .andWhere('alternative_quest_pokemon_id', pokeId)
+                    })
+                  }
+                } else {
+                  questTypes.orWhere(mega => {
+                    mega.where('quest_reward_type', 12)
+                    if (hasRewardAmount) {
+                      mega.andWhere('quest_reward_amount', amount)
+                        .andWhere('quest_pokemon_id', pokeId)
+                    } else {
+                      mega.andWhere(raw(`json_extract(${isMad ? 'quest_reward' : 'quest_rewards'}, "$[0].${isMad ? 'mega_resource' : 'info'}.pokemon_id") = ${pokeId}`))
+                        .andWhere(raw(`json_extract(${isMad ? 'quest_reward' : 'quest_rewards'}, "$[0].${isMad ? 'mega_resource' : 'info'}.amount") = ${amount}`))
+                    }
+                  })
+                  if (hasAltQuests) {
+                    questTypes.orWhere(altMega => {
+                      altMega.where('alternative_quest_reward_type', 12)
+                      if (hasRewardAmount) {
+                        altMega.andWhere('alternative_quest_reward_amount', amount)
+                          .andWhere('alternative_quest_pokemon_id', pokeId)
+                      } else {
+                        altMega.andWhere(raw(`json_extract(alternative_quest_rewards, "$[0].info.pokemon_id") = ${pokeId}`))
+                          .andWhere(raw(`json_extract(alternative_quest_rewards, "$[0].info.amount") = ${amount}`))
+                      }
+                    })
+                  }
                 }
               })
-              candy.forEach(poke => {
-                questTypes.orWhere(candies => {
-                  candies.where('quest_reward_type', 4)
-                    .where(raw(`json_extract(${isMad ? 'quest_reward' : 'quest_rewards'}, "$[0].${isMad ? 'candy' : 'info'}.pokemon_id") = ${poke}`))
-                })
-                if (altQuestCheck) {
-                  questTypes.orWhere(altCandies => {
-                    altCandies.where('alternative_quest_reward_type', 4)
-                      .where(raw(`json_extract(alternative_quest_rewards, "$[0].info.pokemon_id") = ${poke}`))
-                  })
+              if (hasRewardAmount) {
+                questTypes.orWhere('quest_reward_type', 4)
+                  .whereIn('quest_pokemon_id', candy)
+                if (hasAltQuests) {
+                  questTypes.orWhere('alternative_quest_reward_type', 4)
+                    .whereIn('alternative_quest_pokemon_id', candy)
                 }
-              })
-              xlCandy.forEach(poke => {
-                questTypes.orWhere(xlCandies => {
-                  xlCandies.where('quest_reward_type', 9)
-                    .where(raw(`json_extract(${isMad ? 'quest_reward' : 'quest_rewards'}, "$[0].${isMad ? 'xl_candy' : 'info'}.pokemon_id") = ${poke}`))
-                })
-                if (altQuestCheck) {
-                  questTypes.orWhere(altXlCandies => {
-                    altXlCandies.where('alternative_quest_reward_type', 9)
-                      .where(raw(`json_extract(alternative_quest_rewards, "$[0].info.pokemon_id") = ${poke}`))
+              } else {
+                candy.forEach(poke => {
+                  questTypes.orWhere(candies => {
+                    candies.where('quest_reward_type', 4)
+                      .where(raw(`json_extract(${isMad ? 'quest_reward' : 'quest_rewards'}, "$[0].${isMad ? 'candy' : 'info'}.pokemon_id") = ${poke}`))
                   })
+                  if (hasAltQuests) {
+                    questTypes.orWhere(altCandies => {
+                      altCandies.where('alternative_quest_reward_type', 4)
+                        .where(raw(`json_extract(alternative_quest_rewards, "$[0].info.pokemon_id") = ${poke}`))
+                    })
+                  }
+                })
+              }
+              if (hasRewardAmount) {
+                questTypes.orWhere('quest_reward_type', 9)
+                  .whereIn('quest_pokemon_id', xlCandy)
+                if (hasAltQuests) {
+                  questTypes.orWhere('alternative_quest_reward_type', 9)
+                    .whereIn('alternative_quest_pokemon_id', xlCandy)
                 }
-              })
+              } else {
+                xlCandy.forEach(poke => {
+                  questTypes.orWhere(xlCandies => {
+                    xlCandies.where('quest_reward_type', 9)
+                      .where(raw(`json_extract(${isMad ? 'quest_reward' : 'quest_rewards'}, "$[0].${isMad ? 'xl_candy' : 'info'}.pokemon_id") = ${poke}`))
+                  })
+                  if (hasAltQuests) {
+                    questTypes.orWhere(altXlCandies => {
+                      altXlCandies.where('alternative_quest_reward_type', 9)
+                        .where(raw(`json_extract(alternative_quest_rewards, "$[0].info.pokemon_id") = ${poke}`))
+                    })
+                  }
+                })
+              }
               if (general.length && map.enableQuestRewardTypeFilters) {
                 questTypes.orWhere(rewardType => {
                   rewardType.whereIn('quest_reward_type', general)
                 })
-                if (altQuestCheck) {
+                if (hasAltQuests) {
                   questTypes.orWhere(altRewardType => {
                     altRewardType.whereIn('alternative_quest_reward_type', general)
                   })
@@ -233,10 +274,10 @@ module.exports = class Pokestop extends Model {
         })
       }
       if (onlyInvasions && invasionPerms) {
-        if (type === 'chuck') {
+        if (hasMultiInvasions) {
           stops.orWhere(invasion => {
             invasion.whereIn('character', invasions)
-              .andWhere('expiration_ms', '>=', safeTs * 1000)
+              .andWhere(multiInvasionMs ? 'expiration_ms' : 'expiration', '>=', safeTs * (multiInvasionMs ? 1000 : 1))
           })
         } else {
           stops.orWhere(invasion => {
@@ -401,7 +442,7 @@ module.exports = class Pokestop extends Model {
     return Object.values(filtered)
   }
 
-  static async getAvailableQuests(isMad) {
+  static async getAvailable({ isMad, hasAltQuests, hasRewardAmount }) {
     const ts = Math.floor((new Date()).getTime() / 1000)
     const finalList = new Set()
     const quests = {}
@@ -411,7 +452,7 @@ module.exports = class Pokestop extends Model {
       .from(isMad ? 'trs_quest' : 'pokestop')
       .where('quest_reward_type', 2)
       .groupBy('quest_item_id')
-    if (altQuestCheck) {
+    if (hasAltQuests) {
       quests.items = [
         ...quests.items,
         ...await this.query()
@@ -428,66 +469,93 @@ module.exports = class Pokestop extends Model {
         .where('quest_stardust', '>', 0)
         .groupBy('amount')
     } else {
-      quests.stardust = await this.query()
-        .distinct(raw('json_extract(quest_rewards, "$[0].info.amount")')
-          .as('amount'))
+      const dustQuery = this.query()
         .where('quest_reward_type', 3)
-      if (altQuestCheck) {
-        quests.stardust = [
-          ...quests.stardust,
-          ...await this.query()
+      if (hasRewardAmount) {
+        dustQuery
+          .select('quest_reward_amount AS amount')
+          .where('quest_reward_amount', '>', 0)
+          .groupBy('amount')
+      } else {
+        dustQuery
+          .distinct(raw('json_extract(quest_rewards, "$[0].info.amount")')
+            .as('amount'))
+      }
+      quests.stardust = await dustQuery
+      if (hasAltQuests) {
+        const altDustQuery = this.query()
+          .where('alternative_quest_reward_type', 3)
+        if (hasRewardAmount) {
+          altDustQuery
+            .select('alternative_quest_reward_amount AS amount')
+            .where('alternative_quest_reward_amount', '>', 0)
+            .groupBy('amount')
+        } else {
+          altDustQuery
             .distinct(raw('json_extract(alternative_quest_rewards, "$[0].info.amount")')
               .as('amount'))
-            .where('alternative_quest_reward_type', 3),
+        }
+        quests.stardust = [
+          ...quests.stardust,
+          ...await altDustQuery,
         ]
       }
     }
-    quests.mega = await this.query()
-      .distinct(raw(`json_extract(${isMad ? 'quest_reward' : 'quest_rewards'}, "$[0].${isMad ? 'mega_resource' : 'info'}.pokemon_id")`)
-        .as('id'))
-      .distinct(raw(`json_extract(${isMad ? 'quest_reward' : 'quest_rewards'}, "$[0].${isMad ? 'mega_resource' : 'info'}.amount")`)
-        .as('amount'))
+    const megaQuery = this.query()
       .from(isMad ? 'trs_quest' : 'pokestop')
       .where('quest_reward_type', 12)
-    if (altQuestCheck) {
-      quests.mega = [
-        ...quests.mega,
-        ...await this.query()
+    if (hasRewardAmount) {
+      megaQuery
+        .distinct(`${isMad ? 'quest_item_amount' : 'quest_reward_amount'} AS amount`)
+        .distinct('quest_pokemon_id AS id')
+    } else {
+      megaQuery
+        .distinct(raw(`json_extract(${isMad ? 'quest_reward' : 'quest_rewards'}, "$[0].${isMad ? 'mega_resource' : 'info'}.pokemon_id")`)
+          .as('id'))
+        .distinct(raw(`json_extract(${isMad ? 'quest_reward' : 'quest_rewards'}, "$[0].${isMad ? 'mega_resource' : 'info'}.amount")`)
+          .as('amount'))
+    }
+    quests.mega = await megaQuery
+    if (hasAltQuests) {
+      const altMegaQuery = this.query()
+        .where('alternative_quest_reward_type', 12)
+      if (hasRewardAmount) {
+        altMegaQuery
+          .distinct('quest_reward_amount AS amount')
+          .distinct('quest_pokemon_id AS id')
+      } else {
+        altMegaQuery
           .distinct(raw('json_extract(alternative_quest_rewards, "$[0].info.pokemon_id")')
             .as('id'))
           .distinct(raw('json_extract(alternative_quest_rewards, "$[0].info.amount")')
             .as('amount'))
-          .from('pokestop')
-          .where('alternative_quest_reward_type', 12),
+      }
+      quests.mega = [
+        ...quests.mega,
+        ...await altMegaQuery,
       ]
     }
     quests.candy = await this.query()
-      .distinct(raw(`json_extract(${isMad ? 'quest_reward' : 'quest_rewards'}, "$[0].${isMad ? 'candy' : 'info'}.pokemon_id")`)
-        .as('id'))
+      .distinct('quest_pokemon_id')
       .from(isMad ? 'trs_quest' : 'pokestop')
       .where('quest_reward_type', 4)
-    if (altQuestCheck) {
+    if (hasAltQuests) {
       quests.candy = [
         ...quests.candy,
         ...await this.query()
-          .distinct(raw('json_extract(alternative_quest_rewards, "$[0].info.pokemon_id")')
-            .as('id'))
-          .from('pokestop')
+          .distinct('alternative_quest_pokemon_id')
           .where('alternative_quest_reward_type', 4),
       ]
     }
     quests.xlCandy = await this.query()
-      .distinct(raw(`json_extract(${isMad ? 'quest_reward' : 'quest_rewards'}, "$[0].${isMad ? 'xl_candy' : 'info'}.pokemon_id")`)
-        .as('id'))
+      .distinct('quest_pokemon_id')
       .from(isMad ? 'trs_quest' : 'pokestop')
       .where('quest_reward_type', 9)
-    if (altQuestCheck) {
+    if (hasAltQuests) {
       quests.xlCandy = [
         ...quests.xlCandy,
         ...await this.query()
-          .distinct(raw('json_extract(alternative_quest_rewards, "$[0].info.pokemon_id")')
-            .as('id'))
-          .from('pokestop')
+          .distinct('alternative_quest_pokemon_id')
           .where('alternative_quest_reward_type', 9),
       ]
     }
@@ -503,7 +571,7 @@ module.exports = class Pokestop extends Model {
         .select(raw('json_extract(quest_rewards, "$[0].info.form_id")')
           .as('form'))
         .where('quest_reward_type', 7)
-      if (altQuestCheck) {
+      if (hasAltQuests) {
         quests.pokemon = [
           ...quests.pokemon,
           ...await this.query()
@@ -514,7 +582,6 @@ module.exports = class Pokestop extends Model {
         ]
       }
     }
-
     Object.entries(quests).forEach(([questType, rewards]) => {
       switch (questType) {
         case 'items': rewards.forEach(reward => finalList.add(`q${reward.quest_item_id}`)); break
@@ -584,7 +651,7 @@ module.exports = class Pokestop extends Model {
     return quest
   }
 
-  static async search(args, perms, isMad, distance) {
+  static async search(perms, args, { isMad }, distance) {
     const query = this.query()
       .select([
         'name',
@@ -604,7 +671,7 @@ module.exports = class Pokestop extends Model {
     return query
   }
 
-  static async searchQuests(args, perms, isMad, distance) {
+  static async searchQuests(perms, args, { isMad, hasAltQuests }, distance) {
     const { search, locale, midnight: clientMidnight } = args
     const midnight = settings.hideOldQuests ? clientMidnight : 0
 
@@ -645,12 +712,6 @@ module.exports = class Pokestop extends Model {
         quests.whereIn('quest_pokemon_id', pokemonIds)
           .orWhereIn('quest_item_id', itemIds)
           .orWhereIn('quest_reward_type', rewardTypes)
-        if (!isMad) {
-          pokemonIds.forEach(pkmn => {
-            quests.orWhere(raw(`json_extract(quest_rewards, "$[0].info.pokemon_id") = ${pkmn}`))
-              .whereIn('quest_reward_type', [4, 9, 12])
-          })
-        }
       })
       .limit(searchResultsLimit)
       .orderBy('distance')
@@ -667,7 +728,7 @@ module.exports = class Pokestop extends Model {
     }
     const results = await query
 
-    if (altQuestCheck) {
+    if (hasAltQuests) {
       const altQuestQuery = this.query()
         .select(['*', distance])
         .where('deleted', false)
@@ -676,10 +737,6 @@ module.exports = class Pokestop extends Model {
           quests.whereIn('alternative_quest_pokemon_id', pokemonIds)
             .orWhereIn('alternative_quest_item_id', itemIds)
             .orWhereIn('alternative_quest_reward_type', rewardTypes)
-          pokemonIds.forEach(pkmn => {
-            quests.orWhere(raw(`json_extract(alternative_quest_rewards, "$[0].info.pokemon_id") = ${pkmn}`))
-              .whereIn('alternative_quest_reward_type', [4, 9, 12])
-          })
         })
         .limit(searchResultsLimit)
         .orderBy('distance')
@@ -699,5 +756,36 @@ module.exports = class Pokestop extends Model {
       results.length = searchResultsLimit
     }
     return results.map(result => isMad ? this.parseMadRewards(result) : this.parseRdmRewards(result)).filter(x => x)
+  }
+
+  static getOne(id, { isMad }) {
+    return this.query()
+      .select([
+        isMad ? 'latitude AS lat' : 'lat',
+        isMad ? 'longitude AS lon' : 'lon',
+      ])
+      .where(isMad ? 'pokestop_id' : 'id', id)
+      .first()
+  }
+
+  static getSubmissions(args, { isMad }) {
+    const query = this.query()
+      .whereBetween(`lat${isMad ? 'itude' : ''}`, [args.minLat - 0.025, args.maxLat + 0.025])
+      .andWhereBetween(`lon${isMad ? 'gitude' : ''}`, [args.minLon - 0.025, args.maxLon + 0.025])
+      .andWhere(isMad ? 'enabled' : 'deleted', isMad)
+    if (isMad) {
+      query.select([
+        'pokestop_id AS id',
+        'latitude AS lat',
+        'longitude AS lon',
+      ])
+    } else {
+      query.select(['id', 'lat', 'lon'])
+        .andWhere(poi => {
+          poi.whereNull('sponsor_id')
+            .orWhere('sponsor_id', 0)
+        })
+    }
+    return query
   }
 }

--- a/server/src/models/Portal.js
+++ b/server/src/models/Portal.js
@@ -9,7 +9,7 @@ module.exports = class Portal extends Model {
     return 'ingress_portals'
   }
 
-  static async getAllPortals(args, perms) {
+  static async getAll(perms, args) {
     const { areaRestrictions } = perms
     const query = this.query()
       .whereBetween('lat', [args.minLat, args.maxLat])
@@ -21,7 +21,7 @@ module.exports = class Portal extends Model {
     return query.limit(queryLimits.portals)
   }
 
-  static async search(args, perms, isMad, distance) {
+  static async search(perms, args, { isMad }, distance) {
     const { areaRestrictions } = perms
     const query = this.query()
       .select([
@@ -40,5 +40,9 @@ module.exports = class Portal extends Model {
       getAreaSql(query, areaRestrictions, isMad)
     }
     return query
+  }
+
+  static getOne(id) {
+    return this.query().findById(id).select(['lat', 'lon'])
   }
 }

--- a/server/src/models/ScanCell.js
+++ b/server/src/models/ScanCell.js
@@ -1,16 +1,14 @@
 const { Model, ref } = require('objection')
-const dbSelection = require('../services/functions/dbSelection')
 const getPolyVector = require('../services/functions/getPolyVector')
 const getAreaSql = require('../services/functions/getAreaSql')
 const { api: { queryLimits } } = require('../services/config')
 
 module.exports = class ScanCell extends Model {
   static get tableName() {
-    return dbSelection('scanCell').type === 'mad'
-      ? 'trs_s2cells' : 's2cell'
+    return 's2cell'
   }
 
-  static async getAllCells(args, perms, isMad) {
+  static async getAll(perms, args, { isMad }) {
     const { areaRestrictions } = perms
     const query = this.query()
       .select(['*', ref('id')
@@ -21,7 +19,9 @@ module.exports = class ScanCell extends Model {
     if (areaRestrictions?.length) {
       getAreaSql(query, areaRestrictions, isMad, 's2cell')
     }
-    const results = await query.limit(queryLimits.scanCells)
+    const results = await query
+      .limit(queryLimits.scanCells)
+      .from(isMad ? 'trs_s2cells' : 's2cell')
     return results.map(cell => ({
       ...cell,
       polygon: getPolyVector(cell.id, 'polygon'),

--- a/server/src/models/Spawnpoint.js
+++ b/server/src/models/Spawnpoint.js
@@ -1,20 +1,13 @@
 const { Model, raw } = require('objection')
-const dbSelection = require('../services/functions/dbSelection')
 const getAreaSql = require('../services/functions/getAreaSql')
 const { api: { queryLimits } } = require('../services/config')
 
 module.exports = class Spawnpoint extends Model {
   static get tableName() {
-    return dbSelection('spawnpoint').type === 'mad'
-      ? 'trs_spawn' : 'spawnpoint'
+    return 'spawnpoint'
   }
 
-  static get idColumn() {
-    return dbSelection('spawnpoint').type === 'mad'
-      ? 'spawnpoint' : 'id'
-  }
-
-  static async getAllSpawnpoints(args, perms, isMad) {
+  static async getAll(perms, args, { isMad }) {
     const { areaRestrictions } = perms
     const query = this.query()
     if (isMad) {
@@ -33,6 +26,8 @@ module.exports = class Spawnpoint extends Model {
     if (areaRestrictions?.length) {
       getAreaSql(query, areaRestrictions, isMad)
     }
-    return query.limit(queryLimits.spawnpoints)
+    return query
+      .limit(queryLimits.spawnpoints)
+      .from(isMad ? 'trs_spawn' : 'spawnpoint')
   }
 }

--- a/server/src/models/Weather.js
+++ b/server/src/models/Weather.js
@@ -1,6 +1,5 @@
 const { Model, ref, raw } = require('objection')
 const getPolyVector = require('../services/functions/getPolyVector')
-const dbSelection = require('../services/functions/dbSelection')
 const { api: { weatherCellLimit } } = require('../services/config')
 
 module.exports = class Weather extends Model {
@@ -8,12 +7,7 @@ module.exports = class Weather extends Model {
     return 'weather'
   }
 
-  static get idColumn() {
-    return dbSelection('weather').type === 'mad'
-      ? 's2_cell_id' : 'id'
-  }
-
-  static async getAllWeather(isMad) {
+  static async getAll(_perms, _args, { isMad }) {
     const query = this.query()
       .select([
         '*',

--- a/server/src/models/index.js
+++ b/server/src/models/index.js
@@ -1,3 +1,4 @@
+const Db = require('../db/initialization')
 const Badge = require('./Badge')
 const Device = require('./Device')
 const Gym = require('./Gym')
@@ -13,7 +14,7 @@ const User = require('./User')
 const Weather = require('./Weather')
 const { PokemonFilter, GenericFilter } = require('./Filters')
 
-module.exports = {
+const models = {
   Badge,
   Device,
   Gym,
@@ -21,12 +22,18 @@ module.exports = {
   Pokestop,
   Pokemon,
   Portal,
-  Ring,
   ScanCell,
   Session,
   Spawnpoint,
   User,
   Weather,
+}
+
+Db.bindConnections(models)
+
+module.exports = {
+  ...models,
+  Ring,
   PokemonFilter,
   GenericFilter,
 }

--- a/server/src/routes/rootRouter.js
+++ b/server/src/routes/rootRouter.js
@@ -9,9 +9,8 @@ const config = require('../services/config')
 const Utility = require('../services/Utility')
 const Fetch = require('../services/Fetch')
 const masterfile = require('../data/masterfile.json')
-const {
-  Pokemon, Gym, Pokestop, Nest, PokemonFilter, GenericFilter, User,
-} = require('../models/index')
+const { PokemonFilter, GenericFilter, User } = require('../models/index')
+const Db = require('../db/initialization')
 
 const rootRouter = new express.Router()
 
@@ -166,7 +165,7 @@ rootRouter.get('/settings', async (req, res) => {
       try {
         if (serverSettings.user.perms.pokemon) {
           serverSettings.available.pokemon = config.api.queryAvailable.pokemon
-            ? await Pokemon.getAvailablePokemon(Utility.dbSelection('pokemon').type === 'mad')
+            ? Db.getAvailable.pokemon
             : []
         }
       } catch (e) {
@@ -175,7 +174,7 @@ rootRouter.get('/settings', async (req, res) => {
       try {
         if (serverSettings.user.perms.raids || serverSettings.user.perms.gyms) {
           serverSettings.available.gyms = config.api.queryAvailable.raids
-            ? await Gym.getAvailableRaidBosses(Utility.dbSelection('gym').type === 'mad')
+            ? Db.getAvailable.gyms
             : await Fetch.raids()
         }
       } catch (e) {
@@ -187,7 +186,7 @@ rootRouter.get('/settings', async (req, res) => {
           || serverSettings.user.perms.invasions
           || serverSettings.user.perms.lures) {
           serverSettings.available.pokestops = config.api.queryAvailable.quests
-            ? await Pokestop.getAvailableQuests(Utility.dbSelection('pokestop').type === 'mad')
+            ? Db.getAvailable.pokestops
             : await Fetch.quests()
         }
       } catch (e) {
@@ -196,7 +195,7 @@ rootRouter.get('/settings', async (req, res) => {
       try {
         if (serverSettings.user.perms.nests) {
           serverSettings.available.nests = config.api.queryAvailable.nests
-            ? await Nest.getAvailableNestingSpecies()
+            ? Db.getAvailable.nests
             : await Fetch.nests()
         }
       } catch (e) {

--- a/server/src/services/DbCheck.js
+++ b/server/src/services/DbCheck.js
@@ -42,17 +42,29 @@ module.exports = class DbCheck {
       });
     (async () => {
       await this.determineType()
-      await this.pvp()
-      await this.pokestopChecks()
-      await this.updateAvailable()
       if (apiSettings.pvp.reactMapHandlesPvp) {
         await this.initOhbem(apiSettings.pvp.leagues, apiSettings.pvp.levels)
       }
+      await this.pvp()
+      await this.pokestopChecks()
+      await this.availableGyms()
+      await this.availableNests()
+      await this.availablePokemon()
+      await this.availablePokestops()
     })()
 
     setInterval(async () => {
-      await this.updateAvailable()
-    }, 1000 * 60 * 60 * apiSettings.queryAvailable.updateHours)
+      await this.availableGyms()
+    }, 1000 * 60 * 60 * apiSettings.queryUpdateHours.raids)
+    setInterval(async () => {
+      await this.availableNests()
+    }, 1000 * 60 * 60 * apiSettings.queryUpdateHours.nests)
+    setInterval(async () => {
+      await this.availablePokemon()
+    }, 1000 * 60 * 60 * apiSettings.queryUpdateHours.pokemon)
+    setInterval(async () => {
+      await this.availablePokestops()
+    }, 1000 * 60 * 60 * apiSettings.queryUpdateHours.quests)
   }
 
   get getAvailable() {
@@ -254,22 +266,28 @@ module.exports = class DbCheck {
     return [DbCheck.deDupeResults(stopData), DbCheck.deDupeResults(gymData)]
   }
 
-  async updateAvailable() {
-    const gyms = await Promise.all(this.models.Gym.map(async (source) => (
-      source.SubModel.getAvailable(source)
-    )))
-    this.available.gyms = DbCheck.deDupeAvailable(gyms)
-
+  async availablePokestops() {
     const pokestops = await Promise.all(this.models.Pokestop.map(async (source) => (
       source.SubModel.getAvailable(source)
     )))
     this.available.pokestops = DbCheck.deDupeAvailable(pokestops)
+  }
 
+  async availableGyms() {
+    const gyms = await Promise.all(this.models.Gym.map(async (source) => (
+      source.SubModel.getAvailable(source)
+    )))
+    this.available.gyms = DbCheck.deDupeAvailable(gyms)
+  }
+
+  async availableNests() {
     const nests = await Promise.all(this.models.Nest.map(async (source) => (
       source.SubModel.getAvailable(source)
     )))
     this.available.nests = DbCheck.deDupeAvailable(nests)
+  }
 
+  async availablePokemon() {
     const pokemon = await Promise.all(this.models.Pokemon.map(async (source) => (
       source.SubModel.getAvailable(source)
     )))

--- a/server/src/services/DbCheck.js
+++ b/server/src/services/DbCheck.js
@@ -73,7 +73,7 @@ module.exports = class DbCheck {
   }
 
   async determineType() {
-    console.log('[Init] Determining database types')
+    console.log('[DB] Determining database types..')
     await Promise.all(this.connections.map(async (schema, i) => {
       const isMad = await DbCheck.isMadDb(schema)
       Object.entries(this.models).forEach(([category, sources]) => {
@@ -95,7 +95,7 @@ module.exports = class DbCheck {
       Object.entries(this.models).forEach(([model, sources]) => {
         if (this.singleModels.includes(model)) {
           if (sources.length > 1) {
-            console.error(`[Init] ${model} only supports one database connection`)
+            console.error(`[DB] ${model} only supports one database connection`)
             process.exit(0)
           }
           if (model === 'User') {
@@ -107,7 +107,7 @@ module.exports = class DbCheck {
             this.models[model][i].SubModel = models[model].bindKnex(this.connections[source.connection])
           })
         }
-        console.log(`[Init] Bound ${model} to ${sources.length} connections`)
+        console.log(`[DB] Bound ${model} to ${sources.length} connections`)
       })
     } catch (e) {
       console.error(`
@@ -190,7 +190,7 @@ module.exports = class DbCheck {
         await source.SubModel.query()
           .whereNotNull('alternative_quest_type')
           .limit(1)
-        source.hasAltQuest = true
+        source.hasAltQuests = true
       } catch (_) {
         source.hasAltQuests = false
       }

--- a/server/src/services/DbCheck.js
+++ b/server/src/services/DbCheck.js
@@ -1,20 +1,274 @@
-const models = require('../models/index')
+/* eslint-disable no-await-in-loop */
+/* eslint-disable no-console */
+const knex = require('knex')
+const { raw } = require('objection')
+const Ohbem = require('ohbem')
 
 module.exports = class DbCheck {
-  constructor() {
-    this.pvpV2 = false;
-
+  constructor(validModels, dbSettings, queryDebug, apiSettings) {
+    this.validModels = validModels.flatMap(s => s.useFor)
+    this.singleModels = ['User', 'Badge', 'Session']
+    this.ohbem = null
+    this.searchLimit = apiSettings.searchLimit
+    this.models = {}
+    this.available = { gyms: [], pokestops: [], pokemon: [], nests: [] }
+    this.connections = dbSettings.schemas
+      .filter(s => s.useFor.length)
+      .map((schema, i) => {
+        schema.useFor.forEach(category => {
+          const capital = `${category.charAt(0).toUpperCase()}${category.slice(1)}`
+          if (!this.models[capital]) {
+            this.models[capital] = []
+          }
+          this.models[capital].push({ connection: i, isMad: false })
+        })
+        return knex({
+          client: 'mysql2',
+          connection: {
+            host: schema.host,
+            port: schema.port,
+            user: schema.username,
+            password: schema.password,
+            database: schema.database,
+          },
+          debug: queryDebug,
+          pool: {
+            max: dbSettings.settings.maxConnections,
+            afterCreate(conn, done) {
+              conn.query('SET time_zone="+00:00";', (err) => done(err, conn))
+            },
+          },
+        })
+      });
     (async () => {
+      await this.determineType()
       await this.pvp()
+      await this.pokestopChecks()
+      await this.updateAvailable()
+      if (apiSettings.pvp.reactMapHandlesPvp) {
+        await this.initOhbem(apiSettings.pvp.leagues, apiSettings.pvp.levels)
+      }
     })()
+
+    setInterval(async () => {
+      await this.updateAvailable()
+    }, 1000 * 60 * 60 * apiSettings.queryAvailable.updateHours)
+  }
+
+  get getAvailable() {
+    return this.available
+  }
+
+  static async isMadDb(connection) {
+    try {
+      await connection('trs_quest').limit(1).first()
+      return true
+    } catch (e) {
+      return false
+    }
+  }
+
+  static getDistance(args, isMad) {
+    return raw(`ROUND(( 3959 * acos( cos( radians(${args.lat}) ) * cos( radians( ${isMad ? 'latitude' : 'lat'} ) ) * cos( radians( ${isMad ? 'longitude' : 'lon'} ) - radians(${args.lon}) ) + sin( radians(${args.lat}) ) * sin( radians( ${isMad ? 'latitude' : 'lat'} ) ) ) ),2)`).as('distance')
+  }
+
+  async determineType() {
+    console.log('[Init] Determining database types')
+    await Promise.all(this.connections.map(async (schema, i) => {
+      const isMad = await DbCheck.isMadDb(schema)
+      Object.entries(this.models).forEach(([category, sources]) => {
+        try {
+          sources.forEach((source, j) => {
+            if (source.connection === i) {
+              this.models[category][j].isMad = isMad
+            }
+          })
+        } catch (e) {
+          console.log(e.message)
+        }
+      })
+    }))
+  }
+
+  bindConnections(models) {
+    try {
+      Object.entries(this.models).forEach(([category, sources]) => {
+        models[category].knex(this.connections[sources[0].connection])
+
+        if (!this.singleModels.includes(category)) {
+          sources.forEach((source, i) => {
+            if (category === 'Pokemon') {
+              this.models[category][i].ohbem = this.ohbem
+            }
+            this.models[category][i].SubModel = models[category].bindKnex(this.connections[source.connection])
+          })
+        }
+        console.log(`[Init] Bound ${category} to ${sources.length} connections`)
+      })
+    } catch (e) {
+      console.error(`
+  Error: ${e.message}
+
+  Info: Only ${[this.validModels].join(', ')} are valid options in the useFor arrays
+  `)
+      process.exit(9)
+    }
+  }
+
+  async initOhbem(leagues, levels) {
+    const leagueObj = Object.fromEntries(leagues.map(league => [league.name, league.cp]))
+    const hasLittle = leagues.find(league => league.name === 'little')
+    if (hasLittle) {
+      leagueObj.little = hasLittle.littleCupRules ? 500 : { little: false, cap: 500 }
+    }
+    this.ohbem = new Ohbem({
+      leagues: leagueObj,
+      pokemonData: await Ohbem.fetchPokemonData(),
+      levelCaps: levels,
+      cachingStrategy: Ohbem.cachingStrategies.memoryHeavy,
+    })
+  }
+
+  static deDupeResults(results) {
+    if (results.length === 1) return results[0]
+    if (results.length > 1) {
+      const returnObj = {}
+      for (let i = 0; i < results.length; i += 1) {
+        for (let j = 0; j < results[i].length; j += 1) {
+          returnObj[results[i][j].id] = results[i][j]
+        }
+      }
+      return Object.values(returnObj)
+    }
+    return []
+  }
+
+  static deDupeAvailable(results) {
+    if (results.length === 1) return results[0]
+    if (results.length > 1) {
+      const returnSet = new Set()
+      for (let i = 0; i < results.length; i += 1) {
+        for (let j = 0; j < results[i].length; j += 1) {
+          returnSet.add(results[i][j])
+        }
+      }
+      return [...returnSet]
+    }
+    return []
   }
 
   async pvp() {
-    try {
-      await models.Pokemon.query().whereNotNull('pvp').limit(1)
-      this.pvpV2 = true
-    } catch (e) {
-      this.pvpV2 = false
+    await Promise.all(this.models.Pokemon.map(async (source) => {
+      try {
+        await source.SubModel.query()
+          .whereNotNull('pvp')
+          .limit(1)
+        source.pvpV2 = true
+      } catch (_) {
+        source.pvpV2 = false
+      }
+    }))
+  }
+
+  async pokestopChecks() {
+    await Promise.all(this.models.Pokestop.map(async (source) => {
+      try {
+        if (!source.isMad) {
+          await source.SubModel.query()
+            .whereNotNull('quest_reward_amount')
+            .limit(1)
+        }
+        source.hasRewardAmount = true
+      } catch (_) {
+        source.hasRewardAmount = false
+      }
+      try {
+        await source.SubModel.query()
+          .whereNotNull('alternative_quest_type')
+          .limit(1)
+        source.hasAltQuest = true
+      } catch (_) {
+        source.hasAltQuests = false
+      }
+      try {
+        await source.SubModel.query()
+          .join('incident', 'pokestop.id', 'incident.pokestop_id')
+          .limit(1)
+        source.hasMultiInvasions = true
+      } catch (_) {
+        source.hasMultiInvasions = false
+      }
+      try {
+        await source.SubModel.query()
+          .join('incident', 'pokestop.id', 'incident.pokestop_id')
+          .select('expiration_ms')
+          .limit(1)
+        source.multiInvasionMs = true
+      } catch (_) {
+        source.multiInvasionMs = false
+      }
+    }))
+  }
+
+  async getAll(model, perms, args, userId, method = 'getAll') {
+    const data = await Promise.all(this.models[model].map(async (source) => (
+      source.SubModel[method](perms, args, source, userId, this.ohbem)
+    )))
+    return DbCheck.deDupeResults(data)
+  }
+
+  async getOne(model, id, method = 'getOne') {
+    const sources = this.models[model]
+    let foundObj
+    let source = 0
+    while (!foundObj && source < sources.length) {
+      const found = await sources[source].SubModel[method](id, sources[source])
+      foundObj = found
+      source += 1
     }
+    return foundObj || {}
+  }
+
+  async search(model, perms, args, method = 'search') {
+    const data = await Promise.all(this.models[model].map(async (source) => (
+      source.SubModel[method](perms, args, source, DbCheck.getDistance(args, source.isMad))
+    )))
+    const deDuped = DbCheck.deDupeResults(data).sort((a, b) => a.distance - b.distance)
+    if (deDuped.length > this.searchLimit) {
+      deDuped.length = this.searchLimit
+    }
+    return deDuped
+  }
+
+  async submissionCells(args) {
+    const stopData = await Promise.all(this.models.Pokestop.map(async (source) => (
+      source.SubModel.getSubmissions(args, source)
+    )))
+    const gymData = await Promise.all(this.models.Gym.map(async (source) => (
+      source.SubModel.getSubmissions(args, source)
+    )))
+    return [DbCheck.deDupeResults(stopData), DbCheck.deDupeResults(gymData)]
+  }
+
+  async updateAvailable() {
+    const gyms = await Promise.all(this.models.Gym.map(async (source) => (
+      source.SubModel.getAvailable(source)
+    )))
+    this.available.gyms = DbCheck.deDupeAvailable(gyms)
+
+    const pokestops = await Promise.all(this.models.Pokestop.map(async (source) => (
+      source.SubModel.getAvailable(source)
+    )))
+    this.available.pokestops = DbCheck.deDupeAvailable(pokestops)
+
+    const nests = await Promise.all(this.models.Nest.map(async (source) => (
+      source.SubModel.getAvailable(source)
+    )))
+    this.available.nests = DbCheck.deDupeAvailable(nests)
+
+    const pokemon = await Promise.all(this.models.Pokemon.map(async (source) => (
+      source.SubModel.getAvailable(source)
+    )))
+    this.available.pokemon = DbCheck.deDupeAvailable(pokemon)
   }
 }

--- a/src/components/Clustering.jsx
+++ b/src/components/Clustering.jsx
@@ -6,9 +6,7 @@ import Notification from './layout/general/Notification'
 
 const getId = (component, item) => {
   switch (component) {
-    case 'devices': return item.uuid
     case 'submissionCells': return component
-    case 'nests': return item.nest_id
     default: return item.id
   }
 }

--- a/src/components/popups/Device.jsx
+++ b/src/components/popups/Device.jsx
@@ -15,7 +15,7 @@ export default function DevicePopup({ device, isOnline, ts }) {
   return (
     <>
       <Typography variant="h6" align="center">
-        {device.uuid}
+        {device.id}
       </Typography>
       <Typography variant="subtitle2">
         {t('instance')} {device.instance_name}

--- a/src/components/tiles/Nest.jsx
+++ b/src/components/tiles/Nest.jsx
@@ -18,15 +18,15 @@ const NestTile = ({
   const parsedJson = JSON.parse(item.polygon_path)
   const recent = ts - item.updated < 172800000
 
-  useForcePopup(item.nest_id, markerRef, params, setParams, done)
+  useForcePopup(item.id, markerRef, params, setParams, done)
 
   return (
     <>
       {filters.pokemon && (
         <Marker
           ref={(m) => {
-            markerRef.current[item.nest_id] = m
-            if (!done && item.nest_id === params.id) {
+            markerRef.current[item.id] = m
+            if (!done && item.id === params.id) {
               setDone(true)
             }
           }}
@@ -51,7 +51,7 @@ const NestTile = ({
 }
 
 const areEqual = (prev, next) => (
-  prev.item.nest_id === next.item.nest_id
+  prev.item.id === next.item.id
   && prev.item.updated === next.item.updated
   && prev.filters.pokemon === next.filters.pokemon
   && prev.filters.polygons === next.filters.polygons

--- a/src/services/queries/device.js
+++ b/src/services/queries/device.js
@@ -3,7 +3,7 @@ import { gql } from '@apollo/client'
 const getAllDevices = gql`
   query Devices {
     devices{
-      uuid
+      id
       instance_name
       last_seen
       last_lat

--- a/src/services/queries/nest.js
+++ b/src/services/queries/nest.js
@@ -2,7 +2,7 @@ import { gql } from '@apollo/client'
 
 const core = gql`
   fragment CoreNest on Nest {
-    nest_id
+    id
     lat
     lon
   }


### PR DESCRIPTION
- Auto database detection type (mad/rdm)
- Auto detects certain DB configurations such as PVP V2, Multiple Invasions, amount column, alternative quests, etc
- Now binds models for every category on every database (multiple databases for things like devices, quests, etc)
- Handles deduping results when querying a category from multiple databases
- Now handles ohbem init
- New methods for all GQL resolvers
- Now queries available at startup instead at every session init, and updates every 1 hr (configurable)
- Uses amount columns to rapidly increase quest querying and searching
- Supports RDM multiple invasions https://github.com/RealDeviceMap/RealDeviceMap/pull/326
- User/Badge/Session models (ie, all ReactMap tables) can still only have 1 connection/table, for obvious reasons

**I really wouldn't recommend this for the Pokemon table** - especially if you're using Ohbem to calculate PVP. You're going to be much better off running multiple instances of ReactMap. 