### PR TITLE
Scan Next/Zone Discord Logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactmap",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "React based frontend map.",
   "main": "ReactMap.js",
   "author": "TurtIeSocks <58572875+TurtIeSocks@users.noreply.github.com>",

--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -559,6 +559,8 @@
         "type": "discord",
         "enabled": false,
         "logChannelId": "",
+        "scanNextLogChannelId": "",
+        "scanZoneLogChannelId": "",
         "presence": "Map Status: Online",
         "presenceType": 3,
         "botToken": "",

--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -567,7 +567,8 @@
         "redirectUri": "http://localhost:8080/auth/discord/callback",
         "allowedGuilds": [],
         "blockedGuilds": [],
-        "allowedUsers": []
+        "allowedUsers": [],
+        "thumbnailUrl": "https://user-images.githubusercontent.com/58572875/167069223-745a139d-f485-45e3-a25c-93ec4d09779c.png"
       },
       {
         "name": "telegram",

--- a/server/src/graphql/resolvers.js
+++ b/server/src/graphql/resolvers.js
@@ -333,16 +333,16 @@ module.exports = {
       }
       return {}
     },
-    scanner: (_, args, { perms, serverV, clientV }) => {
+    scanner: (_, args, { req, perms, serverV, clientV }) => {
       if (clientV !== serverV) throw new UserInputError('old_client')
       if (!perms) throw new AuthenticationError('session_expired')
 
       const { category, method, data } = args
       if (category === 'getQueue') {
-        return Fetch.scannerApi(category, method, data)
+        return Fetch.scannerApi(category, method, data, req?.user)
       }
       if (perms?.scanner?.includes(category)) {
-        return Fetch.scannerApi(category, method, data)
+        return Fetch.scannerApi(category, method, data, req?.user)
       }
       return {}
     },

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -150,15 +150,6 @@ app.use(
   }),
 )
 
-config.authentication.strategies.forEach((strategy) => {
-  if (strategy.enabled) {
-    require(`./strategies/${strategy.name}.js`)
-    console.log(`[AUTH] Strategy ${strategy.name} initialized`)
-  } else {
-    console.log(`[AUTH] Strategy ${strategy.name} was not initialized`)
-  }
-})
-
 app.use(passport.initialize())
 
 app.use(passport.session())

