### PR TITLE
feat: exclude rocket pokemon

### DIFF
--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -537,11 +537,11 @@ module.exports = class Pokestop extends Model {
                 '>=',
                 safeTs * (multiInvasionMs ? 1000 : 1),
               )
+              if (hasConfirmed && onlyConfirmed) {
+                invasion.andWhere('confirmed', onlyConfirmed)
+              }
               invasion.andWhere((subQuery) => {
                 if (hasConfirmed) {
-                  if (onlyConfirmed) {
-                    subQuery.andWhere('confirmed', onlyConfirmed)
-                  }
                   if (rocketPokemon.length) {
                     subQuery
                       .whereIn('slot_1_pokemon_id', rocketPokemon)


### PR DESCRIPTION
- Exclude rocket pokemon from the pokestop popup
- Only ones that can actually be rewards
- Gradually hides the grunt type and different rocket pokemon rewards as you hide them, to help with clarity
- Fixes a filtering issue when using `only confirmed`

Resolves #685 