### PR TITLE
Expand Scan Areas List

### DIFF
--- a/server/src/configs/areas.example.json
+++ b/server/src/configs/areas.example.json
@@ -34,7 +34,8 @@
         "stroke": "#352BFF",
         "stroke-width": 2.0,
         "fill": "#0651FF",
-        "hidden": false
+        "hidden": false,
+        "parent": "USA"
       }
     }
   ]

--- a/server/src/configs/custom-environment-variables.json
+++ b/server/src/configs/custom-environment-variables.json
@@ -352,6 +352,10 @@
         "__name": "MAP_MISC_NO_SCAN_AREA_OVERLAY",
         "__format": "boolean"
       },
+      "scanAreaMenuHeight": {
+        "__name": "MAP_MISC_SCAN_AREA_MENU_HEIGHT",
+        "__format": "number"
+      },
       "permImageDir": "MAP_MISC_PERM_IMAGE_DIR",
       "permArrayImages": {
         "__name": "MAP_MISC_PERM_ARRAY_IMAGES",

--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -143,6 +143,7 @@
       "enableUserProfile": true,
       "enableQuestSetSelector": false,
       "noScanAreaOverlay": false,
+      "scanAreaMenuHeight": 400,
       "permImageDir": "images/perms",
       "permArrayImages": false,
       "clientTimeoutMinutes": 30,

--- a/server/src/configs/local.example.json
+++ b/server/src/configs/local.example.json
@@ -303,9 +303,21 @@
       "zoom": 15
     },
     {
+      "name": "California",
+      "lat": 37.1931249,
+      "lon": -123.7961458
+    },
+    {
       "name": "San Francisco",
       "lat": 37.79539194255634,
-      "lon": -122.39333173075096
+      "lon": -122.39333173075096,
+      "parent": "California"
+    },
+    {
+      "name": "Houston",
+      "lat": 33.6145517,
+      "lon": -108.6038347,
+      "parent": "Texas"
     }
   ]
 }

--- a/server/src/configs/local.example.json
+++ b/server/src/configs/local.example.json
@@ -300,12 +300,15 @@
       "name": "New York",
       "lat": 40.7481666,
       "lon": -74.0174788,
-      "zoom": 15
+      "zoom": 15,
+      "color": "blue"
     },
     {
       "name": "California",
       "lat": 37.1931249,
-      "lon": -123.7961458
+      "lon": -123.7961458,
+      "color": "orange",
+      "fillColor": "purple"
     },
     {
       "name": "San Francisco",

--- a/server/src/graphql/mapTypes.js
+++ b/server/src/graphql/mapTypes.js
@@ -52,6 +52,12 @@ module.exports = gql`
     features: [Feature]
   }
 
+  type ScanAreasMenu {
+    name: String
+    details: Feature
+    children: [Feature]
+  }
+
   type Search {
     id: ID
     name: String

--- a/server/src/graphql/resolvers.js
+++ b/server/src/graphql/resolvers.js
@@ -192,6 +192,19 @@ module.exports = {
       }
       return [{ features: [] }]
     },
+    scanAreasMenu: (_, args, { perms, version, req }) => {
+      if (args.version && args.version !== version)
+        throw new UserInputError('old_client')
+      if (!perms) throw new AuthenticationError('session_expired')
+
+      const scanAreas = config.scanAreasMenu[req.headers.host]
+        ? config.scanAreasMenu[req.headers.host]
+        : config.scanAreasMenu.main
+      if (perms?.scanAreas && scanAreas.length) {
+        return scanAreas
+      }
+      return []
+    },
     search: async (_, args, { Event, perms, version, Db }) => {
       if (args.version && args.version !== version)
         throw new UserInputError('old_client')

--- a/server/src/graphql/resolvers.js
+++ b/server/src/graphql/resolvers.js
@@ -188,13 +188,6 @@ module.exports = {
         ? config.scanAreas[req.headers.host]
         : config.scanAreas.main
       if (perms?.scanAreas && scanAreas.features.length) {
-        try {
-          scanAreas.features = scanAreas.features
-            .filter((feature) => !feature.properties.hidden)
-            .sort((a, b) => (a.properties.name > b.properties.name ? 1 : -1))
-        } catch (e) {
-          console.warn('[WARN] Failed to sort scan areas', e.message)
-        }
         return [scanAreas]
       }
       return [{ features: [] }]

--- a/server/src/graphql/typeDefs.js
+++ b/server/src/graphql/typeDefs.js
@@ -77,6 +77,7 @@ module.exports = gql`
       version: String
     ): [ScanCell]
     scanAreas(version: String): [ScanArea]
