### PR TITLE
Added a grass icon for Pokemon found in nearby cells

### DIFF
--- a/src/components/markers/pokemon.jsx
+++ b/src/components/markers/pokemon.jsx
@@ -50,6 +50,18 @@ export const fancyMarker = (
           width: size,
         }}
       />
+      {pkmn.seen_type === 'nearby_cell' && (
+        <img
+          src={Icons.getMisc('grass')}
+          alt='nearby_cell'
+          style={{
+            width: size / 1.5,
+            height: 'auto',
+            bottom: (-size / 5) * pokemonMod.offsetY,
+            left: `10%`,
+          }}
+        />
+      )}
       {badge && (
         <img
           src={Icons.getMisc(badge)}

--- a/src/components/tiles/Pokemon.jsx
+++ b/src/components/tiles/Pokemon.jsx
@@ -126,7 +126,7 @@ const PokemonTile = ({
         zIndexOffset={item.iv * 100}
         position={finalLocation}
         icon={
-          pvpCheck || glowStatus || ivCircle || weatherCheck
+          pvpCheck || glowStatus || ivCircle || weatherCheck || item.seen_type === 'nearby_cell'
             ? fancyMarker(
                 url,
                 size,


### PR DESCRIPTION
A marker for for mons found in nearby cells so users can see right away that their location isn't accurate.
I didn't quite understand the current calculation for icon placement when accounting for the pokemon icon offsetX so I just set the position to fixed 10%.