### PR TITLE
Fix Pvp Rank Filtering

### DIFF
--- a/server/src/models/Pokemon.js
+++ b/server/src/models/Pokemon.js
@@ -86,8 +86,9 @@ module.exports = class Pokemon extends Model {
       const [min, max] = getMinMax(filterId, league)
       let best = 4096
       const filtered = data.filter(pkmn => {
-        if (pkmn.rank < best) best = pkmn.rank
-        return pvpCheck(pkmn, league, min, max)
+        const valid = pvpCheck(pkmn, league, min, max)
+        if (valid && pkmn.rank < best) best = pkmn.rank
+        return valid
       })
       return { filtered, best }
     }

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -153,7 +153,7 @@ export default function Map({ serverSettings:
               Utility.analytics('Data', `${category} being fetched`, category, true)
               return (
                 <QueryData
-                  key={category}
+                  key={`${category}-${Object.values(userSettings[category] || {}).join('')}-${Object.values(icons).join('')}`}
                   sizeKey={filters[category].filter ? Object.values(filters[category].filter).map(x => x ? x.size : 'md').join(',') : 'md'}
                   bounds={Utility.getQueryArgs(map)}
                   setExcludeList={setExcludeList}

--- a/src/components/tiles/Device.jsx
+++ b/src/components/tiles/Device.jsx
@@ -47,7 +47,6 @@ const areEqual = (prev, next) => (
   && prev.item.last_lat === next.item.last_lat
   && prev.item.last_lon === next.item.last_lon
   && prev.item.last_seen === next.item.last_seen
-  && prev.userIcons.device === next.userIcons.device
 )
 
 export default memo(DeviceTile, areEqual)

--- a/src/components/tiles/Gym.jsx
+++ b/src/components/tiles/Gym.jsx
@@ -117,8 +117,6 @@ const areEqual = (prev, next) => {
     && !next.excludeList.includes(`${prev.item.raid_pokemon_id}-${prev.item.raid_pokemon_form}`)
     && !next.excludeList.includes(`t${prev.item.team_id}-0`)
     && !next.excludeList.includes(`e${prev.item.raid_level}`)
-    && Object.keys(prev.userIcons).every(key => prev.userIcons[key] === next.userIcons[key])
-    && Object.keys(prev.userSettings).every(key => prev.userSettings[key] === next.userSettings[key])
 }
 
 export default memo(GymTile, areEqual)

--- a/src/components/tiles/Pokemon.jsx
+++ b/src/components/tiles/Pokemon.jsx
@@ -126,7 +126,6 @@ const areEqual = (prev, next) => (
   && prev.showTimer === next.showTimer
   && !next.excludeList.includes(`${prev.item.pokemon_id}-${prev.item.form}`)
   && prev.userIcons.pokemon === next.userIcons.pokemon
-  && Object.keys(prev.userSettings).every(key => prev.userSettings[key] === next.userSettings[key])
   && prev.showCircles === next.showCircles
 )
 

--- a/src/components/tiles/Pokestop.jsx
+++ b/src/components/tiles/Pokestop.jsx
@@ -86,8 +86,6 @@ const areEqual = (prev, next) => (
   && prev.item.invasions?.length === next.item.invasions?.length
   && prev.item.updated === next.item.updated
   && prev.showTimer === next.showTimer
-  && Object.keys(prev.userIcons).every(key => prev.userIcons[key] === next.userIcons[key])
-  && Object.keys(prev.userSettings).every(key => prev.userSettings[key] === next.userSettings[key])
   && (prev.item.quests
     ? !prev.item.quests.some(quest => next.excludeList.includes(quest.key))
     : true)

--- a/src/components/tiles/Spawnpoint.jsx
+++ b/src/components/tiles/Spawnpoint.jsx
@@ -32,7 +32,6 @@ const SpawnpointTile = ({ item, Icons, ts }) => {
 const areEqual = (prev, next) => (
   prev.item.id === next.item.id
   && prev.item.updated === next.item.updated
-  && prev.userIcons.spawnpoint === next.userIcons.spawnpoint
 )
 
 export default memo(SpawnpointTile, areEqual)


### PR DESCRIPTION
- Set best rank correctly, ignores unrequested ranks
- Fixes some rendering issues by setting keys to check all icons and settings at a larger level - guaranteeing re-renders when necessary and saving performance on memoized marker renders
- Resolves #357 