### PR TITLE
Add a config api route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ server/src/routes/api/v1/*
 !server/src/routes/api/v1/users.js
 !server/src/routes/api/v1/sessions.js
 !server/src/routes/api/v1/available.js
+!server/src/routes/api/v1/config.js
 
 # custom model
 server/src/models/Custom.js

--- a/server/src/configs/custom-environment-variables.json
+++ b/server/src/configs/custom-environment-variables.json
@@ -27,6 +27,14 @@
   "api": {
     "sessionSecret": "API_SESSION_SECRET",
     "reactMapSecret": "API_REACT_MAP_SECRET",
+    "showSchemasInConfigApi": {
+      "__name": "API_SHOW_SCHEMAS_IN_CONFIG_API",
+      "__format": "boolean"
+    },
+    "showStrategiesInConfigApi": {
+      "__name": "API_SHOW_STRATEGIES_IN_CONFIG_API",
+      "__format": "boolean"
+    },
     "maxSessions": {
       "__name": "API_MAX_SESSIONS",
       "__format": "number"

--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -12,6 +12,8 @@
   "api": {
     "sessionSecret": "98ki^e72~!@#(85o3kXLI*#c9wu5l!Z",
     "reactMapSecret": "",
+    "showSchemasInConfigApi": false,
+    "showStrategiesInConfigApi": false,
     "maxSessions": 5,
     "sessionCheckIntervalMs": 900000,
     "cookieAgeDays": 7,

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -140,7 +140,7 @@ app.use(express.static(path.join(__dirname, config.devOptions.clientPath)))
 
 app.use(
   session({
-    name: 'discord',
+    name: 'reactmap',
     key: 'session',
     secret: config.api.sessionSecret,
     store: sessionStore,

--- a/server/src/routes/api/v1/config.js
+++ b/server/src/routes/api/v1/config.js
@@ -1,0 +1,41 @@
+/* eslint-disable no-console */
+const path = require('path')
+const router = require('express').Router()
+const config = require('../../../services/config')
+
+router.get('/', (req, res) => {
+  try {
+    if (
+      config.api.reactMapSecret &&
+      req.headers['react-map-secret'] === config.api.reactMapSecret
+    ) {
+      res.status(200).json({
+        api: {
+          ...config.api,
+          reactMapSecret: undefined,
+        },
+        ...config,
+        database: {
+          ...config.database,
+          schemas: config.api.showSchemasInConfigApi
+            ? config.database.schemas
+            : [],
+        },
+        authentication: {
+          ...config.authentication,
+          strategies: config.api.showStrategiesInConfigApi
+            ? config.authentication.strategies
+            : [],
+        },
+      })
+    } else {
+      throw new Error('Incorrect or missing API secret')
+    }
+    console.log(`[API] api/v1/${path.parse(__filename).name}`)
+  } catch (e) {
+    console.error(`[API Error] api/v1/${path.parse(__filename).name}`, e)
+    res.status(500).json({ status: 'error', reason: e.message })
+  }
+})
+
+module.exports = router

--- a/server/src/services/sessionStore.js
+++ b/server/src/services/sessionStore.js
@@ -14,23 +14,25 @@ const { Session } = require('../models/index')
 
 const dbSelection = schemas.find(({ useFor }) => useFor?.includes('session'))
 
-const sessionStore = new MySQLStore(
-  {
-    clearExpired: true,
-    checkExpirationInterval: sessionCheckIntervalMs,
-    createDatabaseTable: true,
-    schema: {
-      tableName: sessionTableName,
-    },
-  },
-  mysql2.createPool({
-    host: dbSelection.host,
-    port: dbSelection.port,
-    user: dbSelection.username,
-    password: dbSelection.password,
-    database: dbSelection.database,
-  }),
-)
+const sessionStore = dbSelection
+  ? new MySQLStore(
+      {
+        clearExpired: true,
+        checkExpirationInterval: sessionCheckIntervalMs,
+        createDatabaseTable: true,
+        schema: {
+          tableName: sessionTableName,
+        },
+      },
+      mysql2.createPool({
+        host: dbSelection.host,
+        port: dbSelection.port,
+        user: dbSelection.username,
+        password: dbSelection.password,
+        database: dbSelection.database,
+      }),
+    )
+  : null
 
 const isValidSession = async (userId) => {
   try {


### PR DESCRIPTION
- Allows admins to fetch their config so they can see the full config after the merges and mutations have been applied
- Configurable options to include the schemas and authentication strategies for security reasons
- Minor change in sessionStore.js to allow running the map server without any db connections
- Accessible at `https://my_map_url.com/api/v1/config` with your react-map-secret of course