### PR TITLE
feat: individual event filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactmap",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "description": "React based frontend map.",
   "main": "ReactMap.js",
   "author": "TurtIeSocks <58572875+TurtIeSocks@users.noreply.github.com>",

--- a/public/base-locales/de.json
+++ b/public/base-locales/de.json
@@ -574,8 +574,6 @@
   "seen_lure_encounter": "getroffen am Lockmodul",
   "seen_lure_wild": "Spawn am Lockmodul",
   "seen_wild": "Spawn in der Wildnis",
-  "event_stops": "Kecleon",
-  "event_stop_timers": "Kecleon Timer",
   "size_0": "alle",
   "size_1": "XXS",
   "size_2": "XS",

--- a/public/base-locales/en.json
+++ b/public/base-locales/en.json
@@ -571,8 +571,8 @@
   "seen_lure_encounter": "Lure Encounter",
   "seen_lure_wild": "Lure Spawn",
   "seen_wild": "Wild Spawn",
-  "event_stops": "Kecleon",
-  "event_stop_timers": "Kecleon Timers",
+  "event_stops": "Event Stops",
+  "event_stop_timers": "Event Stop Timers",
   "size_0": "Any",
   "size_1": "XXS",
   "size_2": "XS",
@@ -600,5 +600,7 @@
   "enable_portal_popup_coords": "Show Portal Coords",
   "on_block_join_discord": "Please join our discord for more information.",
   "on_block_msg": "You have been blocked for being a member of",
-  "denied": "Denied"
+  "denied": "Denied",
+  "showcase": "Showcase",
+  "unknown_event": "Unknown Event"
 }

--- a/server/src/models/Gym.js
+++ b/server/src/models/Gym.js
@@ -213,7 +213,7 @@ module.exports = class Gym extends Model {
       }
     }
 
