### PR TITLE
User feedback on Discord guild blocking & no map access

### DIFF
--- a/public/base-locales/en.json
+++ b/public/base-locales/en.json
@@ -597,5 +597,8 @@
   "enable_pokemon_popup_coords": "Show Pokémon Coords",
   "enable_gym_popup_coords": "Show Gym Coords",
   "enable_pokestop_popup_coords": "Show Pokéstop Coords",
-  "enable_portal_popup_coords": "Show Portal Coords"
+  "enable_portal_popup_coords": "Show Portal Coords",
+  "on_block_join_discord": "Please join our discord for more information.",
+  "on_block_msg": "You have been blocked for being a member of",
+  "denied": "Denied"
 }

--- a/server/src/routes/authRouter.js
+++ b/server/src/routes/authRouter.js
@@ -26,7 +26,7 @@ strategies.forEach((strategy, i) => {
           return next(err)
         }
         if (!user) {
-          res.status(401).json(info.message)
+          res.redirect(`/blocked/${encodeURIComponent(info.message)}`)
         } else {
           try {
             return req.login(user, async () => {

--- a/server/src/routes/authRouter.js
+++ b/server/src/routes/authRouter.js
@@ -26,7 +26,11 @@ strategies.forEach((strategy, i) => {
           return next(err)
         }
         if (!user) {
-          res.redirect(`/blocked/${encodeURIComponent(info.message)}`)
+          res.redirect(
+            `/blocked/${encodeURIComponent(
+              new URLSearchParams(info).toString(),
+            )}`,
+          )
         } else {
           try {
             return req.login(user, async () => {

--- a/server/src/routes/clientRouter.js
+++ b/server/src/routes/clientRouter.js
@@ -7,6 +7,7 @@ const router = new express.Router()
 const clientRoutes = [
   '/',
   '/login',
+  '/blocked/:blockedGuilds',
   '/@/:lat/:lon/:zoom?',
   '/id/:category/:id/:zoom?',
   '/304',

--- a/server/src/routes/clientRouter.js
+++ b/server/src/routes/clientRouter.js
@@ -7,7 +7,7 @@ const router = new express.Router()
 const clientRoutes = [
   '/',
   '/login',
-  '/blocked/:blockedGuilds',
+  '/blocked/:info',
   '/@/:lat/:lon/:zoom?',
   '/id/:category/:id/:zoom?',
   '/304',

--- a/server/src/services/DiscordClient.js
+++ b/server/src/services/DiscordClient.js
@@ -253,11 +253,11 @@ module.exports = class DiscordClient {
       this.sendMessage(embed)
 
       if (user.perms.blocked) {
-        const guildArray = Array.from(user.perms.blockedGuildNames)
+        const guildArray = [...user.perms.blockedGuildNames]
         const lastGuild = guildArray.pop()
         const guildString =
           guildArray.length === 1
-            ? `${guildArray.join(', ')} & ${lastGuild} `
+            ? `${guildArray.join(', ')} & ${lastGuild}`
             : lastGuild
         return done(null, false, {
           message: guildString,

--- a/server/src/services/DiscordClient.js
+++ b/server/src/services/DiscordClient.js
@@ -260,7 +260,7 @@ module.exports = class DiscordClient {
             ? guildArray.join(', ') + ' & ' + lastGuild
             : lastGuild
         return done(null, false, {
-          message: `You have been blocked for being a member of ${guildString}.`,
+          message: guildString,
         })
       }
       if (user) {

--- a/server/src/services/DiscordClient.js
+++ b/server/src/services/DiscordClient.js
@@ -259,9 +259,10 @@ module.exports = class DiscordClient {
           guildArray.length === 1
             ? `${guildArray.join(', ')} & ${lastGuild}`
             : lastGuild
-        return done(null, false, {
-          message: guildString,
-        })
+        return done(null, false, { blockedGuilds: guildString })
+      }
+      if (user.perms.map === false) {
+        return done(null, false, { message: 'access_denied' })
       }
       if (user) {
         delete user.guilds

--- a/server/src/services/DiscordClient.js
+++ b/server/src/services/DiscordClient.js
@@ -139,9 +139,6 @@ module.exports = class DiscordClient {
               : new Set([currentGuildName])
           }
         }
-        if (perms.blocked === true) {
-          return perms
-        }
         await Promise.all(
           this.strategy.allowedGuilds.map(async (guildId) => {
             if (guilds.includes(guildId)) {
@@ -253,7 +250,7 @@ module.exports = class DiscordClient {
       this.sendMessage(embed)
 
       if (user.perms.blocked) {
-        const guildArray = [...user.perms.blockedGuildNames]
+        const guildArray = user.perms.blockedGuildNames
         const lastGuild = guildArray.pop()
         const guildString =
           guildArray.length === 1

--- a/server/src/services/DiscordClient.js
+++ b/server/src/services/DiscordClient.js
@@ -114,7 +114,6 @@ module.exports = class DiscordClient {
     }
 
     try {
-      const { guildsFull } = user
       const guilds = user.guilds.map((guild) => guild.id)
       if (this.strategy.allowedUsers.includes(user.id)) {
         Object.keys(this.perms).forEach((key) => (perms[key] = true))
@@ -127,12 +126,21 @@ module.exports = class DiscordClient {
           `User ${user.username} (${user.id}) in allowed users list, skipping guild and role check.`,
         )
       } else {
+        const guildsFull = user.guilds
         for (let i = 0; i < this.strategy.blockedGuilds.length; i += 1) {
           const guildId = this.strategy.blockedGuilds[i]
           if (guilds.includes(guildId)) {
-            perms.blocked = !!guildsFull.find((x) => x.id === guildId)
-            return perms
+            perms.blocked = true
+            const currentGuildName = guildsFull.find(
+              (x) => x.id === guildId,
+            ).name
+            perms.blockedGuildNames = perms.blockedGuildNames
+              ? perms.blockedGuildNames.add(currentGuildName)
+              : new Set([currentGuildName])
           }
+        }
+        if (perms.blocked === true) {
+          return perms
         }
         await Promise.all(
           this.strategy.allowedGuilds.map(async (guildId) => {
@@ -245,7 +253,15 @@ module.exports = class DiscordClient {
       this.sendMessage(embed)
 
       if (user.perms.blocked) {
-        return done(null, false)
+        const guildArray = Array.from(user.perms.blockedGuildNames)
+        const lastGuild = guildArray.pop()
+        const guildString =
+          guildArray.length === 1
+            ? guildArray.join(', ') + ' & ' + lastGuild
+            : lastGuild
+        return done(null, false, {
+          message: `You have been blocked for being a member of ${guildString}.`,
+        })
       }
       if (user) {
         delete user.guilds

--- a/server/src/services/DiscordClient.js
+++ b/server/src/services/DiscordClient.js
@@ -257,7 +257,7 @@ module.exports = class DiscordClient {
         const lastGuild = guildArray.pop()
         const guildString =
           guildArray.length === 1
-            ? guildArray.join(', ') + ' & ' + lastGuild
+            ? `${guildArray.join(', ')} & ${lastGuild} `
             : lastGuild
         return done(null, false, {
           message: guildString,

--- a/server/src/services/logUserAuth.js
+++ b/server/src/services/logUserAuth.js
@@ -165,7 +165,7 @@ module.exports = async function getAuthInfo(req, user, strategy = 'custom') {
     )
     embed.color = 0x00ff00
   } else if (user.perms?.blocked) {
-    const blockedGuilds = Array.from(user.perms.blockedGuildNames).join(', ')
+    const blockedGuilds = [...user.perms.blockedGuildNames].join(', ')
     log.warn(
       HELPERS.custom(strategy, '#7289da'),
       user.id,

--- a/server/src/services/logUserAuth.js
+++ b/server/src/services/logUserAuth.js
@@ -165,7 +165,7 @@ module.exports = async function getAuthInfo(req, user, strategy = 'custom') {
     )
     embed.color = 0x00ff00
   } else if (user.perms?.blocked) {
-    const blockedGuilds = [...user.perms.blockedGuildNames].join(', ')
+    const blockedGuilds = user.perms.blockedGuildNames.join(', ')
     log.warn(
       HELPERS.custom(strategy, '#7289da'),
       user.id,

--- a/server/src/services/logUserAuth.js
+++ b/server/src/services/logUserAuth.js
@@ -165,13 +165,14 @@ module.exports = async function getAuthInfo(req, user, strategy = 'custom') {
     )
     embed.color = 0x00ff00
   } else if (user.perms?.blocked) {
+    const blockedGuilds = Array.from(user.perms.blockedGuildNames).join(', ')
     log.warn(
       HELPERS.custom(strategy, '#7289da'),
       user.id,
       'Blocked due to',
-      user.blocked,
+      blockedGuilds,
     )
-    embed.description = `User Blocked Due to ${user.blocked}`
+    embed.description = `User Blocked Due to ${blockedGuilds}`
     embed.color = 0xff0000
   } else {
     log.warn(

--- a/src/components/ReactRouter.jsx
+++ b/src/components/ReactRouter.jsx
@@ -3,6 +3,7 @@ import { Route, Routes } from 'react-router-dom'
 
 import Auth from './layout/auth/Auth'
 import Login from './layout/auth/Login'
+import Blocked from './layout/auth/Blocked'
 import Errors from './Errors'
 import ClearStorage from './ClearStorage'
 
@@ -30,6 +31,10 @@ export default function ReactRouter({ serverSettings, getServerSettings }) {
             getServerSettings={getServerSettings}
           />
         }
+      />
+      <Route
+        path="blocked/:guilds"
+        element={<Blocked serverSettings={serverSettings} />}
       />
       <Route path="@/:lat/:lon" element={authRoute} />
       <Route path="@/:lat/:lon/:zoom" element={authRoute} />

--- a/src/components/ReactRouter.jsx
+++ b/src/components/ReactRouter.jsx
@@ -33,7 +33,7 @@ export default function ReactRouter({ serverSettings, getServerSettings }) {
         }
       />
       <Route
-        path="blocked/:guilds"
+        path="blocked/:info"
         element={<Blocked serverSettings={serverSettings} />}
       />
       <Route path="@/:lat/:lon" element={authRoute} />

--- a/src/components/layout/auth/Blocked.jsx
+++ b/src/components/layout/auth/Blocked.jsx
@@ -51,7 +51,7 @@ export default function Blocked({ serverSettings }) {
       >
         <Grid
           item
-          xs={serverSettings.config.map.discordInvite ? t('go_back') : 10}
+          xs={serverSettings.config.map.discordInvite ? 3 : 10}
           sm={serverSettings.config.map.discordInvite ? 3 : 10}
           style={{
             textAlign: 'center',
@@ -69,7 +69,7 @@ export default function Blocked({ serverSettings }) {
         {serverSettings.config.map.discordInvite && (
           <Grid
             item
-            xs={t('join')}
+            xs={3}
             sm={3}
             style={{ textAlign: 'center', marginTop: 20 }}
           >

--- a/src/components/layout/auth/Blocked.jsx
+++ b/src/components/layout/auth/Blocked.jsx
@@ -1,15 +1,12 @@
 /* eslint-disable react/no-array-index-key */
 import React from 'react'
+import { useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { Grid, Typography, Button } from '@material-ui/core'
 
-function decodeQueryParam(p) {
-  return decodeURIComponent(p.replace(/\+/g, ' '))
-}
-
 export default function Blocked({ serverSettings }) {
   const { t } = useTranslation()
-  const params = window.location.href.split('/').pop()
+  const { guilds } = useParams()
 
   return (
     <Grid
@@ -24,14 +21,18 @@ export default function Blocked({ serverSettings }) {
           {t('access')} {t('denied')}!
         </Typography>
       </Grid>
+      <br />
+      <br />
+
       <Grid item>
         <Typography variant="h6" style={{ color: 'white' }} align="center">
-          {t('on_block_msg')} {decodeQueryParam(params)}.
+          {t('on_block_msg')} {guilds}.
         </Typography>
       </Grid>
 
       {serverSettings.config.map.discordInvite && (
         <Grid item>
+          <br />
           <Typography variant="h6" style={{ color: 'white' }} align="center">
             {t('on_block_join_discord')}
           </Typography>
@@ -73,7 +74,7 @@ export default function Blocked({ serverSettings }) {
               variant="outlined"
               color="secondary"
               onClick={() =>
-                (window.location = serverSettings.config.map.discordInvite)
+                window.open(serverSettings.config.map.discordInvite, '_blank')
               }
             >
               {t('join')}

--- a/src/components/layout/auth/Blocked.jsx
+++ b/src/components/layout/auth/Blocked.jsx
@@ -1,0 +1,90 @@
+/* eslint-disable react/no-array-index-key */
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Grid, Typography, Button } from '@material-ui/core'
+
+function decodeQueryParam(p) {
+  return decodeURIComponent(p.replace(/\+/g, ' '))
+}
+
+export default function Blocked({ serverSettings }) {
+  const { t } = useTranslation()
+  const params = window.location.href.split('/').pop()
+
+  return (
+    <Grid
+      container
+      direction="column"
+      justifyContent="center"
+      alignItems="center"
+      style={{ minHeight: '95vh' }}
+    >
+      <Grid item>
+        <Typography variant="h3" style={{ color: 'white' }} align="center">
+          {t('access')} {t('denied')}!
+        </Typography>
+      </Grid>
+      <Grid item>
+        <Typography variant="h6" style={{ color: 'white' }} align="center">
+          {/* {`You have been blocked for being a member of `} */}
+          {t('on_block_msg') + ' '}
+          {decodeQueryParam(params)}
+          {'.'}
+        </Typography>
+      </Grid>
+
+      {serverSettings.config.map.discordInvite && (
+        <Grid item>
+          <Typography variant="h6" style={{ color: 'white' }} align="center">
+            {/* {`Please join our discord for more information.`} */}
+            {t('on_block_join_discord')}
+          </Typography>
+        </Grid>
+      )}
+
+      <Grid
+        container
+        item
+        justifyContent="center"
+        alignItems="center"
+        style={{ marginTop: 20, paddingTop: 20, marginBottom: 20 }}
+      >
+        <Grid
+          item
+          xs={serverSettings.config.map.discordInvite ? t('go_back') : 10}
+          sm={serverSettings.config.map.discordInvite ? 3 : 10}
+          style={{
+            textAlign: 'center',
+            marginTop: serverSettings.config.map.discordAuthUrl ? 20 : 0,
+          }}
+        >
+          <Button
+            variant="outlined"
+            color="secondary"
+            onClick={() => (window.location = window.location.origin)}
+          >
+            {t('go_back')}
+          </Button>
+        </Grid>
+        {serverSettings.config.map.discordInvite && (
+          <Grid
+            item
+            xs={t('join')}
+            sm={3}
+            style={{ textAlign: 'center', marginTop: 20 }}
+          >
+            <Button
+              variant="outlined"
+              color="secondary"
+              onClick={() =>
+                (window.location = serverSettings.config.map.discordInvite)
+              }
+            >
+              {t('join')}
+            </Button>
+          </Grid>
+        )}
+      </Grid>
+    </Grid>
+  )
+}

--- a/src/components/layout/auth/Blocked.jsx
+++ b/src/components/layout/auth/Blocked.jsx
@@ -26,17 +26,13 @@ export default function Blocked({ serverSettings }) {
       </Grid>
       <Grid item>
         <Typography variant="h6" style={{ color: 'white' }} align="center">
-          {/* {`You have been blocked for being a member of `} */}
-          {t('on_block_msg') + ' '}
-          {decodeQueryParam(params)}
-          {'.'}
+          {t('on_block_msg')} {decodeQueryParam(params)}.
         </Typography>
       </Grid>
 
       {serverSettings.config.map.discordInvite && (
         <Grid item>
           <Typography variant="h6" style={{ color: 'white' }} align="center">
-            {/* {`Please join our discord for more information.`} */}
             {t('on_block_join_discord')}
           </Typography>
         </Grid>

--- a/src/components/layout/auth/Blocked.jsx
+++ b/src/components/layout/auth/Blocked.jsx
@@ -6,7 +6,8 @@ import { Grid, Typography, Button } from '@material-ui/core'
 
 export default function Blocked({ serverSettings }) {
   const { t } = useTranslation()
-  const { guilds } = useParams()
+  const { info } = useParams()
+  const queryParams = new URLSearchParams(info)
 
   return (
     <Grid
@@ -24,11 +25,13 @@ export default function Blocked({ serverSettings }) {
       <br />
       <br />
 
-      <Grid item>
-        <Typography variant="h6" style={{ color: 'white' }} align="center">
-          {t('on_block_msg')} {guilds}.
-        </Typography>
-      </Grid>
+      {queryParams.get('blockedGuilds') && (
+        <Grid item>
+          <Typography variant="h6" style={{ color: 'white' }} align="center">
+            {t('on_block_msg')} {queryParams.get('blockedGuilds')}.
+          </Typography>
+        </Grid>
+      )}
 
       {serverSettings.config.map.discordInvite && (
         <Grid item>


### PR DESCRIPTION
# Problem
Discord guild blocking has been broken for a while maybe since the MapJS port? It was never a major issue but the current implementation definitely doesn't look correct. Currently when a user attempts to sign-in and is included in a blocked Discord Guild they will return to the login page and no discord alert is ever sent.


<details>
<summary>
Server side error before this PR
</summary>

    ℹ 2023-06-22 00:59:30 [EVENT] Added Spinda Key: 327-0 to masterfile. (pokestops)
    Server is now listening at http://0.0.0.0:8060
    Server is now listening at http://0.0.0.0:8060
    ⚠ 2023-06-22 00:59:41 [DISCORD] Failed to get perms for user 130865078219046915 TypeError: Cannot read properties of undefined (reading 'find')
        at DiscordClient.getPerms (/Users/clayton/src/scanner/ReactMap/server/src/services/DiscordClient.js:133:42)
        at DiscordClient.authHandler (/Users/clayton/src/scanner/ReactMap/server/src/services/DiscordClient.js:240:27)
        at Strategy._verify (/Users/clayton/src/scanner/ReactMap/server/src/services/DiscordClient.js:334:27)
        at /Users/clayton/src/scanner/ReactMap/node_modules/passport-oauth2/lib/strategy.js:198:24
        at /Users/clayton/src/scanner/ReactMap/node_modules/passport-discord/lib/strategy.js:99:24
        at /Users/clayton/src/scanner/ReactMap/node_modules/passport-discord/lib/strategy.js:115:13
        at passBackControl (/Users/clayton/src/scanner/ReactMap/node_modules/oauth/lib/oauth2.js:134:9)
        at IncomingMessage.<anonymous> (/Users/clayton/src/scanner/ReactMap/node_modules/oauth/lib/oauth2.js:157:7)
        at IncomingMessage.emit (node:events:525:35)
        at IncomingMessage.emit (node:domain:489:12)
        at endReadableNT (node:internal/streams/readable:1359:12)
        at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
    ⚠ 2023-06-22 00:59:41 [DISCORD] 130865078219046915 Not authorized to access map

</details>


# The fix

We now include a nice UI for the end user telling them that:
A. They were blocked on purpose
B. Which discord server(s) are on the block list
C. How to get more information by joining discord

This also now properly fires a discord alert to the audit log. Also if a RM user doesn't have the `discordLink` option enabled the Join button isn't shown.

PS - I'm aware the Discord Join button is not the same as the Login page but this does align with the 404 error page. It looks fine to me 🤞  

### Screenshots

<img width="738" alt="Screenshot 2023-06-21 at 7 52 15 PM" src="https://github.com/WatWowMap/ReactMap/assets/2831320/af3f8a20-4583-453d-9b79-5dc0e708ada6">
<img width="749" alt="Screenshot 2023-06-21 at 7 53 57 PM" src="https://github.com/WatWowMap/ReactMap/assets/2831320/421fbba7-1e50-4a95-bdfc-82ca965d1e57">
<img width="463" alt="Screenshot 2023-06-21 at 7 58 06 PM" src="https://github.com/WatWowMap/ReactMap/assets/2831320/f411cce5-29a4-4620-bdab-5c9c1a220c27">
 
## Update 
After talking in discord I figured we can add the UI feedback when users don't have map access.
 
<img width="471" alt="Screenshot 2023-06-22 at 10 13 48 PM" src="https://github.com/WatWowMap/ReactMap/assets/2831320/6971f5ee-191f-4e7c-ba2c-236320d9844a">
