### PR TITLE
Logging Adjustments & Docker Fixes

### DIFF
--- a/ReactMap.js
+++ b/ReactMap.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable import/extensions */
-process.env.FORCE_COLOR = 1
+process.env.FORCE_COLOR = 3
 
 const { build } = require('vite')
 const { log, HELPERS } = require('./server/src/services/logger')

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -16,7 +16,6 @@ services:
       SCANNER_DB_NAME: scanner_db
 
       # Your ReactMap Database
-      # optional, but recommended, if omitted it will default to your manual database
       REACT_MAP_DB_HOST: 127.0.0.1
       REACT_MAP_DB_PORT: 3306
       REACT_MAP_DB_USERNAME: react_map_username
@@ -24,11 +23,11 @@ services:
       REACT_MAP_DB_NAME: react_map_db
 
       # Your Manual Database (Optional - Nests & Portals)
-      MANUAL_DB_HOST: 127.0.0.1
-      MANUAL_DB_PORT: 3306
-      MANUAL_DB_USERNAME: manual_username
-      MANUAL_DB_PASSWORD: manual_user_pw
-      MANUAL_DB_NAME: manual_db
+      # MANUAL_DB_HOST: 127.0.0.1
+      # MANUAL_DB_PORT: 3306
+      # MANUAL_DB_USERNAME: manual_username
+      # MANUAL_DB_PASSWORD: manual_user_pw
+      # MANUAL_DB_NAME: manual_db
 
       # Other config values - the below env vars will override anything, including `local.json`
       # More config values you can add:
@@ -53,7 +52,7 @@ services:
       - no-new-privileges:true
 
     ports:
-      - '9090:8080'
+      - '9090:8080' # change left one for external port
   # nginx:
   #   image: nginx
   #   container_name: nginx

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,5 +1,5 @@
 process.title = 'ReactMap'
-process.env.FORCE_COLOR = 1
+process.env.FORCE_COLOR = 3
 
 const path = require('path')
 const express = require('express')
