### PR TITLE
Robust timeout v2

### DIFF
--- a/src/services/apollo/AbortableContext.js
+++ b/src/services/apollo/AbortableContext.js
@@ -6,8 +6,9 @@ import { Observable } from '@apollo/client/utilities/observables/Observable'
  * @author Mygod
  */
 export default class AbortableContext {
-  constructor() {
+  constructor(error = 'Request aborted') {
     this._pendingOp = null
+    this._error = error
   }
 
   _abort() {
@@ -32,7 +33,7 @@ export default class AbortableContext {
       operation.setContext({ fetchOptions })
     }
 
-    observer.error(new Error('Request aborted'))
+    if (this._error) observer.error(new Error(this._error))
     subscription.unsubscribe()
   }
 

--- a/src/services/apollo/AbortableContext.js
+++ b/src/services/apollo/AbortableContext.js
@@ -7,44 +7,33 @@ import { Observable } from '@apollo/client/utilities/observables/Observable'
  */
 export default class AbortableContext {
   constructor() {
-    this._pendingOp = []
+    this._pendingOp = null
   }
 
-  abortAll() {
-    this._pendingOp.forEach(
-      ({ controller, operation, observer, subscription }) => {
-        controller.abort() // abort fetch operation
+  _abort() {
+    if (!this._pendingOp) return
+    const { controller, operation, observer, subscription } = this._pendingOp
+    controller.abort() // abort fetch operation
 
-        // if the AbortController in the operation context is one we created,
-        // it's now "used up", so we need to remove it to avoid blocking any
-        // future retry of the operation.
-        const context = operation.getContext()
-        let fetchOptions = context.fetchOptions || {}
-        if (
-          fetchOptions.controller === controller &&
-          fetchOptions.signal === controller.signal
-        ) {
-          fetchOptions = {
-            ...fetchOptions,
-            controller: null,
-            signal: null,
-          }
-          operation.setContext({ fetchOptions })
-        }
+    // if the AbortController in the operation context is one we created,
+    // it's now "used up", so we need to remove it to avoid blocking any
+    // future retry of the operation.
+    const context = operation.getContext()
+    let fetchOptions = context.fetchOptions || {}
+    if (
+      fetchOptions.controller === controller &&
+      fetchOptions.signal === controller.signal
+    ) {
+      fetchOptions = {
+        ...fetchOptions,
+        controller: null,
+        signal: null,
+      }
+      operation.setContext({ fetchOptions })
+    }
 
-        observer.error(new Error('Request aborted'))
-        subscription.unsubscribe()
-      },
-    )
-    this._pendingOp = []
-  }
-
-  _removeOp(op) {
-    const i = this._pendingOp.indexOf(op)
-    if (i === -1) return
-    const last = this._pendingOp.length - 1
-    if (last > 0) this._pendingOp[i] = this._pendingOp[last]
-    this._pendingOp.pop()
+    observer.error(new Error('Request aborted'))
+    subscription.unsubscribe()
   }
 
   handle(operation, forward) {
@@ -76,22 +65,23 @@ export default class AbortableContext {
       // listen to chainObservable for result and pass to localObservable if received before timeout
       const subscription = chainObservable.subscribe(
         (result) => {
-          this._removeOp(op)
+          this._pendingOp = null
           observer.next(result)
           observer.complete()
         },
         (error) => {
-          this._removeOp(op)
+          this._pendingOp = null
           observer.error(error)
           observer.complete()
         },
       )
       op.subscription = subscription
-      this._pendingOp.push(op)
+      this._abort()
+      this._pendingOp = op
 
       // this function is called when a client unsubscribes from localObservable
       return () => {
-        this._removeOp(op)
+        this._pendingOp = null
         subscription.unsubscribe()
       }
     })

--- a/src/services/apollo/RobustTimeout.js
+++ b/src/services/apollo/RobustTimeout.js
@@ -9,14 +9,13 @@ export default class RobustTimeout extends AbortableContext {
 
   doRefetch(variables) {
     const now = Date.now()
-    if (now - this._lastUpdated < (this._pendingOp.length ? 4000 : 500)) {
+    if (now - this._lastUpdated < (this._pendingOp ? 4000 : 500)) {
       if (variables !== undefined) {
         this._pendingVariables = variables
       }
       return
     }
     this._lastUpdated = now
-    this.abortAll()
     if (this._ms) {
       clearTimeout(this.timeout)
       this.timeout = setTimeout(() => this.doRefetch(), this._ms)

--- a/src/services/apollo/RobustTimeout.js
+++ b/src/services/apollo/RobustTimeout.js
@@ -9,7 +9,7 @@ export default class RobustTimeout extends AbortableContext {
 
   doRefetch(variables) {
     const now = Date.now()
-    if (now - this._lastUpdated < (this._pendingOp ? 4000 : 500)) {
+    if (now - this._lastUpdated < (this._pendingOp ? 5000 : 500)) {
       if (variables !== undefined) {
         this._pendingVariables = variables
       }

--- a/src/services/apollo/RobustTimeout.js
+++ b/src/services/apollo/RobustTimeout.js
@@ -2,7 +2,7 @@ import AbortableContext from './AbortableContext'
 
 export default class RobustTimeout extends AbortableContext {
   constructor(ms) {
-    super()
+    super(null)
     this._ms = ms
     this._lastUpdated = 0
   }


### PR DESCRIPTION
Should fix the following issues:

* When the querydata is being created for the first time, the connection is not subject to timeout.
* When the query was aborted, the old data is being removed and an error pops out.