### PR TITLE
Fix MAD devices not showing up on map correctly

### DIFF
--- a/server/src/models/Device.js
+++ b/server/src/models/Device.js
@@ -19,8 +19,8 @@ module.exports = class Device extends Model {
           'settings_area.name AS instance_name',
           'mode AS type',
           raw('UNIX_TIMESTAMP(lastProtoDateTime)').as('last_seen'),
-          raw('X(currentPos)').as('last_lat'),
-          raw('Y(currentPos)').as('last_lon'),
+          raw('Y(currentPos)').as('last_lat'),
+          raw('X(currentPos)').as('last_lon'),
           raw(true).as('isMad'),
         ])
     } else {


### PR DESCRIPTION
The X and Y coords are swapped currently for MAD devices. This is because X is mapped to latitude and Y is mapped to longitude which is incorrect in this case.  Some more info: https://gdal.org/tutorials/osr_api_tut.html#crs-and-axis-order This is a very confusing topic overall when working with geometries and both versions exsists (latitude, longitude / longitude, latitude) depending on the libraries used and also db engines.