### PR TITLE
fix Pokemon icon not working with shinies

### DIFF
--- a/src/services/Icons.js
+++ b/src/services/Icons.js
@@ -173,7 +173,7 @@ export default class UIcons {
     const formSuffixes = form ? [`_f${form}`, ''] : ['']
     const costumeSuffixes = costume ? [`_c${costume}`, ''] : ['']
     const genderSuffixes = gender ? [`_g${gender}`, ''] : ['']
-    const shinySuffixes = shiny ? ['_shiny', ''] : ['']
+    const shinySuffixes = shiny ? ['_s', ''] : ['']
     for (let e = 0; e < evolutionSuffixes.length; e += 1) {
       for (let f = 0; f < formSuffixes.length; f += 1) {
         for (let c = 0; c < costumeSuffixes.length; c += 1) {


### PR DESCRIPTION
Hello,

I noticed that the Pokémon icons didn't work with shinies. According to the [UIcons specifications](https://github.com/UIcons/UIcons#pokemon-icons), the shiny flag is `_s` and not `_shiny`. Even though this flag is only provided on quest rewards icons, this function might be used by custom components. 

Thanks. 