@@ -96,11 +96,12 @@ const server = new ApolloServer({
     const returned = data?.data?.[endpoint]?.length || 0
     log.info(
       HELPERS.gql,
-      'Endpoint:',
-      endpoint,
-      'Returned:',
+      HELPERS[endpoint] || `[${endpoint?.toUpperCase()}]`,
+      '|',
+      context.operationName,
+      '|',
       returned || 0,
-      'User:',
+      '|',
       context.context.req?.user?.username || 'Not Logged In',
     )
     return data
@@ -237,9 +238,10 @@ connection.migrate.latest().then(async () => {
       (config.areas = await getAreas()),
     ]).then(() => {
       app.listen(config.port, config.interface, () => {
-        rainbow(
+        const text = rainbow(
           `Server is now listening at http://${config.interface}:${config.port}`,
         )
+        setTimeout(() => text.stop(), 10_000)
       })
     })
   })

--- a/server/src/services/areas.js
+++ b/server/src/services/areas.js
@@ -48,6 +48,7 @@ const getGeojson = async (location) => {
         .then((res) => res.json())
         .then((res) => {
           if (res?.data) {
+            log.info(HELPERS.areas, 'Caching', location, 'from Kōji')
             fs.writeFileSync(
               resolve(
                 __dirname,

--- a/server/src/services/config.js
+++ b/server/src/services/config.js
@@ -136,10 +136,10 @@ if (!fs.existsSync(resolve(`${__dirname}/../configs/local.json`))) {
         ? ['nest', 'portal']
         : ['session', 'user', 'nest', 'portal'],
     })
-  } else {
+  } else if (!hasReactMapDb) {
     log.error(
       HELPERS.config,
-      'Missing manual database config! \nCheck to make sure you have MANUAL_DB_HOST,MANUAL_DB_PORT, MANUAL_DB_NAME, MANUAL_DB_USERNAME, and MANUAL_DB_PASSWORD',
+      'Neither a ReactMap database or Manual database was found, you will need one of these to proceed.',
     )
   }
   if (!MAP_GENERAL_START_LAT || !MAP_GENERAL_START_LON) {
@@ -154,6 +154,25 @@ if (fs.existsSync(resolve(`${__dirname}/../configs/config.json`))) {
     HELPERS.config,
     'Config v1 (config.json) found, it is fine to leave it but make sure you are using and updating local.json instead.',
   )
+}
+
+if (config.icons.styles.length === 0) {
+  config.icons.styles.push({
+    name: 'Default',
+    path: 'https://raw.githubusercontent.com/WatWowMap/wwm-uicons/main/',
+    modifiers: {
+      gym: {
+        0: 1,
+        1: 1,
+        2: 1,
+        3: 3,
+        4: 4,
+        5: 4,
+        6: 18,
+        sizeMultiplier: 1.2,
+      },
+    },
+  })
 }
 
 const checkExtraJsons = (fileName, domain = '') => {

--- a/server/src/services/geocoder.js
+++ b/server/src/services/geocoder.js
@@ -1,5 +1,5 @@
 const NodeGeocoder = require('node-geocoder')
-const { log } = require('./logger')
+const { log, HELPERS } = require('./logger')
 
 module.exports = async function geocoder(nominatimUrl, search, reverse) {
   try {
@@ -22,7 +22,7 @@ module.exports = async function geocoder(nominatimUrl, search, reverse) {
       : await stockGeocoder.geocode(search)
     return reverse ? results[0] : results
   } catch (e) {
-    log.warn('[GEOCODER] Unable to geocode for', search, e)
+    log.warn(HELPERS.geocoder, 'Unable to geocode for', search, e)
     return {}
   }
 }

--- a/server/src/services/logger.js
+++ b/server/src/services/logger.js
@@ -30,10 +30,24 @@ const HELPERS = {
   db: chalk.hex('#aa00ff')('[DB]'),
   event: chalk.hex('#283593')('[EVENT]'),
   webhooks: chalk.hex('#1de9b6')('[WEBHOOKS]'),
-  pokemon: chalk.hex('#ffc107')('[POKEMON]'),
+  geocoder: chalk.hex('#ff5722')('[GEOCODER]'),
   fetch: chalk.hex('#880e4f')('[FETCH]'),
   scanner: chalk.hex('#b39ddb')('[SCANNER]'),
   build: chalk.hex('#ef6c00')('[BUILD]'),
+
+  pokemon: chalk.hex('#f44336')('[POKEMON]'),
+  pokestops: chalk.hex('#e91e63')('[POKESTOPS]'),
+  gyms: chalk.hex('#9c27b0')('[GYMS]'),
+  weather: chalk.hex('#3f51b5')('[WEATHER]'),
+  available: chalk.hex('#2196f3')('[AVAILABLE]'),
+  scanAreas: chalk.hex('#00bcd4')('[SCAN AREAS]'),
+  scanAreasMenu: chalk.hex('#009688')('[SCAN AREAS MENU]'),
+  submissionCells: chalk.hex('#4caf50')('[SUBMISSION CELLS]'),
+  spawnpoints: chalk.hex('#8bc34a')('[SPAWNPOINTS]'),
+  scanCells: chalk.hex('#ffeb3b')('[SCAN CELLS]'),
+  s2cells: chalk.hex('#ffc107')('[S2 CELLS]'),
+  devices: chalk.hex('#ff9800')('[DEVICE]'),
+
   custom: (text, color = '#64b5f6') => chalk.hex(color)(`[${text}]`),
 }
 


### PR DESCRIPTION
- Adjust docker-compose example for clarity
- Force color level 3
- Make the main data log more informative
- Push the default uicons set when none are present, e.g. docker use
- Add some more colors for different endpoints
- Timer on server startup log animation