--- a/server/src/services/Clients.js
+++ b/server/src/services/Clients.js
@@ -7,7 +7,6 @@ module.exports = Object.fromEntries(
   config.authentication.strategies
     .filter(({ name, enabled }) => {
       if (enabled) {
-        require(resolve(__dirname, `../strategies/${name}.js`))
         console.log(`[AUTH] Strategy ${name} initialized`)
       } else {
         console.log(`[AUTH] Strategy ${name} was not initialized`)

--- a/server/src/services/Clients.js
+++ b/server/src/services/Clients.js
@@ -1,0 +1,28 @@
+/* eslint-disable no-console */
+const { resolve } = require('path')
+
+const config = require('./config')
+
+module.exports = Object.fromEntries(
+  config.authentication.strategies
+    .filter(({ name, enabled }) => {
+      if (enabled) {
+        require(resolve(__dirname, `../strategies/${name}.js`))
+        console.log(`[AUTH] Strategy ${name} initialized`)
+      } else {
+        console.log(`[AUTH] Strategy ${name} was not initialized`)
+      }
+      return !!enabled
+    })
+    .map(({ name }) => {
+      try {
+        return [name, require(resolve(__dirname, `../strategies/${name}.js`))]
+      } catch (e) {
+        console.error(
+          `\nFailed to load ${name} to log scanner requests, this likely means that you are using a non-updated custom strategy, please view the newly updated module.exports found at the bottom of the base strategy file:\n /server/src/strategies/${name}.js.\n`,
+          e.message,
+        )
+        return [name, null]
+      }
+    }),
+)

--- a/server/src/services/Clients.js
+++ b/server/src/services/Clients.js
@@ -13,12 +13,12 @@ module.exports = Object.fromEntries(
       }
       return !!enabled
     })
-    .map(({ name }) => {
+    .map(({ name, type }) => {
       try {
         return [name, require(resolve(__dirname, `../strategies/${name}.js`))]
       } catch (e) {
         console.error(
-          `\nFailed to load ${name} to log scanner requests, this likely means that you are using a non-updated custom strategy, please view the newly updated module.exports found at the bottom of the base strategy file:\n /server/src/strategies/${name}.js.\n`,
+          `\nFailed to load ${name} to log scanner requests, this likely means that you are using a non-updated custom strategy, please view the newly updated module.exports found at the bottom of the base strategy file:\n /server/src/strategies/${type}.js.\nRelevant Changes: https://github.com/WatWowMap/ReactMap/pull/590/files#diff-394ccb49bcfb0f1a2579a922821e914aeb25904dace1658cd251d70f63c5d529`,
           e.message,
         )
         return [name, null]

--- a/server/src/services/DiscordClient.js
+++ b/server/src/services/DiscordClient.js
@@ -12,10 +12,11 @@ const {
 const Utility = require('./Utility')
 
 module.exports = class DiscordMapClient {
-  constructor(client, config, accessToken) {
+  constructor(client, config, logChannelId) {
     this.client = client
     this.config = config
-    this.accessToken = accessToken
+    this.accessToken = null
+    this.logChannelId = logChannelId
     this.discordEvents()
   }
 
@@ -131,12 +132,14 @@ module.exports = class DiscordMapClient {
     return perms
   }
 
-  async sendMessage(channelId, message) {
-    if (!channelId) {
+  async sendMessage(message) {
+    if (!this.logChannelId || typeof message !== 'object') {
       return
     }
     try {
-      const channel = await this.client.channels.cache.get(channelId).fetch()
+      const channel = await this.client.channels.cache
+        .get(this.logChannelId)
+        .fetch()
       if (channel && message) {
         channel.send(message)
       }

--- a/server/src/services/Fetch.js
+++ b/server/src/services/Fetch.js
@@ -26,7 +26,7 @@ module.exports = class Fetch {
     return webhookApi(category, discordId, method, name, data)
   }
 
-  static async scannerApi(category, method, data) {
-    return scannerApi(category, method, data)
+  static async scannerApi(category, method, data, user) {
+    return scannerApi(category, method, data, user)
   }
 }

--- a/server/src/services/logUserAuth.js
+++ b/server/src/services/logUserAuth.js
@@ -1,8 +1,12 @@
 /* eslint-disable no-console */
-const { capitalize } = require('@material-ui/core')
-const Fetch = require('./Fetch')
+const fetch = require('node-fetch')
 
-const capCamel = (str) => capitalize(str.replace(/([a-z](?=[A-Z]))/g, '$1 '))
+const capCamel = (str) =>
+  str
+    .replace(/([a-z](?=[A-Z]))/g, '$1 ')
+    .split(' ')
+    .map((str2) => str2.charAt(0).toUpperCase() + str2.slice(1))
+    .join(' ')
 
 const mapPerms = (perms, userPerms) =>
   perms
@@ -19,14 +23,15 @@ module.exports = async function getAuthInfo(req, user, strategy) {
       '[0-9]+.[0-9].+[0-9]+.[0-9]+$',
     )[0]
 
-  const geo = await Fetch.json(
+  const geo = await fetch(
     `http://ip-api.com/json/${ip}?fields=66846719&lang=en`,
-  )
+  ).catch((err) => console.warn('failed to fetch user information', err))
+
   const embed = {
     color: 0xff0000,
     title: 'Authentication',
     author: {
-      name: `${user.username}`,
+      name: user.username,
       icon_url: `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png`,
     },
     description: `${user.username} ${

--- a/server/src/strategies/discord.js
+++ b/server/src/strategies/discord.js
@@ -31,6 +31,8 @@ const MapClient = new DiscordMapClient(
   client,
   { ...strategyConfig, perms },
   strategyConfig.logChannelId,
+  strategyConfig.scanNextLogChannelId,
+  strategyConfig.scanZoneLogChannelId,
 )
 
 const authHandler = async (req, accessToken, refreshToken, profile, done) => {

--- a/server/src/strategies/discord.js
+++ b/server/src/strategies/discord.js
@@ -27,7 +27,11 @@ client.on('ready', () => {
 
 client.login(strategyConfig.botToken)
 
-const MapClient = new DiscordMapClient(client, { ...strategyConfig, perms })
+const MapClient = new DiscordMapClient(
+  client,
+  { ...strategyConfig, perms },
+  strategyConfig.logChannelId,
+)
 
 const authHandler = async (req, accessToken, refreshToken, profile, done) => {
   if (!req.query.code) {
@@ -40,9 +44,10 @@ const authHandler = async (req, accessToken, refreshToken, profile, done) => {
     user.perms = await MapClient.getPerms(profile)
     user.valid = user.perms.map !== false
     user.blocked = user.perms.blocked
+    user.rmStrategy = path.parse(__filename).name
 
     const embed = await logUserAuth(req, user, 'Discord')
-    await MapClient.sendMessage(strategyConfig.logChannelId, { embed })
+    await MapClient.sendMessage({ embed })
 
     if (user) {
       delete user.guilds
@@ -113,3 +118,5 @@ passport.use(
     authHandler,
   ),
 )
+
+module.exports = MapClient

--- a/server/src/strategies/local.js
+++ b/server/src/strategies/local.js
@@ -35,6 +35,7 @@ const authHandler = async (req, username, password, done) => {
       webhooks: [],
       scanner: [],
     },
+    rmStrategy: path.parse(__filename).name,
   }
 
   try {
@@ -100,3 +101,5 @@ passport.use(
     authHandler,
   ),
 )
+
+module.exports = null

--- a/server/src/strategies/telegram.js
+++ b/server/src/strategies/telegram.js
@@ -23,6 +23,7 @@ const authHandler = async (req, profile, done) => {
       areaRestrictions: [],
       webhooks: [],
     },
+    rmStrategy: path.parse(__filename).name,
   }
 
   const chatInfo = [user.id]
@@ -146,3 +147,5 @@ passport.use(
     authHandler,
   ),
 )
+
+module.exports = null

--- a/src/components/layout/dialogs/scanner/ScanOnDemand.jsx
+++ b/src/components/layout/dialogs/scanner/ScanOnDemand.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-no-useless-fragment */
 import React, { useEffect, useState } from 'react'
 import { useQuery, useLazyQuery } from '@apollo/client'
-import { useStatic, useStore } from '@hooks/useStore'
+import { useStore } from '@hooks/useStore'
 import Query from '@services/Query'
 import ScanNextTarget from './ScanNextTarget'
 import ScanZoneTarget from './ScanZoneTarget'
@@ -27,8 +27,6 @@ export default function ScanOnDemand({
   },
   mode,
 }) {
-  const { loggedIn } = useStatic((state) => state.auth)
-
   const location = useStore((s) => s.location)
 
   const [queue, setQueue] = useState('init')
@@ -44,8 +42,6 @@ export default function ScanOnDemand({
         category: mode,
         method: 'GET',
         data: {
-          username: loggedIn?.username || 'a visitor',
-          userId: loggedIn?.id,
           scanLocation,
           scanCoords,
           scanNextType,
@@ -61,8 +57,6 @@ export default function ScanOnDemand({
         category: 'getQueue',
         method: 'GET',
         data: {
-          username: loggedIn?.username || 'a visitor',
-          userId: loggedIn?.id,
           type: 'scan_next',
           typeName: mode,
         },


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/58572875/195735426-64d7e116-1bf0-481e-ae4a-aee60b107b67.png)

**Important**
- REQUIRES ADJUSTMENTS IF YOU USE A CUSTOM STRATEGY, see the changes to the files in `server/src/strategies` 

**Other notes**
- Version bump
- Add thumbnailUrl to discord strategy object
- pass full req.user to scanner api
- Initialize strategies in a separate file for dynamically collecting all clients
- Rudimentary cache for storing # of requests for users in a given day
- Log to the same channel as authentication reqs
- Remove unused accessToken arg
- Save logChanneld in the class instance
- Remove user info from frontend, collect from request instead
