### PR TITLE
Scan Area Filtering Refinements

### DIFF
--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -94,7 +94,7 @@
       "minZoom": 10,
       "maxZoom": 18,
       "interactionRangeZoom": 15,
-      "scanAreasZoom": 12,
+      "scanAreasZoom": 15,
       "scanCellsZoom": 13,
       "submissionZoom": 15,
       "activeWeatherZoom": 13,

--- a/server/src/configs/local.example.json
+++ b/server/src/configs/local.example.json
@@ -314,13 +314,15 @@
       "name": "San Francisco",
       "lat": 37.79539194255634,
       "lon": -122.39333173075096,
-      "parent": "California"
+      "parent": "California",
+      "hidden": false
     },
     {
       "name": "Houston",
       "lat": 33.6145517,
       "lon": -108.6038347,
-      "parent": "Texas"
+      "parent": "Texas",
+      "domain": "map_2.your_map.com"
     }
   ]
 }

--- a/server/src/models/Weather.js
+++ b/server/src/models/Weather.js
@@ -52,15 +52,16 @@ module.exports = class Weather extends Model {
           !merged.length ||
           merged.some(
             (area) =>
-              pointInPolygon(
+              config.scanAreasObj[area] &&
+              (pointInPolygon(
                 point(config.scanAreasObj[area].geometry.coordinates[0][0]),
                 geojson,
               ) ||
-              pointInPolygon(
-                point([cell.longitude, cell.latitude]),
-                config.scanAreasObj[area],
-              ) ||
-              booleanOverlap(geojson, config.scanAreasObj[area]),
+                pointInPolygon(
+                  point([cell.longitude, cell.latitude]),
+                  config.scanAreasObj[area],
+                ) ||
+                booleanOverlap(geojson, config.scanAreasObj[area])),
           )
         return (
           hasOverlap && {

--- a/server/src/services/areas.js
+++ b/server/src/services/areas.js
@@ -6,7 +6,7 @@ const loadAreas = () => {
     const normalized = { type: 'FeatureCollection', features: [] }
     Object.values(config.scanAreas).forEach((area) => {
       if (area?.features.length) {
-        normalized.features.push(...area.features)
+        normalized.features.push(...area.features.filter((f) => !f.manual))
       }
     })
     return normalized

--- a/server/src/services/config.js
+++ b/server/src/services/config.js
@@ -169,7 +169,9 @@ config.authMethods = [
 const manualGeojson = {
   type: 'FeatureCollection',
   features: config.manualAreas
-    .filter((area) => ['lat', 'lon', 'name'].every((k) => k in area && !area.hidden))
+    .filter((area) =>
+      ['lat', 'lon', 'name'].every((k) => k in area && !area.hidden),
+    )
     .map((area) => {
       const { lat, lon, ...rest } = area
       return {

--- a/server/src/services/config.js
+++ b/server/src/services/config.js
@@ -166,51 +166,52 @@ config.authMethods = [
   }
 })
 
+const manualGeojson = {
+  type: 'FeatureCollection',
+  features: config.manualAreas
+    .filter((area) => ['lat', 'lon', 'name'].every((k) => k in area && !area.hidden))
+    .map((area) => {
+      const { lat, lon, ...rest } = area
+      return {
+        type: 'Feature',
+        properties: {
+          center: [lat, lon],
+          manual: true,
+          ...rest,
+        },
+        geometry: {
+          type: 'Polygon',
+          coordinates: [[[lon, lat]]],
+        },
+      }
+    }),
+}
+
 // Load each areas.json
-const loadScanPolygons = (fileName) => {
+const loadScanPolygons = (fileName, domain) => {
   const geojson = fs.existsSync(resolve(`${__dirname}/../configs/${fileName}`))
     ? JSON.parse(fs.readFileSync(resolve(__dirname, `../configs/${fileName}`)))
     : { features: [] }
   return {
     ...geojson,
-    features: geojson.features
-      .filter((f) => !f.properties.hidden)
-      .map((f) => ({
+    features: [
+      ...manualGeojson.features.filter(
+        (f) => !f.properties.domain || f.properties.domain === domain,
+      ),
+      ...geojson.features.map((f) => ({
         ...f,
         properties: {
           ...f.properties,
           center: center(f).geometry.coordinates.reverse(),
         },
-      }))
-      .sort((a, b) => a.properties.name.localeCompare(b.properties.name)),
+      })),
+    ].sort((a, b) => a.properties.name.localeCompare(b.properties.name)),
   }
 }
 
 // Check if an areas.json exists
 config.scanAreas = {
-  main: config.manualAreas.length
-    ? {
-        type: 'FeatureCollection',
-        features: config.manualAreas
-          .filter((area) => ['lat', 'lon', 'name'].every((k) => k in area))
-          .map((area) => {
-            const { lat, lon, ...rest } = area
-            return {
-              type: 'Feature',
-              properties: {
-                center: [lat, lon],
-                manual: true,
-                ...rest,
-              },
-              geometry: {
-                type: 'Polygon',
-                coordinates: [[[lon, lat]]],
-              },
-            }
-          })
-          .sort((a, b) => a.properties.name.localeCompare(b.properties.name)),
-      }
-    : loadScanPolygons(config.map.geoJsonFileName),
+  main: loadScanPolygons(config.map.geoJsonFileName),
   ...Object.fromEntries(
     config.multiDomains.map((d) => [
       d.general?.geoJsonFileName ? d.domain : 'main',
@@ -224,7 +225,13 @@ config.scanAreas = {
 config.scanAreasMenu = Object.fromEntries(
   Object.entries(config.scanAreas).map(([domain, areas]) => {
     const parents = { '': { children: [], name: '' } }
-    areas.features.forEach((feature) => {
+
+    const noHidden = {
+      ...areas,
+      features: areas.features.filter((f) => !f.properties.hidden),
+    }
+    // Finds unique parents and determines if the parents have their own properties
+    noHidden.features.forEach((feature) => {
       if (feature.properties.parent) {
         parents[feature.properties.parent] = {
           name: feature.properties.parent,
@@ -235,13 +242,17 @@ config.scanAreasMenu = Object.fromEntries(
         }
       }
     })
-    areas.features.forEach((feature) => {
+
+    // Finds the children of each parent
+    noHidden.features.forEach((feature) => {
       if (feature.properties.parent) {
         parents[feature.properties.parent].children.push(feature)
       } else if (!parents[feature.properties.name]) {
         parents[''].children.push(feature)
       }
     })
+
+    // Create blanks for better formatting when there's an odd number of children
     Object.values(parents).forEach(({ children }) => {
       if (children.length % 2 === 1) {
         children.push({

--- a/server/src/services/functions/getAreaSql.js
+++ b/server/src/services/functions/getAreaSql.js
@@ -1,4 +1,3 @@
-const config = require('../config')
 const areas = require('../areas')
 
 module.exports = function getAreaRestrictionSql(
@@ -8,11 +7,7 @@ module.exports = function getAreaRestrictionSql(
   isMad,
   category,
 ) {
-  if (
-    !areaRestrictions?.length &&
-    (!onlyAreas?.length || config.manualAreas.length)
-  )
-    return true
+  if (!areaRestrictions?.length && !onlyAreas?.length) return true
 
   const cleanUserAreas = onlyAreas.filter((area) => areas.names.includes(area))
   const consolidatedAreas = areaRestrictions.length

--- a/src/components/layout/drawer/AreaTile.jsx
+++ b/src/components/layout/drawer/AreaTile.jsx
@@ -21,13 +21,16 @@ export default function AreaTile({
 
   const hasAll =
     childAreas &&
-    childAreas.every((c) => scanAreas.filter.areas.includes(c.properties.name))
+    childAreas.every(
+      (c) =>
+        c.properties.manual ||
+        scanAreas.filter.areas.includes(c.properties.name),
+    )
   const hasSome =
     childAreas &&
     childAreas.some((c) => scanAreas.filter.areas.includes(c.properties.name))
-  const hasManual = childAreas
-    ? childAreas.some((c) => c.properties.manual)
-    : feature.properties.manual
+  const hasManual =
+    feature?.properties?.manual || childAreas.every((c) => c.properties.manual)
 
   return (
     <Grid
@@ -43,8 +46,9 @@ export default function AreaTile({
       }}
     >
       <MenuItem
+        style={{ height: '100%' }}
         onClick={() => {
-          if (feature?.properties) {
+          if (feature?.properties?.center) {
             map.flyTo(
               feature.properties.center,
               feature.properties.zoom || scanAreasZoom,
@@ -52,48 +56,53 @@ export default function AreaTile({
           }
         }}
       >
-        <Grid container alignItems="center" justifyContent="space-between">
-          <Grid
-            item
-            // eslint-disable-next-line no-nested-ternary
-            xs={hasManual ? 12 : name ? 11 : 10}
-            style={{ textAlign: 'center' }}
-          >
+        <Grid container alignItems="center" justifyContent="center">
+          <Grid item xs={name ? 11 : 10} style={{ textAlign: 'center' }}>
             <Typography
               variant={name ? 'h6' : 'caption'}
               align="center"
-              style={{ width: '100%', fontWeight: 'bold' }}
+              style={{
+                whiteSpace: 'pre-wrap',
+              }}
             >
               {name || feature.properties.name ? (
                 Utility.getProperName(name || feature.properties.name)
+                  .split(' ')
+                  .join('\n')
               ) : (
                 <>&nbsp;</>
               )}
             </Typography>
           </Grid>
-          {!hasManual && (
-            <Grid item xs={name ? 1 : 2} style={{ textAlign: 'right' }}>
-              <Checkbox
-                size="small"
-                indeterminate={name ? hasSome && !hasAll : false}
-                checked={
+          <Grid item xs={name ? 1 : 2} style={{ textAlign: 'right' }}>
+            <Checkbox
+              size="small"
+              indeterminate={name ? hasSome && !hasAll : false}
+              checked={
+                name
+                  ? hasAll
+                  : scanAreas.filter.areas.includes(feature.properties.name)
+              }
+              onChange={() =>
+                setAreas(
                   name
-                    ? hasAll
-                    : scanAreas.filter.areas.includes(feature.properties.name)
-                }
-                onChange={() =>
-                  setAreas(
-                    name
-                      ? childAreas.map((c) => c.properties.name)
-                      : feature.properties.name,
-                    allAreas,
-                    name ? hasSome : false,
-                  )
-                }
-                disabled={!childAreas.length}
-              />
-            </Grid>
-          )}
+                    ? childAreas.map((c) => c.properties.name)
+                    : feature.properties.name,
+                  allAreas,
+                  name ? hasSome : false,
+                )
+              }
+              style={{
+                color:
+                  !childAreas.length || hasManual
+                    ? feature?.properties?.fillColor ||
+                      feature?.properties?.fill ||
+                      '#212121'
+                    : 'none',
+              }}
+              disabled={!childAreas.length || hasManual}
+            />
+          </Grid>
         </Grid>
       </MenuItem>
     </Grid>

--- a/src/components/layout/drawer/Areas.jsx
+++ b/src/components/layout/drawer/Areas.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { useQuery } from '@apollo/client'
 import { Grid, Button, Paper } from '@material-ui/core'
 import { useTranslation } from 'react-i18next'
@@ -12,10 +12,12 @@ export default function AreaDropDown({ scanAreaMenuHeight, scanAreasZoom }) {
   const { t } = useTranslation()
   const setAreas = useStore((s) => s.setAreas)
 
-  const allAreas = React.useMemo(() => {
+  const allAreas = useMemo(() => {
     if (data?.scanAreasMenu) {
       return data.scanAreasMenu.flatMap((parent) =>
-        parent.children.map((child) => child.properties.name),
+        parent.children
+          .filter((child) => !child.properties.manual)
+          .map((child) => child.properties.name),
       )
     }
     return []
@@ -52,7 +54,7 @@ export default function AreaDropDown({ scanAreaMenuHeight, scanAreasZoom }) {
           <Grid
             key={name || ''}
             container
-            alignItems="center"
+            alignItems="stretch"
             justifyContent="center"
           >
             {name && (

--- a/src/components/tiles/ScanArea.jsx
+++ b/src/components/tiles/ScanArea.jsx
@@ -13,6 +13,9 @@ export function ScanAreaTile({
   userSettings,
 }) {
   const setAreas = useStore((s) => s.setAreas)
+  const names = item.features
+    .filter((f) => !f.properties.manual)
+    .map((f) => f.properties.name)
 
   const handleClick = (name) => {
     if (selectedAreas.includes(name)) {
@@ -53,7 +56,7 @@ export function ScanAreaTile({
       if (webhookMode) {
         layer.on('click', () => handleClick(name.toLowerCase()))
       } else if (!feature.properties.manual) {
-        layer.on('click', () => setAreas(name))
+        layer.on('click', () => setAreas(name, names))
       }
     }
   }

--- a/src/hooks/useStore.js
+++ b/src/hooks/useStore.js
@@ -31,8 +31,8 @@ export const useStore = create(
                 ...filters.scanAreas,
                 filter: {
                   ...filters.scanAreas.filter,
-                  areas: [...existing].filter(
-                    (area) => !validAreas.length || validAreas.includes(area),
+                  areas: [...existing].filter((area) =>
+                    validAreas.includes(area),
                   ),
                 },
               },


### PR DESCRIPTION
- Add multiDomain and hidden support to manual areas
- Maintain hidden areas for areaRestriction purposes but still hide them from the map and sidebar menu
- Add a check in weather model to fix an edge case
- *Allow* manualAreas and an areas.json to be used together
- Fix reset button
- Fix sidebar menu grid items when the name is too long, assuming it's a multi-word name
- Less hacky ScanArea tile stuff