### PR TITLE
Fix Available Cache Issue

### DIFF
--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -31,15 +31,15 @@
       "weather": 30
     },
     "queryUpdateHours": {
-      "pokemon": 0.5,
-      "quests": 1,
-      "raids": 0.5,
-      "nests": 3
+      "pokemon": 0.25,
+      "quests": 0.5,
+      "raids": 0.2,
+      "nests": 1
     },
     "queryOnSessionInit": {
       "pokemon": false,
       "quests": false,
-      "raids": false,
+      "raids": true,
       "nests": false
     },
     "queryLimits": {

--- a/server/src/routes/rootRouter.js
+++ b/server/src/routes/rootRouter.js
@@ -223,14 +223,16 @@ rootRouter.get('/settings', async (req, res) => {
       })
 
       if (serverSettings.user.perms.pokemon) {
-        serverSettings.available.pokemon = config.api.queryOnSessionInit.pokemon
-          ? await Db.getAvailable('Pokemon')
-          : Event.available.pokemon
+        if (config.api.queryOnSessionInit.pokemon) {
+          Event.setAvailable('pokemon', 'Pokemon', Db, false)
+        }
+        serverSettings.available.pokemon = Event.getAvailable('pokemon')
       }
       if (serverSettings.user.perms.raids || serverSettings.user.perms.gyms) {
-        serverSettings.available.gyms = config.api.queryOnSessionInit.raids
-          ? await Db.getAvailable('Gym')
-          : Event.available.gyms
+        if (config.api.queryOnSessionInit.raids) {
+          Event.setAvailable('gyms', 'Gym', Db, false)
+        }
+        serverSettings.available.gyms = Event.getAvailable('gyms')
       }
       if (
         serverSettings.user.perms.quests ||
@@ -238,16 +240,16 @@ rootRouter.get('/settings', async (req, res) => {
         serverSettings.user.perms.invasions ||
         serverSettings.user.perms.lures
       ) {
-        serverSettings.available.pokestops = config.api.queryOnSessionInit
-          .quests
-          ? await Db.getAvailable('Pokestop')
-          : Event.available.pokestops
-        serverSettings.available.withConditions = Db.questConditions
+        if (config.api.queryOnSessionInit.quests) {
+          Event.setAvailable('pokestops', 'Pokestop', Db, false)
+        }
+        serverSettings.available.pokestops = Event.getAvailable('pokestops')
       }
       if (serverSettings.user.perms.nests) {
-        serverSettings.available.nests = config.api.queryOnSessionInit.nests
-          ? await Db.getAvailable('Nest')
-          : Event.available.nests
+        if (config.api.queryOnSessionInit.nests) {
+          Event.setAvailable('nests', 'Nest', Db, false)
+        }
+        serverSettings.available.nests = Event.getAvailable('nests')
       }
       if (Object.values(config.api.queryOnSessionInit).some((v) => v)) {
         Event.addAvailable()

--- a/server/src/services/DbCheck.js
+++ b/server/src/services/DbCheck.js
@@ -212,16 +212,16 @@ module.exports = class DbCheck {
     return [DbCheck.deDupeResults(stopData), DbCheck.deDupeResults(gymData)]
   }
 
-  async getAvailable(model) {
+  async getAvailable(model, log = true) {
     if (this.models[model]) {
-      console.log(`[DB] Querying available for ${model}`)
+      if (log) console.log(`[DB] Querying available for ${model}`)
       try {
         const results = await Promise.all(
           this.models[model].map(async (source) =>
             source.SubModel.getAvailable(source),
           ),
         )
-        console.log(`[DB] Setting available for ${model}`)
+        if (log) console.log(`[DB] Setting available for ${model}`)
         if (model === 'Pokestop') {
           results.forEach((result) => {
             if ('conditions' in result) {

--- a/server/src/services/EventManager.js
+++ b/server/src/services/EventManager.js
@@ -18,29 +18,33 @@ module.exports = class EventManager {
     this.webhookObj = {}
   }
 
-  async setAvailable(category, model, Db) {
-    this.available[category] = await Db.getAvailable(model)
+  getAvailable(category) {
+    return this.available[category]
+  }
+
+  async setAvailable(category, model, Db, log) {
+    this.available[category] = await Db.getAvailable(model, log)
   }
 
   setTimers(config, Db, Pvp) {
     if (!config.api.queryOnSessionInit.raids) {
       setInterval(async () => {
-        this.available.gyms = await Db.getAvailable('Gym')
+        await this.setAvailable('gyms', 'Gym', Db, true)
       }, 1000 * 60 * 60 * (config.api.queryUpdateHours.raids || 1))
     }
     if (!config.api.queryOnSessionInit.nests) {
       setInterval(async () => {
-        this.available.nests = await Db.getAvailable('Nest')
+        await this.setAvailable('nests', 'Nest', Db, true)
       }, 1000 * 60 * 60 * (config.api.queryUpdateHours.nests || 6))
     }
     if (!config.api.queryOnSessionInit.pokemon) {
       setInterval(async () => {
-        this.available.pokemon = await Db.getAvailable('Pokemon')
+        await this.setAvailable('pokemon', 'Pokemon', Db, true)
       }, 1000 * 60 * 60 * (config.api.queryUpdateHours.pokemon || 1))
     }
     if (!config.api.queryOnSessionInit.quests) {
       setInterval(async () => {
-        this.available.pokestops = await Db.getAvailable('Pokestop')
+        await this.setAvailable('pokestops', 'Pokestop', Db, true)
       }, 1000 * 60 * 60 * (config.api.queryUpdateHours.quests || 3))
     }
     setInterval(async () => {

--- a/server/src/services/functions/getAreaSql.js
+++ b/server/src/services/functions/getAreaSql.js
@@ -8,7 +8,11 @@ module.exports = function getAreaRestrictionSql(
   isMad,
   category,
 ) {
-  if (!areaRestrictions?.length && (!onlyAreas?.length || config.manualAreas.length)) return true
+  if (
+    !areaRestrictions?.length &&
+    (!onlyAreas?.length || config.manualAreas.length)
+  )
+    return true
 
   const cleanUserAreas = onlyAreas.filter((area) => areas.names.includes(area))
   const consolidatedAreas = areaRestrictions.length


### PR DESCRIPTION
- Wasn't updating cache for gql frontend to grab when queryOnSessionInit was enabled
- Lower default values for when it queries
- Enable raids by default now to query on session init since it's low cost
- Add optional logging to getAvailable method