### PR TITLE
iOS15.x floating menu button css fix

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1,6 +1,10 @@
 @import "holiday.css";
 @import "loading.css";
 
+.leaflet-control-container .leaflet-top, .leaflet-control-container .leaflet-bottom {
+    transform: translate3d(0px, 0px, 0px);
+}
+
 .leaflet-container {
   position: absolute;
   max-width: 100% !important;


### PR DESCRIPTION
Fixes the issue with the floating menu buttons being overlapped by leaflet layers on iOS15.x devices