### PR TITLE
Extract Config Pages

### DIFF
--- a/server/src/services/config.js
+++ b/server/src/services/config.js
@@ -106,11 +106,12 @@ const checkExtraJsons = (fileName, domain = '') => {
     domain &&
     fs.existsSync(resolve(`${__dirname}/../configs/${fileName}/${domain}.json`))
   ) {
-    const domainJson = JSON.parse(
-      fs.readFileSync(
-        resolve(__dirname, `../configs/${fileName}/${domain}.json`),
-      ),
-    ) || {}
+    const domainJson =
+      JSON.parse(
+        fs.readFileSync(
+          resolve(__dirname, `../configs/${fileName}/${domain}.json`),
+        ),
+      ) || {}
     if (Object.keys(domainJson).length) {
       console.log(
         `[CONFIG] config ${fileName}/${domain}.json found, overwriting your config.map.${fileName} with the found data.`,

--- a/server/src/services/config.js
+++ b/server/src/services/config.js
@@ -89,6 +89,41 @@ if (fs.existsSync(resolve(`${__dirname}/../configs/config.json`))) {
   )
 }
 
+const checkExtraJsons = (fileName, domain = '') => {
+  const generalJson = fs.existsSync(
+    resolve(`${__dirname}/../configs/${fileName}.json`),
+  )
+    ? JSON.parse(
+        fs.readFileSync(resolve(__dirname, `../configs/${fileName}.json`)),
+      )
+    : {}
+  if (Object.keys(generalJson).length) {
+    console.log(
+      `[CONFIG] config ${fileName}.json found, overwriting your config.map.${fileName} with the found data.`,
+    )
+  }
+  if (
+    domain &&
+    fs.existsSync(resolve(`${__dirname}/../configs/${fileName}/${domain}.json`))
+  ) {
+    const domainJson = JSON.parse(
+      fs.readFileSync(
+        resolve(__dirname, `../configs/${fileName}/${domain}.json`),
+      ),
+    ) || {}
+    if (Object.keys(domainJson).length) {
+      console.log(
+        `[CONFIG] config ${fileName}/${domain}.json found, overwriting your config.map.${fileName} with the found data.`,
+      )
+    }
+    return {
+      ...generalJson,
+      ...domainJson,
+    }
+  }
+  return generalJson
+}
+
 const mergeMapConfig = (obj) => {
   if (process.env.TELEGRAM_BOT_NAME && !obj?.customRoutes?.telegramBotName) {
     if (obj.customRoutes)
@@ -120,6 +155,7 @@ const mergeMapConfig = (obj) => {
       })
     }
   })
+
   return {
     localeSelection: obj.localeSelection,
     ...obj,
@@ -128,6 +164,18 @@ const mergeMapConfig = (obj) => {
     ...obj.links,
     ...obj.holidayEffects,
     ...obj.misc,
+    messageOfTheDay: {
+      ...obj.messageOfTheDay,
+      ...checkExtraJsons('messageOfTheDay', obj.domain),
+    },
+    donationPage: {
+      ...obj.donationPage,
+      ...checkExtraJsons('donationPage', obj.domain),
+    },
+    loginPage: {
+      ...obj.loginPage,
+      ...checkExtraJsons('loginPage', obj.domain),
+    },
     general: undefined,
     customRoutes: undefined,
     links: undefined,


### PR DESCRIPTION
- Allow `messageOfTheDay.json`, `loginPage.json`, and `donationPage.json` in the config folder
- Works with multiDomains by adding a folder and named jsons instead: `server/src/configs/loginPage/subDomain_1.json`
`server/src/configs/loginPage/subDomain_2.json`

Resolves #574 