### PR TITLE
use plain objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactmap",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "React based frontend map.",
   "main": "ReactMap.js",
   "author": "TurtIeSocks <58572875+TurtIeSocks@users.noreply.github.com>",

--- a/server/scripts/generateMasterfile.js
+++ b/server/scripts/generateMasterfile.js
@@ -14,11 +14,7 @@ Object.entries(defaultRarity).forEach(([tier, pokemon]) => {
   }
 })
 
-const generate = async (
-  save = false,
-  historicRarity = new Map(),
-  dbRarity = new Map(),
-) => {
+const generate = async (save = false, historicRarity = {}, dbRarity = {}) => {
   try {
     if (!api.pogoApiEndpoints.masterfile)
       throw new Error('No masterfile endpoint')
@@ -31,11 +27,11 @@ const generate = async (
         Object.values(masterfile.pokemon).map((pokemon) => {
           const { legendary, mythical, ultraBeast } = pokemon
           const historic =
-            historicRarity.get(pokemon.pokedexId.toString()) || 'never'
+            historicRarity[pokemon.pokedexId.toString()] || 'never'
 
           let rarity =
             (dbRarity.size
-              ? dbRarity.get(`${pokemon.pokedexId}-${pokemon.defaultFormId}`)
+              ? dbRarity[`${pokemon.pokedexId}-${pokemon.defaultFormId}`]
               : rarityObj[pokemon.pokedexId]) || 'never'
           if (legendary) rarity = 'legendary'
           if (mythical) rarity = 'mythical'
@@ -50,7 +46,7 @@ const generate = async (
                 rarity:
                   +formId === pokemon.defaultFormId
                     ? rarity
-                    : dbRarity.get(`${pokemon.pokedexId}-${formId}`) || 'never',
+                    : dbRarity[`${pokemon.pokedexId}-${formId}`] || 'never',
               },
             ]),
           )

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -53,7 +53,11 @@ const apolloServer = new ApolloServer({
     if (e?.message.includes('skipUndefined()') || e?.message === 'old_client') {
       log.info(
         HELPERS.gql,
-        'Old client detected, forcing user to refresh, no need to report this error unless it continues to happen\nClient:',
+        'Old client detected, forcing user to refresh, no need to report this error unless it continues to happen',
+      )
+      log.info(
+        HELPERS.gql,
+        'Client:',
         e.extensions.clientV,
         'Server:',
         e.extensions.serverV,

--- a/server/src/services/DbCheck.js
+++ b/server/src/services/DbCheck.js
@@ -27,8 +27,8 @@ module.exports = class DbCheck {
     this.models = {}
     this.questConditions = {}
     this.endpoints = {}
-    this.rarity = new Map()
-    this.historical = new Map()
+    this.rarity = {}
+    this.historical = {}
     this.connections = dbSettings.schemas
       .filter((s) => s.useFor.length)
       .map((schema, i) => {
@@ -214,18 +214,19 @@ module.exports = class DbCheck {
         },
       )
     })
+    this[mapKey] = {}
     Object.entries(base).forEach(([id, count]) => {
       const percent = (count / total) * 100
       if (percent === 0) {
-        this[mapKey].set(id, 'never')
+        this[mapKey][id] = 'never'
       } else if (percent < this.rarityPercents.ultraRare) {
-        this[mapKey].set(id, 'ultraRare')
+        this[mapKey][id] = 'ultraRare'
       } else if (percent < this.rarityPercents.rare) {
-        this[mapKey].set(id, 'rare')
+        this[mapKey][id] = 'rare'
       } else if (percent < this.rarityPercents.uncommon) {
-        this[mapKey].set(id, 'uncommon')
+        this[mapKey][id] = 'uncommon'
       } else {
-        this[mapKey].set(id, 'common')
+        this[mapKey][id] = 'common'
       }
     })
   }
@@ -317,21 +318,21 @@ module.exports = class DbCheck {
   static deDupeResults(results) {
     if (results.length === 1) return results[0]
     if (results.length > 1) {
-      const returnObj = new Map()
+      const returnObj = {}
       const { length } = results
       for (let i = 0; i < length; i += 1) {
         const { length: subLength } = results[i]
         for (let j = 0; j < subLength; j += 1) {
           const item = results[i][j]
           if (
-            !returnObj.has(item.id) ||
-            item.updated > returnObj.get(item.id).updated
+            !returnObj[item.id] ||
+            item.updated > returnObj[item.id].updated
           ) {
-            returnObj.set(item.id, item)
+            returnObj[item.id] = item
           }
         }
       }
-      return [...returnObj.values()]
+      return Object.values(returnObj)
     }
     return []
   }

--- a/server/src/services/filters/pokemon/Backend.js
+++ b/server/src/services/filters/pokemon/Backend.js
@@ -134,6 +134,7 @@ module.exports = class PkmnBackend {
       orStr,
       merged,
     })
+
     return merged
   }
 
@@ -232,9 +233,6 @@ module.exports = class PkmnBackend {
     return { filtered, best }
   }
 
-  /**
-   * @returns {object}
-   */
   buildApiFilter() {
     const {
       enabled: _enabled,


### PR DESCRIPTION
- Replaces a couple of other places that previously used JS Maps with just plain objects, since they seem to be somewhat prone to memory leaks
- Fixes a log that was writing to a new line without a tag
- Fixes a jsdoc return type