### PR TITLE
Tap to toggle option

### DIFF
--- a/public/base-locales/en.json
+++ b/public/base-locales/en.json
@@ -550,5 +550,6 @@
   "historic_rarity": "Historic Rarity",
   "poi": "Points of Interest",
   "300m_range": "300m Range",
-  "lure_range": "Lure Range"
+  "lure_range": "Lure Range",
+  "tap_to_toggle": "Tap To Toggle"
 }

--- a/server/src/configs/custom-environment-variables.json
+++ b/server/src/configs/custom-environment-variables.json
@@ -653,6 +653,10 @@
       "alwaysShowLabels": {
         "__name": "CLIENT_SIDE_OPTIONS_SCAN_AREAS_ALWAYS_SHOW_LABELS",
         "__format": "boolean"
+      },
+      "tapToToggle": {
+        "__name": "CLIENT_SIDE_OPTIONS_SCAN_AREAS_TAP_TO_TOGGLE",
+        "__format": "boolean"
       }
     },
     "weather": {

--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -300,7 +300,8 @@
       "poiColor": "#03ffff"
     },
     "scanAreas": {
-      "alwaysShowLabels": true
+      "alwaysShowLabels": true,
+      "tapToToggle": true
     },
     "weather": {
       "clickableIcon": false,

--- a/server/src/services/ui/clientOptions.js
+++ b/server/src/services/ui/clientOptions.js
@@ -57,6 +57,7 @@ module.exports = function clientOptions(perms) {
     },
     scanAreas: {
       alwaysShowLabels: { type: 'bool', perm: ['scanAreas'] },
+      tapToToggle: { type: 'bool', perm: ['scanAreas'] },
     },
     weather: {
       clickableIcon: { type: 'bool', perm: ['weather'] },

--- a/src/components/tiles/ScanArea.jsx
+++ b/src/components/tiles/ScanArea.jsx
@@ -55,7 +55,7 @@ export function ScanAreaTile({
       }
       if (webhookMode) {
         layer.on('click', () => handleClick(name.toLowerCase()))
-      } else if (!feature.properties.manual) {
+      } else if (!feature.properties.manual && userSettings?.tapToToggle) {
         layer.on('click', () => setAreas(name, names))
       }
     }


### PR DESCRIPTION
- Client side option to toggle whether area polygons are selectable when tapping/clicking on them on the map