### PR TITLE
Crank up timeout from 4s to 10s

### DIFF
--- a/src/services/apollo/RobustTimeout.js
+++ b/src/services/apollo/RobustTimeout.js
@@ -9,7 +9,7 @@ export default class RobustTimeout extends AbortableContext {
 
   doRefetch(variables) {
     const now = Date.now()
-    if (now - this._lastUpdated < (this._pendingOp.length ? 4000 : 500)) {
+    if (now - this._lastUpdated < (this._pendingOp.length ? 10000 : 500)) {
       if (variables !== undefined) {
         this._pendingVariables = variables
       }


### PR DESCRIPTION
This might make reactmap loading work under slow mobile networks.