### PR TITLE
Include Kacleon Stops in Event Stops

### DIFF
--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -519,7 +519,7 @@ module.exports = class Pokestop extends Model {
         if (onlyEventStops && pokestopPerms) {
           stops.orWhere((event) => {
             event
-              .where('display_type', 7)
+              .where('display_type', '>=', 7)
               .andWhere('character', 0)
               .andWhere(
                 multiInvasionMs ? 'expiration_ms' : 'expiration',

--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -42,6 +42,7 @@ Object.keys(questProps).forEach((key) => {
 const invasionProps = {
   incident_expire_timestamp: true,
   grunt_type: true,
+  display_type: true,
 }
 
 module.exports = class Pokestop extends Model {
@@ -590,9 +591,12 @@ module.exports = class Pokestop extends Model {
             (invasion) => !invasion.grunt_type,
           )
           if (filtered.invasions.length) {
-            filtered.display_type = Math.max(
+            const displayType = Math.max(
               ...filtered.invasions.map((inv) => inv.display_type),
             )
+            if (displayType) {
+              filtered.display_type = displayType
+            }
           }
         }
       }

--- a/src/components/popups/Pokestop.jsx
+++ b/src/components/popups/Pokestop.jsx
@@ -162,7 +162,10 @@ export default function PokestopPopup({
                           icon={
                             invasion.grunt_type
                               ? Icons.getInvasions(invasion.grunt_type)
-                              : Icons.getMisc('event_coin')
+                              : {
+                                  7: Icons.getMisc('event_coin'),
+                                  8: Icons.getPokemon(352),
+                                }[pokestop.display_type]
                           }
                           until
                           tt={`grunt_a_${invasion.grunt_type}`}


### PR DESCRIPTION
This should change the event stop query so that it includes all display types >= 7. Right now this only includes the Coin and Kacleon Stops. This is assuming that future event stops work the same way.

Untested