+    scanAreasMenu(version: String): [ScanAreasMenu]
     search(
       search: String
       category: String

--- a/server/src/routes/rootRouter.js
+++ b/server/src/routes/rootRouter.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 const express = require('express')
-const { default: center } = require('@turf/center')
 
 const authRouter = require('./authRouter')
 const clientRouter = require('./clientRouter')
@@ -46,7 +45,7 @@ rootRouter.post('/clientError', (req) => {
 rootRouter.get('/area/:area/:zoom?', (req, res) => {
   const { area, zoom } = req.params
   try {
-    const { scanAreas, manualAreas } = config
+    const { scanAreas } = config
     const validScanAreas = scanAreas[req.headers.host]
       ? scanAreas[req.headers.host]
       : scanAreas.main
@@ -55,13 +54,7 @@ rootRouter.get('/area/:area/:zoom?', (req, res) => {
         (a) => a.properties.name.toLowerCase() === area.toLowerCase(),
       )
       if (foundArea) {
-        const [lon, lat] = center(foundArea).geometry.coordinates
-        return res.redirect(`/@/${lat}/${lon}/${zoom || 18}`)
-      }
-      if (manualAreas.length) {
-        const { lat, lon } = manualAreas.find(
-          (a) => a.name.toLowerCase() === area.toLowerCase(),
-        )
+        const [lat, lon] = foundArea.properties.center
         return res.redirect(`/@/${lat}/${lon}/${zoom || 18}`)
       }
       return res.redirect('/404')
@@ -166,7 +159,6 @@ rootRouter.get('/settings', async (req, res) => {
           react: {},
           leaflet: {},
         },
-        manualAreas: config.manualAreas || {},
         icons: { ...config.icons, styles: Event.uicons },
         scanner: {
           scannerType: config.scanner.backendConfig.platform,
@@ -199,7 +191,6 @@ rootRouter.get('/settings', async (req, res) => {
       // keys that are being sent to the frontend but are not options
       const ignoreKeys = [
         'map',
-        'manualAreas',
         'limit',
         'icons',
         'scanner',

--- a/server/src/services/api/fetchJson.js
+++ b/server/src/services/api/fetchJson.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 const fetch = require('node-fetch')
-const { AbortError } = require('node-fetch')
 
 module.exports = async function fetchJson(
   url,
@@ -21,9 +20,7 @@ module.exports = async function fetchJson(
     }
     return response.json()
   } catch (e) {
-    if (e instanceof AbortError) {
-      console.log('Request to', url, 'timed out and was aborted')
-    } else if (log) {
+    if (log) {
       console.warn(e)
     } else if (e instanceof Error) {
       console.warn(e.message, '\n', e.code, `\nUnable to fetch ${url}`)

--- a/server/src/services/config.js
+++ b/server/src/services/config.js
@@ -4,14 +4,15 @@
 process.env.NODE_CONFIG_DIR = `${__dirname}/../configs`
 
 const fs = require('fs')
-const path = require('path')
+const { resolve } = require('path')
 const dotenv = require('dotenv')
+const { default: center } = require('@turf/center')
 
 dotenv.config()
 
 const config = require('config')
 
-if (!fs.existsSync(path.resolve(`${__dirname}/../configs/local.json`))) {
+if (!fs.existsSync(resolve(`${__dirname}/../configs/local.json`))) {
   // add database env variables from .env or docker-compose
   const {
     SCANNER_DB_HOST,
@@ -82,7 +83,7 @@ if (!fs.existsSync(path.resolve(`${__dirname}/../configs/local.json`))) {
     )
   }
 }
-if (fs.existsSync(path.resolve(`${__dirname}/../configs/config.json`))) {
+if (fs.existsSync(resolve(`${__dirname}/../configs/config.json`))) {
   console.log(
     '[CONFIG] Config v1 (config.json) found, it is fine to leave it but make sure you are using and updating local.json instead.',
   )
@@ -166,14 +167,44 @@ config.authMethods = [
 })
 
 // Load each areas.json
-const loadScanPolygons = (fileName) =>
-  fs.existsSync(path.resolve(`${__dirname}/../configs/${fileName}`))
-    ? require(`../configs/${fileName}`)
+const loadScanPolygons = (fileName) => {
+  const geojson = fs.existsSync(resolve(`${__dirname}/../configs/${fileName}`))
+    ? JSON.parse(fs.readFileSync(resolve(__dirname, `../configs/${fileName}`)))
     : { features: [] }
+  return {
+    ...geojson,
+    features: geojson.features.map((f) => ({
+      ...f,
+      properties: {
+        ...f.properties,
+        center: center(f).geometry.coordinates.reverse(),
+      },
+    })),
+  }
+}
 
 // Check if an areas.json exists
 config.scanAreas = {
-  main: loadScanPolygons(config.map.geoJsonFileName),
+  main: config.manualAreas.length
+    ? {
+        type: 'FeatureCollection',
+        features: config.manualAreas
+          .filter((area) => ['lat', 'lon', 'name'].every((k) => k in area))
+          .map((area) => ({
+            type: 'Feature',
+            properties: {
+              name: area.name,
+              center: [area.lat, area.lon],
+              zoom: area.zoom,
+              parent: area.parent,
+            },
+            geometry: {
+              type: 'Polygon',
+              coordinates: [[[area.lon, area.lat]]],
+            },
+          })),
+      }
+    : loadScanPolygons(config.map.geoJsonFileName),
   ...Object.fromEntries(
     config.multiDomains.map((d) => [
       d.general?.geoJsonFileName ? d.domain : 'main',
@@ -209,10 +240,5 @@ if (
   )
   config.authentication.alwaysEnabledPerms = enabled
 }
-
-// Map manual areas
-config.manualAreas = Object.fromEntries(
-  config.manualAreas.map((area) => [area.name, area]),
-)
 
 module.exports = config

--- a/server/src/services/config.js
+++ b/server/src/services/config.js
@@ -220,6 +220,36 @@ config.scanAreas = {
   ),
 }
 
+config.scanAreasMenu = Object.fromEntries(
+  Object.entries(config.scanAreas).map(([domain, areas]) => {
+    const parents = { '': { children: [], name: '' } }
+    areas.features.forEach((feature) => {
+      if (feature.properties.parent) {
+        parents[feature.properties.parent] = {
+          name: feature.properties.parent,
+          details: areas.features.find(
+            (area) => area.properties.name === feature.properties.parent,
+          ),
+          children: [],
+        }
+      }
+    })
+    areas.features.forEach((feature) => {
+      if (feature.properties.parent) {
+        parents[feature.properties.parent].children.push(feature)
+      } else if (!parents[feature.properties.name]) {
+        parents[''].children.push(feature)
+      }
+    })
+    Object.values(parents).forEach(({ children }) => {
+      if (children.length % 2 === 1) {
+        children.push({ type: 'Feature', properties: { name: '' } })
+      }
+    })
+    return [domain, Object.values(parents)]
+  }),
+)
+
 config.api.pvp.leagueObj = Object.fromEntries(
   config.api.pvp.leagues.map((league) => [league.name, league.cp]),
 )

--- a/src/components/QueryData.jsx
+++ b/src/components/QueryData.jsx
@@ -132,8 +132,8 @@ export default function QueryData({
     }
   }
 
-  const renderedData = data || previousData || {}
-  return renderedData[category] ? (
+  const renderedData = data || previousData || { [category]: [] }
+  return (
     <>
       <Clustering
         key={sizeKey}
@@ -165,5 +165,5 @@ export default function QueryData({
         />
       )}
     </>
-  ) : null
+  )
 }

--- a/src/components/layout/drawer/Areas.jsx
+++ b/src/components/layout/drawer/Areas.jsx
@@ -60,16 +60,18 @@ export default function AreaDropDown({ scanAreasZoom }) {
               onClick={
                 details
                   ? () => {
-                      map.flyTo(
-                        details.properties.center,
-                        details.properties.zoom || scanAreasZoom,
-                      )
+                      if (details?.properties) {
+                        map.flyTo(
+                          details.properties.center,
+                          details.properties.zoom || scanAreasZoom,
+                        )
+                      }
                     }
                   : undefined
               }
               style={{
-                border: `1px solid ${details.properties.color || 'grey'}`,
-                backgroundColor: details.properties.fillColor || 'none',
+                border: `1px solid ${details?.properties?.color || 'grey'}`,
+                backgroundColor: details?.properties?.fillColor || 'none',
               }}
             >
               <MenuItem>

--- a/src/components/layout/drawer/Areas.jsx
+++ b/src/components/layout/drawer/Areas.jsx
@@ -33,6 +33,11 @@ export default function AreaDropDown({ scanAreasZoom }) {
     if (!Object.keys(parents).length) {
       parents[''] = { children: data.scanAreas[0].features }
     }
+    Object.values(parents).forEach(({ children }) => {
+      if (children.length % 2 === 1) {
+        children.push({ type: 'Feature', properties: { name: '' } })
+      }
+    })
     return parents
   }, [])
 
@@ -40,7 +45,7 @@ export default function AreaDropDown({ scanAreasZoom }) {
     <Paper
       style={{
         minHeight: 50,
-        maxHeight: 250,
+        maxHeight: Math.min(data.scanAreas[0].features.length, 12) * 50,
         width: '100%',
         overflow: 'auto',
         backgroundColor: '#212121',
@@ -74,7 +79,7 @@ export default function AreaDropDown({ scanAreasZoom }) {
                 backgroundColor: details?.properties?.fillColor || 'none',
               }}
             >
-              <MenuItem>
+              <MenuItem disabled={!details}>
                 <Typography
                   variant="h6"
                   align="center"
@@ -93,23 +98,29 @@ export default function AreaDropDown({ scanAreasZoom }) {
                 children.length % 2 === 1 && i === children.length - 1 ? 12 : 6
               }
               onClick={() => {
-                map.flyTo(
-                  feat.properties.center,
-                  feat.properties.zoom || scanAreasZoom,
-                )
+                if (feat.properties?.center) {
+                  map.flyTo(
+                    feat.properties.center,
+                    feat.properties.zoom || scanAreasZoom,
+                  )
+                }
               }}
               style={{
                 border: `1px solid ${feat.properties.color || 'grey'}`,
                 backgroundColor: feat.properties.fillColor || 'none',
               }}
             >
-              <MenuItem>
+              <MenuItem disabled={!feat.properties.name}>
                 <Typography
                   variant="subtitle2"
                   align="center"
                   style={{ width: '100%' }}
                 >
-                  {Utility.getProperName(feat.properties.name)}
+                  {feat.properties.name ? (
+                    Utility.getProperName(feat.properties.name)
+                  ) : (
+                    <>&nbsp;</>
+                  )}
                 </Typography>
               </MenuItem>
             </Grid>

--- a/src/components/layout/drawer/Areas.jsx
+++ b/src/components/layout/drawer/Areas.jsx
@@ -6,59 +6,32 @@ import { useMap } from 'react-leaflet'
 import Utility from '@services/Utility'
 import Query from '@services/Query'
 
-export default function AreaDropDown({ scanAreasZoom }) {
-  const { data, loading, error } = useQuery(Query.scanAreas(), {
+export default function AreaDropDown({ scanAreaMenuHeight, scanAreasZoom }) {
+  const { data, loading, error } = useQuery(Query.scanAreasMenu(), {
     variables: { version: inject.VERSION },
   })
   const map = useMap()
 
   if (loading || error) return null
 
-  const areas = React.useMemo(() => {
-    const parents = { '': { children: [] } }
-    data.scanAreas[0].features.forEach((feature) => {
-      if (feature.properties.parent && !parents[feature.properties.parent]) {
-        parents[feature.properties.parent] = {
-          details: data.scanAreas[0].features.find(
-            (area) => area.properties.name === feature.properties.parent,
-          ),
-          children: data.scanAreas[0].features.filter(
-            (area) => area.properties.parent === feature.properties.parent,
-          ),
-        }
-      } else {
-        parents[''].children.push(feature)
-      }
-    })
-    if (!Object.keys(parents).length) {
-      parents[''] = { children: data.scanAreas[0].features }
-    }
-    Object.values(parents).forEach(({ children }) => {
-      if (children.length % 2 === 1) {
-        children.push({ type: 'Feature', properties: { name: '' } })
-      }
-    })
-    return parents
-  }, [])
-
   return (
     <Paper
       style={{
         minHeight: 50,
-        maxHeight: Math.min(data.scanAreas[0].features.length, 12) * 50,
+        maxHeight: scanAreaMenuHeight || 400,
         width: '100%',
         overflow: 'auto',
         backgroundColor: '#212121',
       }}
     >
-      {Object.entries(areas).map(([parent, { details, children }]) => (
+      {data?.scanAreasMenu?.map(({ name, details, children }) => (
         <Grid
-          key={parent}
+          key={name || ''}
           container
           alignItems="center"
           justifyContent="center"
         >
-          {Boolean(parent) && (
+          {Boolean(name) && (
             <Grid
               item
               xs={12}
@@ -85,7 +58,7 @@ export default function AreaDropDown({ scanAreasZoom }) {
                   align="center"
                   style={{ width: '100%' }}
                 >
-                  {Utility.getProperName(parent)}
+                  {Utility.getProperName(name)}
                 </Typography>
               </MenuItem>
             </Grid>

--- a/src/components/layout/drawer/Areas.jsx
+++ b/src/components/layout/drawer/Areas.jsx
@@ -14,7 +14,7 @@ export default function AreaDropDown({ scanAreasZoom }) {
 
   if (loading || error) return null
 
-  const stuff = React.useMemo(() => {
+  const areas = React.useMemo(() => {
     const parents = {}
     data.scanAreas[0].features.forEach((feature) => {
       if (feature.properties.parent && !parents[feature.properties.parent]) {
@@ -28,6 +28,9 @@ export default function AreaDropDown({ scanAreasZoom }) {
         }
       }
     })
+    if (!Object.keys(parents).length) {
+      parents[''] = { children: data.scanAreas[0].features }
+    }
     return parents
   }, [])
 
@@ -41,44 +44,54 @@ export default function AreaDropDown({ scanAreasZoom }) {
         backgroundColor: '#212121',
       }}
     >
-      {Object.entries(stuff).map(([parent, { details, children }]) => (
+      {Object.entries(areas).map(([parent, { details, children }]) => (
         <Grid
           key={parent}
           container
           alignItems="center"
           justifyContent="center"
         >
-          <Grid
-            item
-            xs={12}
-            onClick={
-              details
-                ? () => {
-                    map.flyTo(
-                      details.properties.center,
-                      details.properties.zoom || scanAreasZoom,
-                    )
-                  }
-                : undefined
-            }
-          >
-            <MenuItem>
-              <Typography variant="h6" align="center" style={{ width: '100%' }}>
-                {Utility.getProperName(parent)}
-              </Typography>
-            </MenuItem>
-          </Grid>
+          {Boolean(parent) && (
+            <Grid
+              item
+              xs={12}
+              onClick={
+                details
+                  ? () => {
+                      map.flyTo(
+                        details.properties.center,
+                        details.properties.zoom || scanAreasZoom,
+                      )
+                    }
+                  : undefined
+              }
+              style={{ border: '1px solid grey' }}
+            >
+              <MenuItem>
+                <Typography
+                  variant="h6"
+                  align="center"
+                  style={{ width: '100%' }}
+                >
+                  {Utility.getProperName(parent)}
+                </Typography>
+              </MenuItem>
+            </Grid>
+          )}
           {children.map((feat, i) => (
             <Grid
               key={feat.properties.name}
               item
-              xs={children.length % 2 === 1 && i === children.length -1 ? 12 : 6}
+              xs={
+                children.length % 2 === 1 && i === children.length - 1 ? 12 : 6
+              }
               onClick={() => {
                 map.flyTo(
                   feat.properties.center,
                   feat.properties.zoom || scanAreasZoom,
                 )
               }}
+              style={{ border: '1px solid grey' }}
             >
               <MenuItem>
                 <Typography

--- a/src/components/layout/drawer/Areas.jsx
+++ b/src/components/layout/drawer/Areas.jsx
@@ -1,17 +1,35 @@
 import React from 'react'
 import { useQuery } from '@apollo/client'
-import { Paper, MenuItem, MenuList, Typography } from '@material-ui/core'
-import center from '@turf/center'
+import { Grid, Paper, MenuItem, Typography } from '@material-ui/core'
 import { useMap } from 'react-leaflet'
 
 import Utility from '@services/Utility'
 import Query from '@services/Query'
 
-export default function AreaDropDown({ scanAreasZoom, manualAreas }) {
-  const { data } = useQuery(Query.scanAreas(), {
+export default function AreaDropDown({ scanAreasZoom }) {
+  const { data, loading, error } = useQuery(Query.scanAreas(), {
     variables: { version: inject.VERSION },
   })
   const map = useMap()
+
+  if (loading || error) return null
+
+  const stuff = React.useMemo(() => {
+    const parents = {}
+    data.scanAreas[0].features.forEach((feature) => {
+      if (feature.properties.parent && !parents[feature.properties.parent]) {
+        parents[feature.properties.parent] = {
+          details: data.scanAreas[0].features.find(
+            (area) => area.properties.name === feature.properties.parent,
+          ),
+          children: data.scanAreas[0].features.filter(
+            (area) => area.properties.parent === feature.properties.parent,
+          ),
+        }
+      }
+    })
+    return parents
+  }, [])
 
   return (
     <Paper
@@ -23,40 +41,58 @@ export default function AreaDropDown({ scanAreasZoom, manualAreas }) {
         backgroundColor: '#212121',
       }}
     >
-      {Object.keys(manualAreas).length ? (
-        <MenuList>
-          {Object.keys(manualAreas).map((area) => (
-            <MenuItem
-              key={area}
-              onClick={() => {
-                const { lat, lon, zoom } = manualAreas[area]
-                map.flyTo([lat, lon], zoom || scanAreasZoom)
-              }}
-            >
-              <Typography variant="subtitle2" align="center">
-                {area}
+      {Object.entries(stuff).map(([parent, { details, children }]) => (
+        <Grid
+          key={parent}
+          container
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Grid
+            item
+            xs={12}
+            onClick={
+              details
+                ? () => {
+                    map.flyTo(
+                      details.properties.center,
+                      details.properties.zoom || scanAreasZoom,
+                    )
+                  }
+                : undefined
+            }
+          >
+            <MenuItem>
+              <Typography variant="h6" align="center" style={{ width: '100%' }}>
+                {Utility.getProperName(parent)}
               </Typography>
             </MenuItem>
-          ))}
-        </MenuList>
-      ) : (
-        <MenuList>
-          {data &&
-            data.scanAreas[0].features.map((area) => (
-              <MenuItem
-                key={area.properties.name}
-                onClick={() => {
-                  const [lon, lat] = center(area).geometry.coordinates
-                  map.flyTo([lat, lon], scanAreasZoom)
-                }}
-              >
-                <Typography variant="subtitle2" align="center">
-                  {Utility.getProperName(area.properties.name)}
+          </Grid>
+          {children.map((feat, i) => (
+            <Grid
+              key={feat.properties.name}
+              item
+              xs={children.length % 2 === 1 && i === children.length -1 ? 12 : 6}
+              onClick={() => {
+                map.flyTo(
+                  feat.properties.center,
+                  feat.properties.zoom || scanAreasZoom,
+                )
+              }}
+            >
+              <MenuItem>
+                <Typography
+                  variant="subtitle2"
+                  align="center"
+                  style={{ width: '100%' }}
+                >
+                  {Utility.getProperName(feat.properties.name)}
                 </Typography>
               </MenuItem>
-            ))}
-        </MenuList>
-      )}
+            </Grid>
+          ))}
+        </Grid>
+      ))}
     </Paper>
   )
 }

--- a/src/components/layout/drawer/Areas.jsx
+++ b/src/components/layout/drawer/Areas.jsx
@@ -15,7 +15,7 @@ export default function AreaDropDown({ scanAreasZoom }) {
   if (loading || error) return null
 
   const areas = React.useMemo(() => {
-    const parents = {}
+    const parents = { '': { children: [] } }
     data.scanAreas[0].features.forEach((feature) => {
       if (feature.properties.parent && !parents[feature.properties.parent]) {
         parents[feature.properties.parent] = {
@@ -26,6 +26,8 @@ export default function AreaDropDown({ scanAreasZoom }) {
             (area) => area.properties.parent === feature.properties.parent,
           ),
         }
+      } else {
+        parents[''].children.push(feature)
       }
     })
     if (!Object.keys(parents).length) {
@@ -65,7 +67,10 @@ export default function AreaDropDown({ scanAreasZoom }) {
                     }
                   : undefined
               }
-              style={{ border: '1px solid grey' }}
+              style={{
+                border: `1px solid ${details.properties.color || 'grey'}`,
+                backgroundColor: details.properties.fillColor || 'none',
+              }}
             >
               <MenuItem>
                 <Typography
@@ -91,7 +96,10 @@ export default function AreaDropDown({ scanAreasZoom }) {
                   feat.properties.zoom || scanAreasZoom,
                 )
               }}
-              style={{ border: '1px solid grey' }}
+              style={{
+                border: `1px solid ${feat.properties.color || 'grey'}`,
+                backgroundColor: feat.properties.fillColor || 'none',
+              }}
             >
               <MenuItem>
                 <Typography

--- a/src/components/layout/drawer/Drawer.jsx
+++ b/src/components/layout/drawer/Drawer.jsx
@@ -36,7 +36,13 @@ export default function Sidebar({
   const ui = useStatic((state) => state.ui)
   const staticUserSettings = useStatic((state) => state.userSettings)
   const {
-    map: { title, scanAreasZoom, noScanAreaOverlay, enableQuestSetSelector },
+    map: {
+      title,
+      scanAreasZoom,
+      scanAreaMenuHeight,
+      noScanAreaOverlay,
+      enableQuestSetSelector,
+    },
   } = useStatic((state) => state.config)
   const available = useStatic((s) => s.available)
   const { t } = useTranslation()
@@ -136,7 +142,10 @@ export default function Sidebar({
               </Grid>
             )}
             {category === 'scanAreas' && (
-              <Areas scanAreasZoom={scanAreasZoom} />
+              <Areas
+                scanAreasZoom={scanAreasZoom}
+                scanAreaMenuHeight={scanAreaMenuHeight}
+              />
             )}
           </Grid>
         </AccordionDetails>

--- a/src/components/layout/drawer/Drawer.jsx
+++ b/src/components/layout/drawer/Drawer.jsx
@@ -36,7 +36,6 @@ export default function Sidebar({
   const ui = useStatic((state) => state.ui)
   const staticUserSettings = useStatic((state) => state.userSettings)
   const {
-    manualAreas,
     map: { title, scanAreasZoom, noScanAreaOverlay, enableQuestSetSelector },
   } = useStatic((state) => state.config)
   const available = useStatic((s) => s.available)
@@ -137,7 +136,7 @@ export default function Sidebar({
               </Grid>
             )}
             {category === 'scanAreas' && (
-              <Areas scanAreasZoom={scanAreasZoom} manualAreas={manualAreas} />
+              <Areas scanAreasZoom={scanAreasZoom} />
             )}
           </Grid>
         </AccordionDetails>

--- a/src/components/layout/drawer/WithSubItems.jsx
+++ b/src/components/layout/drawer/WithSubItems.jsx
@@ -74,14 +74,14 @@ export default function WithSubItems({
 
   return (
     <>
-      <Grid item xs={6}>
+      <Grid item xs={8}>
         <Typography>
           {category === 'scanAreas'
             ? t('show_polygons')
             : t(Utility.camelToSnake(subItem))}
         </Typography>
       </Grid>
-      <Grid item xs={6} style={{ textAlign: 'right' }}>
+      <Grid item xs={4} style={{ textAlign: 'right' }}>
         {filterCategory}
       </Grid>
       {enableQuestSetSelector === true &&

--- a/src/components/tiles/ScanArea.jsx
+++ b/src/components/tiles/ScanArea.jsx
@@ -20,10 +20,12 @@ export default function ScanAreaTile({
       const name = feature.properties.name.toLowerCase()
       const popupContent = Utility.getProperName(name)
       layer.setStyle({
-        color: feature.properties.stroke || '#3388ff',
+        color:
+          feature.properties.color || feature.properties.stroke || '#3388ff',
         weight: feature.properties['stroke-width'] || 3,
         opacity: feature.properties['stroke-opacity'] || 1,
-        fillColor: feature.properties.fill || '#3388ff',
+        fillColor:
+          feature.properties.fillColor || feature.properties.fill || '#3388ff',
         fillOpacity:
           selectedAreas &&
           selectedAreas.includes(name) &&

--- a/src/services/Query.js
+++ b/src/services/Query.js
@@ -8,7 +8,7 @@ import getAllWeather from './queries/weather'
 import getAllScanCells from './queries/scanCell'
 import getAllSubmissionCells from './queries/submissionCells'
 import { getOne, getAllNests } from './queries/nest'
-import getAllScanAreas from './queries/scanAreas'
+import { getAllScanAreas, getScanAreasMenu } from './queries/scanAreas'
 import * as searchIndex from './queries/search'
 import * as webhookIndex from './queries/webhook'
 import scanner from './queries/scanner'
@@ -120,6 +120,10 @@ export default class Query {
 
   static scanAreas() {
     return getAllScanAreas
+  }
+
+  static scanAreasMenu() {
+    return getScanAreasMenu
   }
 
   static search(category) {

--- a/src/services/queries/scanAreas.js
+++ b/src/services/queries/scanAreas.js
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 
-const getAllScanAreas = gql`
+export const getAllScanAreas = gql`
   query ScanAreas($version: String) {
     scanAreas(version: $version) {
       type
@@ -16,4 +16,16 @@ const getAllScanAreas = gql`
   }
 `
 
-export default getAllScanAreas
+export const getScanAreasMenu = gql`
+  query ScanAreasMenu($version: String) {
+    scanAreasMenu(version: $version) {
+      name
+      details {
+        properties
+      }
+      children {
+        properties
+      }
+    }
+  }
+`


### PR DESCRIPTION
- Normalize manual areas
- Add parents property support
- Fix instanceof error

When using with an areas.json file, just add the parent name to the properties of the child feature/area, next to the name, etc. 

When using manualAreas in the config, just add a parent property at the same level as the name/lat/lon/zoom.

You do not need an area/feature with the same parent name if you don't want it to be clickable. 