### PR TITLE
Added distance unit selector

### DIFF
--- a/server/src/configs/custom-environment-variables.json
+++ b/server/src/configs/custom-environment-variables.json
@@ -318,7 +318,8 @@
       "clientTimeoutMinutes": {
         "__name": "MAP_MISC_CLIENT_TIMEOUT_MINUTES",
         "__format": "number"
-      }
+      },
+      "distanceUnit": "MAP_MISC_DISTANCE_UNIT"
     },
     "theme": {
       "style": "MAP_THEME_STYLE",

--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -133,7 +133,8 @@
       "noScanAreaOverlay": false,
       "permImageDir": "images/perms",
       "permArrayImages": false,
-      "clientTimeoutMinutes": 30
+      "clientTimeoutMinutes": 30,
+      "distanceUnit" : "km"
     },
     "theme": {
       "style": "dark",

--- a/server/src/services/DbCheck.js
+++ b/server/src/services/DbCheck.js
@@ -3,7 +3,7 @@ const knex = require('knex')
 const { raw } = require('objection')
 
 module.exports = class DbCheck {
-  constructor(validModels, dbSettings, queryDebug, apiSettings) {
+  constructor(validModels, dbSettings, queryDebug, apiSettings, distanceUnit) {
     this.validModels = validModels.flatMap(s => s.useFor)
     this.singleModels = ['User', 'Badge', 'Session']
     this.searchLimit = apiSettings.searchLimit
@@ -36,10 +36,11 @@ module.exports = class DbCheck {
           },
         })
       })
+    this.distanceUnit = distanceUnit
   }
 
-  static getDistance(args, isMad) {
-    return raw(`ROUND(( 3959 * acos( cos( radians(${args.lat}) ) * cos( radians( ${isMad ? 'latitude' : 'lat'} ) ) * cos( radians( ${isMad ? 'longitude' : 'lon'} ) - radians(${args.lon}) ) + sin( radians(${args.lat}) ) * sin( radians( ${isMad ? 'latitude' : 'lat'} ) ) ) ),2)`).as('distance')
+  static getDistance(args, isMad, distanceUnit) {
+    return raw(`ROUND(( ${(distanceUnit == 'mi') ? '3959' : '6371'} * acos( cos( radians(${args.lat}) ) * cos( radians( ${isMad ? 'latitude' : 'lat'} ) ) * cos( radians( ${isMad ? 'longitude' : 'lon'} ) - radians(${args.lon}) ) + sin( radians(${args.lat}) ) * sin( radians( ${isMad ? 'latitude' : 'lat'} ) ) ) ),2)`).as('distance')
   }
 
   async determineType() {
@@ -136,7 +137,7 @@ module.exports = class DbCheck {
 
   async search(model, perms, args, method = 'search') {
     const data = await Promise.all(this.models[model].map(async (source) => (
-      source.SubModel[method](perms, args, source, DbCheck.getDistance(args, source.isMad))
+      source.SubModel[method](perms, args, source, DbCheck.getDistance(args, source.isMad, this.distanceUnit))
     )))
     const deDuped = DbCheck.deDupeResults(data).sort((a, b) => a.distance - b.distance)
     if (deDuped.length > this.searchLimit) {

--- a/server/src/services/DbCheck.js
+++ b/server/src/services/DbCheck.js
@@ -40,7 +40,7 @@ module.exports = class DbCheck {
   }
 
   static getDistance(args, isMad, distanceUnit) {
-    return raw(`ROUND(( ${(distanceUnit == 'mi') ? '3959' : '6371'} * acos( cos( radians(${args.lat}) ) * cos( radians( ${isMad ? 'latitude' : 'lat'} ) ) * cos( radians( ${isMad ? 'longitude' : 'lon'} ) - radians(${args.lon}) ) + sin( radians(${args.lat}) ) * sin( radians( ${isMad ? 'latitude' : 'lat'} ) ) ) ),2)`).as('distance')
+    return raw(`ROUND(( ${distanceUnit === 'mi' ? '3959' : '6371'} * acos( cos( radians(${args.lat}) ) * cos( radians( ${isMad ? 'latitude' : 'lat'} ) ) * cos( radians( ${isMad ? 'longitude' : 'lon'} ) - radians(${args.lon}) ) + sin( radians(${args.lat}) ) * sin( radians( ${isMad ? 'latitude' : 'lat'} ) ) ) ),2)`).as('distance')
   }
 
   async determineType() {

--- a/server/src/services/initialization.js
+++ b/server/src/services/initialization.js
@@ -8,8 +8,7 @@ const staticMf = require('../data/masterfile.json')
 const DbCheck = require('./DbCheck')
 const EventManager = require('./EventManager')
 const PvpWrapper = require('./PvpWrapper')
-
-const Db = new DbCheck(exampleSchemas, config.database, config.devOptions.queryDebug, config.api)
+const Db = new DbCheck(exampleSchemas, config.database, config.devOptions.queryDebug, config.api, config.map.distanceUnit)
 const Pvp = config.api.pvp.reactMapHandlesPvp ? new PvpWrapper(config.api.pvp) : null
 const Event = new EventManager(staticMf)
 

--- a/src/components/layout/dialogs/Search.jsx
+++ b/src/components/layout/dialogs/Search.jsx
@@ -192,7 +192,7 @@ export default function Search({
               )}
             </Grid>
             <Grid item xs={2} style={{ textAlign: 'center' }}>
-              <Typography variant="caption">{option.distance} {(map.distanceUnit == 'mi' ? t('mi') : t('km'))}</Typography>
+              <Typography variant="caption">{option.distance} {map.distanceUnit === 'mi' ? t('mi') : t('km')}</Typography>
               <br />
               {safeSearch[searchTab] === 'quests' && (
                 <Typography variant="caption" className="ar-task" noWrap>

--- a/src/components/layout/dialogs/Search.jsx
+++ b/src/components/layout/dialogs/Search.jsx
@@ -192,7 +192,7 @@ export default function Search({
               )}
             </Grid>
             <Grid item xs={2} style={{ textAlign: 'center' }}>
-              <Typography variant="caption">{option.distance}{t('km')}</Typography>
+              <Typography variant="caption">{option.distance} {(map.distanceUnit == 'mi' ? t('mi') : t('km'))}</Typography>
               <br />
               {safeSearch[searchTab] === 'quests' && (
                 <Typography variant="caption" className="ar-task" noWrap>


### PR DESCRIPTION
In search box the distance to a point is displayed in miles even though the unit says km. Instead of fixing that to either of the units, I added `distanceUnit` in config so admins can select which ever they prefer. I guess the most optimal would be to have it possible for users to select their preferred unit but making that happen was way beyond my skill level.