### PR TITLE
scan area fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactmap",
-  "version": "1.15.3",
+  "version": "1.16.0",
   "description": "React based frontend map.",
   "main": "ReactMap.js",
   "author": "TurtIeSocks <58572875+TurtIeSocks@users.noreply.github.com>",

--- a/server/src/graphql/resolvers.js
+++ b/server/src/graphql/resolvers.js
@@ -172,7 +172,8 @@ module.exports = {
               (feature) =>
                 !feature.properties.hidden &&
                 (!perms.areaRestrictions.length ||
-                  perms.areaRestrictions.includes(feature.properties.name)),
+                  perms.areaRestrictions.includes(feature.properties.name) ||
+                  perms.areaRestrictions.includes(feature.properties.parent)),
             ),
           },
         ]
@@ -189,9 +190,11 @@ module.exports = {
           const filtered = scanAreas
             .map((parent) => ({
               ...parent,
-              children: parent.children.filter((child) =>
-                perms.areaRestrictions.includes(child.properties.name),
-              ),
+              children: perms.areaRestrictions.includes(parent.name)
+                ? parent.children
+                : parent.children.filter((child) =>
+                    perms.areaRestrictions.includes(child.properties.name),
+                  ),
             }))
             .filter((parent) => parent.children.length)
 

--- a/server/src/graphql/scannerTypes.js
+++ b/server/src/graphql/scannerTypes.js
@@ -5,8 +5,8 @@ module.exports = gql`
     id: ID
     instance_name: String
     updated: Int
-    last_lat: Float
-    last_lon: Float
+    lat: Float
+    lon: Float
     type: String
     isMad: Boolean
     route: JSON

--- a/server/src/models/Device.js
+++ b/server/src/models/Device.js
@@ -1,6 +1,7 @@
 const { Model, raw } = require('objection')
 const getAreaSql = require('../services/functions/getAreaSql')
 const fetchJson = require('../services/api/fetchJson')
+const { filterRTree } = require('../services/functions/filterRTree')
 
 module.exports = class Device extends Model {
   static get tableName() {
@@ -20,8 +21,8 @@ module.exports = class Device extends Model {
           'settings_area.name AS instance_name',
           'mode AS type',
           raw('UNIX_TIMESTAMP(lastProtoDateTime)').as('updated'),
-          raw('X(currentPos)').as('last_lat'),
-          raw('Y(currentPos)').as('last_lon'),
+          raw('X(currentPos)').as('lat'),
+          raw('Y(currentPos)').as('lon'),
           raw(true).as('isMad'),
         ])
     } else {
@@ -30,8 +31,8 @@ module.exports = class Device extends Model {
         .select(
           'uuid AS id',
           'last_seen AS updated',
-          'last_lat',
-          'last_lon',
+          'last_lat AS lat',
+          'last_lon AS lon',
           'type',
           'instance_name',
           raw('json_extract(data, "$.area")').as('route'),
@@ -50,18 +51,20 @@ module.exports = class Device extends Model {
             'X-Golbat-Secret': settings.secret || undefined,
           },
         }).then((res) =>
-          Object.entries(res.devices).map(([id, device]) => ({
-            id,
-            last_lat: device.latitude,
-            last_lon: device.longitude,
-            updated: device.last_update,
-            type: device.scan_context,
-          })),
+          Object.entries(res.devices)
+            .map(([id, device]) => ({
+              id,
+              lat: device.latitude,
+              lon: device.longitude,
+              updated: device.last_update,
+              type: device.scan_context,
+            }))
+            .filter((device) =>
+              filterRTree(device, areaRestrictions, onlyAreas),
+            ),
         )
       : await query.from(settings.isMad ? 'settings_device' : 'device')
 
-    return results.filter(
-      (device) => device.id && device.last_lat && device.last_lon,
-    )
+    return results.filter((device) => device.id && device.lat && device.lon)
   }
 }

--- a/server/src/models/Pokemon.js
+++ b/server/src/models/Pokemon.js
@@ -80,6 +80,7 @@ module.exports = class Pokemon extends Model {
    */
   static getFilters(perms, args, { SubModel: _, connection: __, ...ctx }) {
     const mods = {
+      onlyAreas: args.filters.onlyAreas || [],
       ...ctx,
       ...Object.fromEntries(
         LEVELS.map((x) => [`onlyPvp${x}`, args.filters[`onlyPvp${x}`]]),

--- a/server/src/services/areas.js
+++ b/server/src/services/areas.js
@@ -289,7 +289,7 @@ module.exports = async () => {
     features: Object.values(scanAreasObj).filter(
       (f) =>
         !f.properties.manual &&
-        !f.properties.hidden &&
+        f.properties.key &&
         f.geometry.type.includes('Polygon'),
     ),
   })

--- a/server/src/services/functions/consolidateAreas.js
+++ b/server/src/services/functions/consolidateAreas.js
@@ -1,0 +1,30 @@
+const config = require('../config')
+
+/**
+ * Consolidate area restrictions and user set areas, accounts for parents
+ * @param {string[]} areaRestrictions
+ * @param {string[]} onlyAreas
+ * @returns {Set<string>}
+ */
+function consolidateAreas(areaRestrictions = [], onlyAreas = []) {
+  const validAreaRestrictions = areaRestrictions.filter((a) =>
+    config.areas.names.has(a),
+  )
+  const validUserAreas = onlyAreas.filter((a) => config.areas.names.has(a))
+
+  const cleanedValidUserAreas = validUserAreas.filter((area) =>
+    areaRestrictions.length
+      ? areaRestrictions.includes(area) ||
+        areaRestrictions.includes(
+          config.areas.scanAreasObj[area].properties.parent,
+        )
+      : true,
+  )
+  return new Set(
+    cleanedValidUserAreas.length
+      ? cleanedValidUserAreas
+      : validAreaRestrictions,
+  )
+}
+
+module.exports = { consolidateAreas }

--- a/server/src/services/functions/filterRTree.js
+++ b/server/src/services/functions/filterRTree.js
@@ -2,20 +2,22 @@ const { default: pointInPolygon } = require('@turf/boolean-point-in-polygon')
 const { point } = require('@turf/helpers')
 
 const config = require('../config')
+const { consolidateAreas } = require('./consolidateAreas')
 
+/**
+ * Filters via RTree in place of MySQL query when using in memory data
+ * @template {{ lat: number, lon: number }} T
+ * @param {T} item
+ * @param {string[]} areaRestrictions
+ * @param {string[]} onlyAreas
+ * @returns {boolean}
+ */
 function filterRTree(item, areaRestrictions = [], onlyAreas = []) {
   if (!areaRestrictions.length && !onlyAreas.length) return true
 
-  const cleanUserAreas = onlyAreas.filter((area) =>
-    config.areas.names.has(area),
-  )
-  const consolidatedAreas = areaRestrictions.length
-    ? areaRestrictions
-        .filter(
-          (area) => !cleanUserAreas.length || cleanUserAreas.includes(area),
-        )
-        .flatMap((area) => config.areas.withoutParents[area] || area)
-    : cleanUserAreas
+  const consolidatedAreas = consolidateAreas(areaRestrictions, onlyAreas)
+
+  if (!consolidatedAreas.size) return true
 
   const foundFeatures = config.areas.myRTree
     .search({
@@ -24,15 +26,14 @@ function filterRTree(item, areaRestrictions = [], onlyAreas = []) {
       w: 0,
       h: 0,
     })
-    .filter((feature) => feature?.properties?.key)
+    .filter((feature) => consolidatedAreas.has(feature.properties.key))
 
   const foundInRtree =
     foundFeatures.length &&
-    foundFeatures.some(
-      (feature) =>
-        consolidatedAreas.includes(feature.properties.key) &&
-        pointInPolygon(point([item.lon, item.lat]), feature),
+    foundFeatures.some((feature) =>
+      pointInPolygon(point([item.lon, item.lat]), feature),
     )
+
   return foundInRtree
 }
 

--- a/server/src/services/functions/getAreaSql.js
+++ b/server/src/services/functions/getAreaSql.js
@@ -1,4 +1,5 @@
 const config = require('../config')
+const { consolidateAreas } = require('./consolidateAreas')
 
 module.exports = function getAreaRestrictionSql(
   query,
@@ -16,18 +17,9 @@ module.exports = function getAreaRestrictionSql(
 
   if (!areaRestrictions?.length && !onlyAreas?.length) return true
 
-  const cleanUserAreas = onlyAreas.filter((area) =>
-    config.areas.names.has(area),
-  )
-  const consolidatedAreas = areaRestrictions.length
-    ? areaRestrictions
-        .filter(
-          (area) => !cleanUserAreas.length || cleanUserAreas.includes(area),
-        )
-        .flatMap((area) => config.areas.withoutParents[area] || area)
-    : cleanUserAreas
+  const consolidatedAreas = consolidateAreas(areaRestrictions, onlyAreas)
 
-  if (!consolidatedAreas.length) return false
+  if (!consolidatedAreas.size) return false
 
   let columns = ['lat', 'lon']
   if (isMad) {

--- a/src/components/tiles/Device.jsx
+++ b/src/components/tiles/Device.jsx
@@ -19,12 +19,12 @@ const DeviceTile = ({ item, ts, Icons, userSettings }) => {
 
   return (
     <Marker
-      position={[item.last_lat, item.last_lon]}
+      position={[item.lat, item.lon]}
       icon={deviceMarker(isOnline, Icons)}
       ref={markerRef}
     >
       <Popup
-        position={[item.last_lat, item.last_lon]}
+        position={[item.lat, item.lon]}
         onOpen={() => setPoly(true)}
         onClose={() => setPoly(false)}
       >
@@ -41,8 +41,8 @@ const DeviceTile = ({ item, ts, Icons, userSettings }) => {
 
 const areEqual = (prev, next) =>
   prev.item.type === next.item.type &&
-  prev.item.last_lat === next.item.last_lat &&
-  prev.item.last_lon === next.item.last_lon &&
+  prev.item.lat === next.item.lat &&
+  prev.item.lon === next.item.lon &&
   prev.item.updated === next.item.updated
 
 export default memo(DeviceTile, areEqual)

--- a/src/services/queries/device.js
+++ b/src/services/queries/device.js
@@ -6,8 +6,8 @@ const getAllDevices = gql`
       id
       instance_name
       updated
-      last_lat
-      last_lon
+      lat
+      lon
       route
       type
       isMad


### PR DESCRIPTION
- Allow parents to work correctly with area restrictions
- Better function to consolidate areas from permissions and user set, shared between sql and rtree
- Filter with rtree with devices, since that was forgotten
- Change all device `last_lat` => `lat` and `last_lon` => `lon`
- Allow areas that have hidden set to true to still exist in the rtree

Resolves #619 