-    if (onlyAllGyms && onlyLevels !== 'all' && !isMad) {
+    if (onlyAllGyms && onlyLevels !== 'all' && !isMad && onlyLevels) {
       query.andWhere('power_up_level', onlyLevels)
     }
     query.andWhere((gym) => {

--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -203,6 +203,7 @@ module.exports = class Pokestop extends Model {
       const xlCandy = []
       const general = []
       const rocketPokemon = []
+      const displayTypes = []
       // preps arrays for interested objects
       Object.keys(args.filters).forEach((pokestop) => {
         switch (pokestop.charAt(0)) {
@@ -237,6 +238,9 @@ module.exports = class Pokestop extends Model {
             break
           case 'u':
             general.push(pokestop.slice(1))
+            break
+          case 'b':
+            displayTypes.push(pokestop.slice(1))
             break
           default:
             pokemon.push(pokestop.split('-')[0])
@@ -590,7 +594,7 @@ module.exports = class Pokestop extends Model {
             ar.where(isMad ? 'is_ar_scan_eligible' : 'ar_scan_eligible', 1)
           })
         }
-        if (onlyEventStops && eventStopPerms) {
+        if (onlyEventStops && eventStopPerms && displayTypes.length) {
           stops.orWhere((event) => {
             if (isMad && !hasMultiInvasions) {
               event
@@ -598,10 +602,9 @@ module.exports = class Pokestop extends Model {
                 .andWhere('incident_expiration', '>=', this.knex().fn.now())
             } else {
               event
-                .where(
-                  isMad ? 'incident_display_type' : 'display_type',
-                  '>=',
-                  7,
+                .whereIn(
+                  isMad ? 'incident_display_type' : 'incident.display_type',
+                  displayTypes,
                 )
                 .andWhere(isMad ? 'character_display' : 'character', 0)
                 .andWhere(
@@ -687,7 +690,7 @@ module.exports = class Pokestop extends Model {
           .filter((event) =>
             isMad && !hasMultiInvasions
               ? MADE_UP_MAD_INVASIONS.includes(event.grunt_type)
-              : !event.grunt_type,
+              : !event.grunt_type && filters[`b${event.display_type}`],
           )
           .map((event) => ({
             event_expire_timestamp: event.incident_expire_timestamp,
@@ -1223,21 +1226,21 @@ module.exports = class Pokestop extends Model {
             'pokestop.pokestop_id',
             'pokestop_incident.pokestop_id',
           )
-          .distinct('pokestop_incident.character_display AS grunt_type')
+          .select('pokestop_incident.character_display AS grunt_type')
           .where('pokestop_incident.character_display', '>', 0)
           .andWhere('incident_expiration', this.knex().fn.now())
           .orderBy('pokestop_incident.character_display')
       } else {
         queries.invasions = this.query()
           .leftJoin('incident', 'pokestop.id', 'incident.pokestop_id')
-          .distinct('incident.character AS grunt_type')
-          .where('incident.character', '>', 0)
-          .andWhere(
+          .select('incident.character AS grunt_type', 'incident.display_type')
+          .where(
             multiInvasionMs ? 'expiration_ms' : 'incident.expiration',
             '>=',
             ts * (multiInvasionMs ? 1000 : 1),
           )
-          .orderBy('grunt_type')
+          .groupBy('incident.character', 'incident.display_type')
+          .orderBy('incident.character', 'incident.display_type')
       }
     } else {
       queries.invasions = this.query()
@@ -1383,7 +1386,11 @@ module.exports = class Pokestop extends Model {
           rewards.forEach((reward) => finalList.add(`l${reward.lure_id}`))
           break
         case 'invasions':
-          rewards.forEach((reward) => finalList.add(`i${reward.grunt_type}`))
+          rewards.forEach((reward) =>
+            reward.grunt_type
+              ? finalList.add(`i${reward.grunt_type}`)
+              : finalList.add(`b${reward.display_type}`),
+          )
           break
         case 'rocketPokemon':
           if (hasConfirmed) {

--- a/server/src/services/filters/builder/pokestop.js
+++ b/server/src/services/filters/builder/pokestop.js
@@ -66,6 +66,9 @@ module.exports = function buildPokestops(perms, defaults, available) {
         quests[avail] = new BaseFilter(defaults.invasionPokemon)
       }
     }
+    if (perms.eventStops && avail.startsWith('b')) {
+      quests[avail] = new BaseFilter(defaults.eventStops)
+    }
   })
   return quests
 }

--- a/src/components/QueryData.jsx
+++ b/src/components/QueryData.jsx
@@ -110,11 +110,11 @@ export default function QueryData({
   useEffect(() => () => useStatic.setState({ excludeList: [] }))
 
   if (error) {
-    if (error.networkError.statusCode === 464) {
+    if (error.networkError?.statusCode === 464) {
       setError('old_client')
       return null
     }
-    if (error.networkError.statusCode === 401) {
+    if (error.networkError?.statusCode === 401) {
       setError('session_expired')
       return null
     }

--- a/src/components/layout/dialogs/webhooks/WebhookAdv.jsx
+++ b/src/components/layout/dialogs/webhooks/WebhookAdv.jsx
@@ -431,6 +431,10 @@ export default function WebhookAdvanced({
       )
         .map(checkDefaults)
         .join(' ')}`
+    if (id === 'showcase')
+      return `${prefix}${t('showcase')} ${Object.keys(poracleValues)
+        .map(checkDefaults)
+        .join(' ')}`
     switch (id.charAt(0)) {
       case 't':
         return `${prefix}${t('gym')}

--- a/src/components/layout/drawer/WithSubItems.jsx
+++ b/src/components/layout/drawer/WithSubItems.jsx
@@ -27,6 +27,7 @@ export default function WithSubItems({
 }) {
   const { t } = useTranslation()
   const available = useStatic((s) => s.available)
+  const Icons = useStatic((s) => s.Icons)
 
   if (category === 'scanAreas' && noScanAreaOverlay) {
     return null
@@ -197,6 +198,61 @@ export default function WithSubItems({
             </Grid>
           </>
         )}
+      {category === 'pokestops' && subItem === 'eventStops' && (
+        <Grid item xs={12} style={{ textAlign: 'center', padding: '0 12px' }}>
+          <Collapse in={filters[category][subItem]}>
+            {available?.pokestops
+              .filter((event) => event.startsWith('b'))
+              .map((event) => (
+                <Grid
+                  key={event}
+                  container
+                  style={{ width: '100%' }}
+                  alignItems="center"
+                  justifyContent="flex-end"
+                >
+                  <Grid item xs={2}>
+                    <img
+                      src={Icons.getIconById(event)}
+                      alt={t(`display_type_${event.slice(1)}`)}
+                      style={{ maxWidth: 30, maxHeight: 30 }}
+                    />
+                  </Grid>
+                  <Grid
+                    item
+                    xs={5}
+                    style={{ textAlign: 'left', paddingLeft: 20 }}
+                  >
+                    <Typography>
+                      {t(`display_type_${event.slice(1)}`, t('unknown_event'))}
+                    </Typography>
+                  </Grid>
+                  <Grid item xs={5} style={{ textAlign: 'right' }}>
+                    <Switch
+                      checked={filters[category].filter[event].enabled}
+                      onChange={() => {
+                        setFilters({
+                          ...filters,
+                          [category]: {
+                            ...filters[category],
+                            filter: {
+                              ...filters[category].filter,
+                              [event]: {
+                                ...filters[category].filter[event],
+                                enabled:
+                                  !filters[category].filter[event].enabled,
+                              },
+                            },
+                          },
+                        })
+                      }}
+                    />
+                  </Grid>
+                </Grid>
+              ))}
+          </Collapse>
+        </Grid>
+      )}
       {category === 'gyms' &&
         subItem === 'gymBadges' &&
         filters[category].gymBadges === true && (

--- a/src/components/popups/Pokestop.jsx
+++ b/src/components/popups/Pokestop.jsx
@@ -187,19 +187,12 @@ export default function PokestopPopup({
                       ) : null}
                       <TimeTile
                         expireTime={event.event_expire_timestamp}
-                        icon={
-                          {
-                            7: Icons.getMisc('event_coin'),
-                            8: Icons.getPokemon(352),
-                          }[event.display_type] || Icons.getMisc(0)
-                        }
+                        icon={Icons.getEventStops(event.display_type)}
                         until
-                        tt={
-                          {
-                            7: t('event_coin'),
-                            8: t('poke_352'),
-                          }[event.display_type] || '???'
-                        }
+                        tt={t(
+                          `display_type_${event.display_type}`,
+                          t('unknown_event'),
+                        )}
                       />
                     </Fragment>
                   ))}

--- a/src/services/Icons.js
+++ b/src/services/Icons.js
@@ -182,43 +182,85 @@ export default class UIcons {
 
   getIconById(id) {
     if (id === 'kecleon') {
-      id = '352'
+      id = 'b8'
     } else if (id === 'gold-stop') {
-      id = 'l506'
+      id = 'b7'
+    } else if (id === 'showcase') {
+      id = 'b9'
     }
     switch (id.charAt(0)) {
       case 'a':
+        // rocket pokemon
         return this.getPokemon(...id.slice(1).split('-'))
+      case 'b':
+        // event stops
+        return this.getEventStops(id.slice(1))
       case 'c':
+        // candy
         return this.getRewards(4, ...id.slice(1).split('-'))
       case 'd':
+        // stardust
         return this.getRewards(3, id.slice(1))
       case 'e':
+        // raid eggs
         return this.getEggs(id.slice(1), false)
       case 'g':
+        // gyms
         return this.getGyms(...id.slice(1).split('-'))
       case 'i':
+        // invasions
         return this.getInvasions(id.slice(1), true)
       case 'l':
+        // lures
         return this.getPokestops(id.slice(1))
       case 'm':
+        // mega energy
         return this.getPokemon(id.slice(1).split('-')[0], 0, 1)
       case 'p':
+        // experience
         return this.getRewards(1, id.slice(1))
       case 'q':
+        // items
         return this.getRewards(2, ...id.slice(1).split('-'))
       case 'r':
+        // unconfirmed but hatched raids
         return this.getEggs(id.slice(1), true)
       case 's':
+        // ...base pokestop maybe?
         return this.getPokestops(0)
       case 't':
+        // teams
         return this.getGyms(...id.slice(1).split('-'))
       case 'u':
+        // quest types
         return this.getRewards(id.slice(1))
       case 'x':
+        // xl candy
         return this.getRewards(9, ...id.slice(1).split('-'))
       default:
+        // pokemon
         return this.getPokemon(...id.split('-'))
+    }
+  }
+
+  getEventStops(displayType = 0) {
+    try {
+      switch (+displayType) {
+        case 7:
+          // Gimmighoul coin
+          return this.getMisc('event_coin')
+        case 8:
+          // Kecleon
+          return this.getPokemon(352)
+        case 9:
+          // Showcase
+          return this.getMisc('showcase')
+        default:
+      }
+      return this.getMisc('0')
+    } catch (e) {
+      console.error('[UICONS]', e)
+      return `${this.fallback}/misc/0.webp`
     }
   }
 

--- a/src/services/Poracle.js
+++ b/src/services/Poracle.js
@@ -51,6 +51,11 @@ export default class Poracle {
             grunt_type: 'kecleon',
             profile_no: human.current_profile_no,
           },
+          showcase: {
+            ...invasion.defaults,
+            grunt_type: 'showcase',
+            profile_no: human.current_profile_no,
+          },
         },
         lure: {
           global: { ...lure.defaults, profile_no: human.current_profile_no },
@@ -266,6 +271,8 @@ export default class Poracle {
           ? 'gold-stop'
           : item.grunt_type === 'kecleon'
           ? 'kecleon'
+          : item.grunt_type === 'showcase'
+          ? 'showcase'
           : `i${Object.keys(invasions).find(
               (x) =>
                 invasions[x].type?.toLowerCase() ===
@@ -306,7 +313,7 @@ export default class Poracle {
     if (!id) return {}
     if (id === 'gold-stop') return { id: 'gold-stop', type: 'invasion' }
     if (id === 'kecleon') return { id: 'kecleon', type: 'invasion' }
-
+    if (id === 'showcase') return { id: 'showcase', type: 'invasion' }
     switch (id.charAt(0)) {
       case 'e':
         return { id: id.replace('e', ''), type: 'egg' }
@@ -340,6 +347,7 @@ export default class Poracle {
       case 'invasion':
         if (idObj.id === 'gold-stop') return ['gold_stop']
         if (idObj.id === 'kecleon') return ['poke_352']
+        if (idObj.id === 'showcase') return ['showcase']
         return idObj.id === '0' ? ['poke_global'] : [`grunt_a_${idObj.id}`]
       case 'lure':
         return [`lure_${idObj.id}`]

--- a/src/services/filtering/genPokestops.js
+++ b/src/services/filtering/genPokestops.js
@@ -18,6 +18,11 @@ export default function genPokestops(t, pokemon, pokestops, categories) {
       perms: ['invasions'],
       webhookOnly: true,
     }
+    tempObj.invasions.showcase = {
+      name: t('showcase'),
+      perms: ['invasions'],
+      webhookOnly: true,
+    }
   }
 
   Object.keys(pokestops.filter).forEach((id) => {


### PR DESCRIPTION
- split event stops into separate filters
- new collapse menu when enabling `Event Stops` in the drawer
- poracle support for `showcase`
- waiting for better backend support to fill in popup info before merge

<img width="304" alt="Screenshot 2023-07-06 at 1 34 11 PM" src="https://github.com/WatWowMap/ReactMap/assets/58572875/b8b6dc9a-7d02-4661-9fab-1cef97dfa297">
