### PR TITLE
uicons try/catch in browser

### DIFF
--- a/server/src/services/EventManager.js
+++ b/server/src/services/EventManager.js
@@ -12,6 +12,7 @@ module.exports = class EventManager {
     this.invasions = masterfile.invasions
     this.available = { gyms: [], pokestops: [], pokemon: [], nests: [] }
     this.uicons = []
+    this.uiconsBackup = {}
     this.baseUrl =
       'https://raw.githubusercontent.com/WatWowMap/wwm-uicons-webp/main'
     this.webhookObj = {}
@@ -143,7 +144,7 @@ module.exports = class EventManager {
         'Base uicons not found in config (either remotely or locally). This may be fine, but some things might be broken, such as items from the `misc` folder.',
       )
     }
-    this.uicons = await Promise.all(
+    const uicons = await Promise.allSettled(
       styles.map(async (style) => {
         try {
           const response = style.path.startsWith('http')
@@ -172,7 +173,13 @@ module.exports = class EventManager {
         }
       }),
     )
-    this.uicons = this.uicons.filter(Boolean)
+    for (let i = 0; i < uicons.length; i += 1) {
+      const uicon = uicons[i]
+      if (uicon.status === 'fulfilled') {
+        this.uiconsBackup[uicon.value.name] = uicon.value
+      }
+    }
+    this.uicons = Object.values(this.uiconsBackup)
   }
 
   async getInvasions(endpoint) {

--- a/src/services/Icons.js
+++ b/src/services/Icons.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const freezeProps = (target, property) => {
   const {
     value,
@@ -22,7 +23,8 @@ export default class UIcons {
     this.sizes = sizes
     this.selected = {}
     this.questRewardTypes = {}
-    this.fallback = ''
+    this.fallback =
+      'https://raw.githubusercontent.com/WatWowMap/wwm-uicons-webp/main'
     this.modifiers = {
       base: {
         offsetX: 1,
@@ -44,7 +46,7 @@ export default class UIcons {
   }
 
   build(icons) {
-    icons.forEach((icon, i) => {
+    icons.forEach((icon) => {
       try {
         const { data, name: dirtyName, path: dirtyPath } = icon
         const name = dirtyName.endsWith('/')
@@ -59,9 +61,6 @@ export default class UIcons {
             indexes: Object.keys(data),
             ...icon,
             path,
-          }
-          if (!i) {
-            this.fallback = path
           }
           if (!path) {
             // eslint-disable-next-line no-console
@@ -232,46 +231,56 @@ export default class UIcons {
     alignment = 0,
     shiny = false,
   ) {
-    const baseUrl = `${
-      this[this.selected.pokemon]?.path || this.fallback
-    }/pokemon`
-    const extension = this[this.selected.pokemon]?.extension || 'png'
+    try {
+      const baseUrl = `${
+        this[this.selected.pokemon]?.path || this.fallback
+      }/pokemon`
+      const extension = this[this.selected.pokemon]?.extension || 'png'
 
-    const evolutionSuffixes = evolution ? [`_e${evolution}`, ''] : ['']
-    const formSuffixes = form ? [`_f${form}`, ''] : ['']
-    const costumeSuffixes = costume ? [`_c${costume}`, ''] : ['']
-    const genderSuffixes = gender ? [`_g${gender}`, ''] : ['']
-    const alignmentSuffixes = alignment ? [`_a${alignment}`, ''] : ['']
-    const shinySuffixes = shiny ? ['_s', ''] : ['']
+      const evolutionSuffixes = evolution ? [`_e${evolution}`, ''] : ['']
+      const formSuffixes = form ? [`_f${form}`, ''] : ['']
+      const costumeSuffixes = costume ? [`_c${costume}`, ''] : ['']
+      const genderSuffixes = gender ? [`_g${gender}`, ''] : ['']
+      const alignmentSuffixes = alignment ? [`_a${alignment}`, ''] : ['']
+      const shinySuffixes = shiny ? ['_s', ''] : ['']
 
-    for (let e = 0; e < evolutionSuffixes.length; e += 1) {
-      for (let f = 0; f < formSuffixes.length; f += 1) {
-        for (let c = 0; c < costumeSuffixes.length; c += 1) {
-          for (let g = 0; g < genderSuffixes.length; g += 1) {
-            for (let a = 0; a < alignmentSuffixes.length; a += 1) {
-              for (let s = 0; s < shinySuffixes.length; s += 1) {
-                const result = `${pokemonId}${evolutionSuffixes[e]}${formSuffixes[f]}${costumeSuffixes[c]}${genderSuffixes[g]}${alignmentSuffixes[a]}${shinySuffixes[s]}.${extension}`
-                if (this[this.selected.pokemon].pokemon.has(result)) {
-                  return `${baseUrl}/${result}`
+      for (let e = 0; e < evolutionSuffixes.length; e += 1) {
+        for (let f = 0; f < formSuffixes.length; f += 1) {
+          for (let c = 0; c < costumeSuffixes.length; c += 1) {
+            for (let g = 0; g < genderSuffixes.length; g += 1) {
+              for (let a = 0; a < alignmentSuffixes.length; a += 1) {
+                for (let s = 0; s < shinySuffixes.length; s += 1) {
+                  const result = `${pokemonId}${evolutionSuffixes[e]}${formSuffixes[f]}${costumeSuffixes[c]}${genderSuffixes[g]}${alignmentSuffixes[a]}${shinySuffixes[s]}.${extension}`
+                  if (this[this.selected.pokemon].pokemon.has(result)) {
+                    return `${baseUrl}/${result}`
+                  }
                 }
               }
             }
           }
         }
       }
+      return `${baseUrl}/0.${extension}`
+    } catch (e) {
+      console.error('[UICONS]', e)
+      return `${this.fallback}/pokemon/0.webp`
     }
-    return `${baseUrl}/0.${extension}`
   }
 
   getTypes(typeId) {
-    const baseUrl = `${this[this.selected.type]?.path || this.fallback}/type`
-    const extension = this[this.selected.type]?.extension || 'png'
+    try {
+      const baseUrl = `${this[this.selected.type]?.path || this.fallback}/type`
+      const extension = this[this.selected.type]?.extension || 'png'
 
-    const result = `${typeId}.${extension}`
-    if (this[this.selected.type].type.has(result)) {
-      return `${baseUrl}/${result}`
+      const result = `${typeId}.${extension}`
+      if (this[this.selected.type].type.has(result)) {
+        return `${baseUrl}/${result}`
+      }
+      return `${baseUrl}/0.${extension}`
+    } catch (e) {
+      console.error('[UICONS]', e)
+      return `${this.fallback}/type/0.png`
     }
-    return `${baseUrl}/0.${extension}`
   }
 
   getPokestops(
@@ -282,65 +291,80 @@ export default class UIcons {
     power = 0,
     display = '',
   ) {
-    const baseUrl = `${
-      this[this.selected.pokestop]?.path || this.fallback
-    }/pokestop`
-    const extension = this[this.selected.pokestop]?.extension || 'png'
+    try {
+      const baseUrl = `${
+        this[this.selected.pokestop]?.path || this.fallback
+      }/pokestop`
+      const extension = this[this.selected.pokestop]?.extension || 'png'
 
-    const invasionSuffixes =
-      invasionActive || display ? [`_i${display}`, ''] : ['']
-    const questSuffixes = questActive ? ['_q', ''] : ['']
-    const arSuffixes = ar ? ['_ar', ''] : ['']
-    const powerUpSuffixes = power ? [`_p${power}`, ''] : ['']
+      const invasionSuffixes =
+        invasionActive || display ? [`_i${display}`, ''] : ['']
+      const questSuffixes = questActive ? ['_q', ''] : ['']
+      const arSuffixes = ar ? ['_ar', ''] : ['']
+      const powerUpSuffixes = power ? [`_p${power}`, ''] : ['']
 
-    for (let i = 0; i < invasionSuffixes.length; i += 1) {
-      for (let q = 0; q < questSuffixes.length; q += 1) {
-        for (let a = 0; a < arSuffixes.length; a += 1) {
-          for (let p = 0; p < powerUpSuffixes.length; p += 1) {
-            const result = `${lureId}${invasionSuffixes[i]}${questSuffixes[q]}${arSuffixes[a]}${powerUpSuffixes[p]}.${extension}`
-            if (this[this.selected.pokestop].pokestop.has(result)) {
-              return `${baseUrl}/${result}`
+      for (let i = 0; i < invasionSuffixes.length; i += 1) {
+        for (let q = 0; q < questSuffixes.length; q += 1) {
+          for (let a = 0; a < arSuffixes.length; a += 1) {
+            for (let p = 0; p < powerUpSuffixes.length; p += 1) {
+              const result = `${lureId}${invasionSuffixes[i]}${questSuffixes[q]}${arSuffixes[a]}${powerUpSuffixes[p]}.${extension}`
+              if (this[this.selected.pokestop].pokestop.has(result)) {
+                return `${baseUrl}/${result}`
+              }
             }
           }
         }
       }
+      return `${baseUrl}/0.${extension}`
+    } catch (e) {
+      console.error('[UICONS]', e)
+      return `${this.fallback}/pokestop/0.png`
     }
-    return `${baseUrl}/0.${extension}`
   }
 
   getRewards(rewardType, id, amount) {
-    const category = this.questRewardTypes[rewardType] || 'unset'
-    const baseUrl = `${
-      this[this.selected.reward]?.path || this.fallback
-    }/reward/${category}`
-    const extension = this[this.selected.reward]?.extension || 'png'
+    try {
+      const category = this.questRewardTypes[rewardType] || 'unset'
+      const baseUrl = `${
+        this[this.selected.reward]?.path || this.fallback
+      }/reward/${category}`
+      const extension = this[this.selected.reward]?.extension || 'png'
 
-    if (this[this.selected.reward][category]) {
-      const amountSuffixes = amount > 1 ? [`_a${amount}`, ''] : ['']
-      for (let a = 0; a < amountSuffixes.length; a += 1) {
-        const result = `${id}${amountSuffixes[a]}.${extension}`
-        if (this[this.selected.reward][category].has(result)) {
-          return `${baseUrl}/${result}`
+      if (this[this.selected.reward][category]) {
+        const amountSuffixes = amount > 1 ? [`_a${amount}`, ''] : ['']
+        for (let a = 0; a < amountSuffixes.length; a += 1) {
+          const result = `${id}${amountSuffixes[a]}.${extension}`
+          if (this[this.selected.reward][category].has(result)) {
+            return `${baseUrl}/${result}`
+          }
         }
       }
+      return `${baseUrl}/0.${extension}`
+    } catch (e) {
+      console.error('[UICONS]', e)
+      return `${this.fallback}/reward/unset/0.png`
     }
-    return `${baseUrl}/0.${extension}`
   }
 
   getInvasions(gruntType, confirmed = false) {
-    const baseUrl = `${
-      this[this.selected.invasion]?.path || this.fallback
-    }/invasion`
-    const extension = this[this.selected.invasion]?.extension || 'png'
+    try {
+      const baseUrl = `${
+        this[this.selected.invasion]?.path || this.fallback
+      }/invasion`
+      const extension = this[this.selected.invasion]?.extension || 'png'
 
-    const confirmedSuffixes = confirmed ? [''] : ['_u', '']
-    for (let c = 0; c < confirmedSuffixes.length; c += 1) {
-      const result = `${gruntType}${confirmedSuffixes[c]}.${extension}`
-      if (this[this.selected.invasion].invasion.has(result)) {
-        return `${baseUrl}/${result}`
+      const confirmedSuffixes = confirmed ? [''] : ['_u', '']
+      for (let c = 0; c < confirmedSuffixes.length; c += 1) {
+        const result = `${gruntType}${confirmedSuffixes[c]}.${extension}`
+        if (this[this.selected.invasion].invasion.has(result)) {
+          return `${baseUrl}/${result}`
+        }
       }
+      return `${baseUrl}/0.${extension}`
+    } catch (e) {
+      console.error('[UICONS]', e)
+      return `${this.fallback}/invasion/0.png`
     }
-    return `${baseUrl}/0.${extension}`
   }
 
   getGyms(
@@ -350,86 +374,111 @@ export default class UIcons {
     ex = false,
     ar = false,
   ) {
-    const baseUrl = `${this[this.selected.gym]?.path || this.fallback}/gym`
-    const extension = this[this.selected.gym]?.extension || 'png'
+    try {
+      const baseUrl = `${this[this.selected.gym]?.path || this.fallback}/gym`
+      const extension = this[this.selected.gym]?.extension || 'png'
 
-    const trainerSuffixes = trainerCount ? [`_t${trainerCount}`, ''] : ['']
-    const inBattleSuffixes = inBattle ? ['_b', ''] : ['']
-    const exSuffixes = ex ? ['_ex', ''] : ['']
-    const arSuffixes = ar ? ['_ar', ''] : ['']
-    for (let t = 0; t < trainerSuffixes.length; t += 1) {
-      for (let b = 0; b < inBattleSuffixes.length; b += 1) {
-        for (let e = 0; e < exSuffixes.length; e += 1) {
-          for (let a = 0; a < arSuffixes.length; a += 1) {
-            const result = `${teamId}${trainerSuffixes[t]}${inBattleSuffixes[b]}${exSuffixes[e]}${arSuffixes[a]}.${extension}`
-            if (this[this.selected.gym].gym.has(result)) {
-              return `${baseUrl}/${result}`
+      const trainerSuffixes = trainerCount ? [`_t${trainerCount}`, ''] : ['']
+      const inBattleSuffixes = inBattle ? ['_b', ''] : ['']
+      const exSuffixes = ex ? ['_ex', ''] : ['']
+      const arSuffixes = ar ? ['_ar', ''] : ['']
+      for (let t = 0; t < trainerSuffixes.length; t += 1) {
+        for (let b = 0; b < inBattleSuffixes.length; b += 1) {
+          for (let e = 0; e < exSuffixes.length; e += 1) {
+            for (let a = 0; a < arSuffixes.length; a += 1) {
+              const result = `${teamId}${trainerSuffixes[t]}${inBattleSuffixes[b]}${exSuffixes[e]}${arSuffixes[a]}.${extension}`
+              if (this[this.selected.gym].gym.has(result)) {
+                return `${baseUrl}/${result}`
+              }
             }
           }
         }
       }
+      return `${baseUrl}/0.${extension}`
+    } catch (e) {
+      console.error('[UICONS]', e)
+      return `${this.fallback}/gym/0.png`
     }
-    return `${baseUrl}/0.${extension}`
   }
 
   getEggs(level, hatched = false, ex = false) {
-    const baseUrl = `${
-      this[this.selected.raid]?.path || this.fallback
-    }/raid/egg`
-    const extension = this[this.selected.raid]?.extension || 'png'
+    try {
+      const baseUrl = `${
+        this[this.selected.raid]?.path || this.fallback
+      }/raid/egg`
+      const extension = this[this.selected.raid]?.extension || 'png'
 
-    const hatchedSuffixes = hatched ? ['_h', ''] : ['']
-    const exSuffixes = ex ? ['_ex', ''] : ['']
-    for (let h = 0; h < hatchedSuffixes.length; h += 1) {
-      for (let e = 0; e < exSuffixes.length; e += 1) {
-        const result = `${level}${hatchedSuffixes[h]}${exSuffixes[e]}.${extension}`
-        if (
-          this[this.selected.raid].egg &&
-          this[this.selected.raid].egg.has(result)
-        ) {
-          return `${baseUrl}/${result}`
+      const hatchedSuffixes = hatched ? ['_h', ''] : ['']
+      const exSuffixes = ex ? ['_ex', ''] : ['']
+      for (let h = 0; h < hatchedSuffixes.length; h += 1) {
+        for (let e = 0; e < exSuffixes.length; e += 1) {
+          const result = `${level}${hatchedSuffixes[h]}${exSuffixes[e]}.${extension}`
+          if (
+            this[this.selected.raid].egg &&
+            this[this.selected.raid].egg.has(result)
+          ) {
+            return `${baseUrl}/${result}`
+          }
         }
       }
+      return `${baseUrl}/0.${extension}`
+    } catch (e) {
+      console.error('[UICONS]', e)
+      return `${this.fallback}/raid/egg/0.png`
     }
-    return `${baseUrl}/0.${extension}`
   }
 
   getTeams(teamId = 0) {
-    const baseUrl = `${this[this.selected.team]?.path || this.fallback}/team`
-    const extension = this[this.selected.team]?.extension || 'png'
+    try {
+      const baseUrl = `${this[this.selected.team]?.path || this.fallback}/team`
+      const extension = this[this.selected.team]?.extension || 'png'
 
-    const result = `${teamId}.${extension}`
-    if (this[this.selected.team].team.has(result)) {
-      return `${baseUrl}/${result}`
+      const result = `${teamId}.${extension}`
+      if (this[this.selected.team].team.has(result)) {
+        return `${baseUrl}/${result}`
+      }
+      return `${baseUrl}/0.${extension}`
+    } catch (e) {
+      console.error('[UICONS]', e)
+      return `${this.fallback}/team/0.png`
     }
-    return `${baseUrl}/0.${extension}`
   }
 
   getWeather(weatherId, timeOfDay = false) {
-    const baseUrl = `${
-      this[this.selected.weather]?.path || this.fallback
-    }/weather`
-    const extension = this[this.selected.weather]?.extension || 'png'
+    try {
+      const baseUrl = `${
+        this[this.selected.weather]?.path || this.fallback
+      }/weather`
+      const extension = this[this.selected.weather]?.extension || 'png'
 
-    const timeSuffixes = timeOfDay === 'night' ? ['_n', ''] : ['_d', '']
-    for (let t = 0; t < timeSuffixes.length; t += 1) {
-      const result = `${weatherId}${timeSuffixes[t]}.${extension}`
-      if (this[this.selected.weather].weather.has(result)) {
-        return `${baseUrl}/${result}`
+      const timeSuffixes = timeOfDay === 'night' ? ['_n', ''] : ['_d', '']
+      for (let t = 0; t < timeSuffixes.length; t += 1) {
+        const result = `${weatherId}${timeSuffixes[t]}.${extension}`
+        if (this[this.selected.weather].weather.has(result)) {
+          return `${baseUrl}/${result}`
+        }
       }
+      return `${baseUrl}/0.${extension}`
+    } catch (e) {
+      console.error('[UICONS]', e)
+      return `${this.fallback}/weather/0.png`
     }
-    return `${baseUrl}/0.${extension}`
   }
 
   getNests(typeId) {
-    const baseUrl = `${this[this.selected.nest]?.path || this.fallback}/nest`
-    const extension = this[this.selected.nest]?.extension || 'png'
+    try {
+      const baseUrl = `${this[this.selected.nest]?.path || this.fallback}/nest`
+      const extension = this[this.selected.nest]?.extension || 'png'
 
-    const result = `${typeId}.${extension}`
-    if (this[this.selected.nest].nest.has(result)) {
-      return `${baseUrl}/${result}`
+      const result = `${typeId}.${extension}`
+      if (this[this.selected.nest].nest.has(result)) {
+        return `${baseUrl}/${result}`
+      }
+      return `${baseUrl}/0.${extension}`
+    } catch (e) {
+      console.error('[UICONS]', e)
+      return `${this.fallback}/nest/0.png`
     }
-    return `${baseUrl}/0.${extension}`
   }
 
   doesMiscHave(fileName) {
@@ -439,45 +488,62 @@ export default class UIcons {
   }
 
   getMisc(fileName = '') {
-    const baseUrl = `${this[this.selected.misc]?.path || this.fallback}/misc`
-    const extension = this[this.selected.misc]?.extension || 'png'
+    try {
+      const baseUrl = `${this[this.selected.misc]?.path || this.fallback}/misc`
+      const extension = this[this.selected.misc]?.extension || 'png'
 
-    if (this.doesMiscHave(fileName)) {
-      return `${baseUrl}/${fileName}.${extension}`
+      if (this.doesMiscHave(fileName)) {
+        return `${baseUrl}/${fileName}.${extension}`
+      }
+      if (fileName.endsWith('s') && this.doesMiscHave(fileName.slice(0, -1))) {
+        return `${baseUrl}/${fileName.slice(0, -1)}.${extension}`
+      }
+      if (
+        !fileName.endsWith('s') &&
+        this.doesMiscHave(`${fileName}s.${extension}`)
+      ) {
+        return `${baseUrl}/${fileName}s.${extension}`
+      }
+      if (
+        this[this.selected[fileName]]?.path &&
+        this[this.selected[fileName]][fileName]?.has(`0.${extension}`)
+      ) {
+        return `${
+          this[this.selected[fileName]]?.path
+        }/${fileName}/0.${extension}`
+      }
+      return `${baseUrl}/0.${extension}`
+    } catch (e) {
+      console.error('[UICONS]', e)
+      return `${this.fallback}/misc/0.png`
     }
-    if (fileName.endsWith('s') && this.doesMiscHave(fileName.slice(0, -1))) {
-      return `${baseUrl}/${fileName.slice(0, -1)}.${extension}`
-    }
-    if (
-      !fileName.endsWith('s') &&
-      this.doesMiscHave(`${fileName}s.${extension}`)
-    ) {
-      return `${baseUrl}/${fileName}s.${extension}`
-    }
-    if (
-      this[this.selected[fileName]]?.path &&
-      this[this.selected[fileName]][fileName]?.has(`0.${extension}`)
-    ) {
-      return `${this[this.selected[fileName]]?.path}/${fileName}/0.${extension}`
-    }
-    return `${baseUrl}/0.${extension}`
   }
 
   getDevices(online) {
-    const baseUrl = `${
-      this[this.selected.device]?.path || this.fallback
-    }/device`
-    const extension = this[this.selected.device]?.extension || 'png'
+    try {
+      const baseUrl = `${
+        this[this.selected.device]?.path || this.fallback
+      }/device`
+      const extension = this[this.selected.device]?.extension || 'png'
 
-    return online ? `${baseUrl}/1.${extension}` : `${baseUrl}/0.${extension}`
+      return online ? `${baseUrl}/1.${extension}` : `${baseUrl}/0.${extension}`
+    } catch (e) {
+      console.error('[UICONS]', e)
+      return `${this.fallback}/device/0.png`
+    }
   }
 
   getSpawnpoints(hasTth) {
-    const baseUrl = `${
-      this[this.selected.spawnpoint]?.path || this.fallback
-    }/spawnpoint`
-    const extension = this[this.selected.spawnpoint]?.extension || 'png'
+    try {
+      const baseUrl = `${
+        this[this.selected.spawnpoint]?.path || this.fallback
+      }/spawnpoint`
+      const extension = this[this.selected.spawnpoint]?.extension || 'png'
 
-    return hasTth ? `${baseUrl}/1.${extension}` : `${baseUrl}/0.${extension}`
+      return hasTth ? `${baseUrl}/1.${extension}` : `${baseUrl}/0.${extension}`
+    } catch (e) {
+      console.error('[UICONS]', e)
+      return `${this.fallback}/spawnpoint/0.png`
+    }
   }
 }


### PR DESCRIPTION
- Adds a backup object in case index fetching fails 
- Adds try/catch blocks to all uicons methods in the client, since this seems to be the most common crash and won't go away until github stops sucking