### PR TITLE
Change `disabled` to `all` in Raid Quick Selector

### DIFF
--- a/src/components/layout/drawer/WithSubItems.jsx
+++ b/src/components/layout/drawer/WithSubItems.jsx
@@ -117,7 +117,7 @@ export default function WithSubItems({
             >
               {['all', ...available.gyms.filter(x => x.startsWith('r')).map(y => +y.slice(1))].map((tier, i) => (
                 <MenuItem key={tier} dense value={tier}>
-                  {t(i ? `raid_${tier}_plural` : 'disabled')}
+                  {t(i ? `raid_${tier}_plural` : 'all')}
                 </MenuItem>
               ))}
             </Select>


### PR DESCRIPTION
Since default value actually means `all` it makes no sense to have it marked as `disabled`