### PR TITLE
Locale Support for Custom Components

### DIFF
--- a/src/components/layout/custom/CustomButton.jsx
+++ b/src/components/layout/custom/CustomButton.jsx
@@ -1,5 +1,8 @@
 import React from 'react'
 import { Button, Icon, Typography } from '@material-ui/core'
+
+import Utility from '@services/Utility'
+
 import LinkWrapper from './LinkWrapper'
 
 export default function CustomButton({ block, isMuiColor = false }) {
@@ -13,7 +16,7 @@ export default function CustomButton({ block, isMuiColor = false }) {
     >
       {Boolean(block.icon) && <Icon className={block.icon} style={{ fontSize: 30 }} />}&nbsp;
       <Typography variant="button" align="right">
-        {block.content}
+        {Utility.getBlockContent(block)}
       </Typography>
     </Button>
   )

--- a/src/components/layout/custom/CustomButton.jsx
+++ b/src/components/layout/custom/CustomButton.jsx
@@ -16,7 +16,7 @@ export default function CustomButton({ block, isMuiColor = false }) {
     >
       {Boolean(block.icon) && <Icon className={block.icon} style={{ fontSize: 30 }} />}&nbsp;
       <Typography variant="button" align="right">
-        {Utility.getBlockContent(block)}
+        {Utility.getBlockContent(block.content)}
       </Typography>
     </Button>
   )

--- a/src/components/layout/custom/CustomText.jsx
+++ b/src/components/layout/custom/CustomText.jsx
@@ -12,7 +12,7 @@ export default function CustomText({ block, isMuiColor = false }) {
       color={isMuiColor ? block.color : 'inherit'}
       style={block.style || { color: isMuiColor ? 'inherit' : block.color }}
     >
-      {Utility.getBlockContent(block)}
+      {Utility.getBlockContent(block.content)}
     </Typography>
   )
   return block.link ? <LinkWrapper block={block} element={text} /> : text

--- a/src/components/layout/custom/CustomText.jsx
+++ b/src/components/layout/custom/CustomText.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Typography } from '@material-ui/core'
 
+import Utility from '@services/Utility'
+
 import LinkWrapper from './LinkWrapper'
 
 export default function CustomText({ block, isMuiColor = false }) {
@@ -10,7 +12,7 @@ export default function CustomText({ block, isMuiColor = false }) {
       color={isMuiColor ? block.color : 'inherit'}
       style={block.style || { color: isMuiColor ? 'inherit' : block.color }}
     >
-      {block.content}
+      {Utility.getBlockContent(block)}
     </Typography>
   )
   return block.link ? <LinkWrapper block={block} element={text} /> : text

--- a/src/components/layout/dialogs/Motd.jsx
+++ b/src/components/layout/dialogs/Motd.jsx
@@ -2,6 +2,8 @@
 import React from 'react'
 import { Typography } from '@material-ui/core'
 
+import Utility from '@services/Utility'
+
 import DialogWrapper from '../custom/DialogWrapper'
 import CustomTile from '../custom/CustomTile'
 
@@ -36,17 +38,17 @@ const DefaultMotD = ({ block }) => typeof block === 'string' ? (
   <div key={`${block.title}-${block.body}`} style={{ whiteSpace: 'pre-line', margin: 20, textAlign: 'center' }}>
     {block.title && (
       <Typography variant="h6">
-        {block.title}
+        {Utility.getBlockContent(block, 'title')}
       </Typography>
     )}
     {block.body && (
       <Typography variant="subtitle1">
-        {block.body}
+        {Utility.getBlockContent(block, 'body')}
       </Typography>
     )}
     {block.footer && (
       <Typography variant="caption">
-        {block.footer}
+        {Utility.getBlockContent(block, 'footer')}
       </Typography>
     )}
   </div>

--- a/src/components/layout/dialogs/Motd.jsx
+++ b/src/components/layout/dialogs/Motd.jsx
@@ -38,17 +38,17 @@ const DefaultMotD = ({ block }) => typeof block === 'string' ? (
   <div key={`${block.title}-${block.body}`} style={{ whiteSpace: 'pre-line', margin: 20, textAlign: 'center' }}>
     {block.title && (
       <Typography variant="h6">
-        {Utility.getBlockContent(block, 'title')}
+        {Utility.getBlockContent(block.title)}
       </Typography>
     )}
     {block.body && (
       <Typography variant="subtitle1">
-        {Utility.getBlockContent(block, 'body')}
+        {Utility.getBlockContent(block.body)}
       </Typography>
     )}
     {block.footer && (
       <Typography variant="caption">
-        {Utility.getBlockContent(block, 'footer')}
+        {Utility.getBlockContent(block.footer)}
       </Typography>
     )}
   </div>

--- a/src/services/Utility.js
+++ b/src/services/Utility.js
@@ -109,11 +109,12 @@ export default class Utility {
     }
   }
 
-  static getBlockContent(block = {}, field = 'content') {
-    if (!block[field]) return ''
-    return typeof block[field] === 'string'
-      ? block[field]
-      : block[field][localStorage.getItem('i18nextLng')]
-      || Object.values(block[field])[0] || ''
+  static getBlockContent(content) {
+    if (!content) return ''
+    if (typeof content === 'string') return content
+    return typeof content === 'object'
+      ? content[localStorage.getItem('i18nextLng')]
+      || Object.values(content)[0]
+      : ''
   }
 }

--- a/src/services/Utility.js
+++ b/src/services/Utility.js
@@ -108,4 +108,12 @@ export default class Utility {
       midnight: this.getMidnight(),
     }
   }
+
+  static getBlockContent(block = {}, field = 'content') {
+    if (!block[field]) return ''
+    return typeof block[field] === 'string'
+      ? block[field]
+      : block[field][localStorage.getItem('i18nextLng')]
+      || Object.values(block[field])[0] || ''
+  }
 }


### PR DESCRIPTION
Ability to support multiple languages for custom components such as motd, login, and donor page

Example implementation:
```json
          "content": {
            "de": "Some German",
            "en": "Some English"
          },
```

Falls back to first language in the object if the user is using a language that isn't accounted for.

Resolves #281 