### PR TITLE
fix: correct pokemon pvp tooltip

### DIFF
--- a/src/components/popups/Pokemon.jsx
+++ b/src/components/popups/Pokemon.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-nested-ternary */
 import React, { Fragment, useCallback, useState, useEffect } from 'react'
 import Check from '@material-ui/icons/Check'
 import Clear from '@material-ui/icons/Clear'
@@ -596,7 +597,11 @@ const PvpInfo = ({ pokemon, league, data, t, Icons }) => {
             img: (
               <NameTT
                 id={[
-                  each.form ? `form_${each.form}` : '',
+                  each.evolution
+                    ? `evo_${each.evolution}`
+                    : each.form
+                    ? `form_${each.form}`
+                    : '',
                   `poke_${each.pokemon}`,
                 ]}
               >


### PR DESCRIPTION
Fixes the tooltip on a pokemon icon in the pvp table to indicate correctly whether it's a mega evo or not.

Resolves #717 