### PR TITLE
Add Support for Google Analytics 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "prop-types": "^15.7.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "react-ga": "^3.3.0",
+    "react-ga4": "^1.4.1",
     "react-i18next": "^11.16.7",
     "react-leaflet": "3.2.2",
     "react-leaflet-markercluster": "3.0.0-rc1",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render } from 'react-dom'
-import ReactGA from 'react-ga'
+import ReactGA from 'react-ga4'
 import * as Sentry from '@sentry/react'
 import { Integrations } from '@sentry/tracing'
 

--- a/src/services/Utility.js
+++ b/src/services/Utility.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-nested-ternary */
-import ReactGA from 'react-ga'
+import ReactGA from 'react-ga4'
 import SunCalc from 'suncalc'
 
 import formatInterval from './functions/formatInterval'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3889,10 +3889,10 @@ react-dom@17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
-react-ga@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-3.3.0.tgz#c91f407198adcb3b49e2bc5c12b3fe460039b3ca"
-  integrity sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ==
+react-ga4@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.npmjs.org/react-ga4/-/react-ga4-1.4.1.tgz"
+  integrity sha512-ioBMEIxd4ePw4YtaloTUgqhQGqz5ebDdC4slEpLgy2sLx1LuZBC9iYCwDymTXzcntw6K1dHX183ulP32nNdG7w==
 
 react-i18next@^11.16.7:
   version "11.16.7"


### PR DESCRIPTION
As google is stopping support for UA (Universal Analytics) by the end of the year, time has come to move to GA4.

Tested and working on my own instance.