### PR TITLE
feat: interactive marker opacity

### DIFF
--- a/src/components/markers/gym.jsx
+++ b/src/components/markers/gym.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { renderToString } from 'react-dom/server'
 import L from 'leaflet'
+import getOpacity from '@services/functions/getOpacity'
 
 const getBadgeColor = (raidLevel) => {
   switch (raidLevel) {
@@ -83,6 +84,8 @@ export default function GymMarker(
       raidSize = Icons.getSize('raid', filters.filter[filterId])
     }
   }
+
+  const opacity = getOpacity(gym.raid_end_timestamp)
 
   const ReactIcon = (
     <div className="marker-image-holder top-overlay">
@@ -180,6 +183,7 @@ export default function GymMarker(
           src={raidIcon}
           alt={raidIcon}
           style={{
+            opacity,
             width: raidSize,
             height: raidSize,
             bottom: gymSize * 0.4 + slotModifier * raidMod.offsetY,
@@ -192,6 +196,7 @@ export default function GymMarker(
         <div
           className="iv-badge"
           style={{
+            opacity,
             backgroundColor: getBadgeColor(raid_level),
             bottom: gymSize * 0.4 * raidMod.offsetY,
             left: `${raidMod.offsetX * 200}%`,
@@ -203,6 +208,7 @@ export default function GymMarker(
               src={Icons.getMisc('mega')}
               alt="mega"
               style={{
+                opacity,
                 width: 17.5,
                 height: 'auto',
                 position: 'absolute',

--- a/src/components/markers/pokemon.jsx
+++ b/src/components/markers/pokemon.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { renderToString } from 'react-dom/server'
-import L, { Icon } from 'leaflet'
+import { Icon, divIcon } from 'leaflet'
+import getOpacity from '@services/functions/getOpacity'
 
 export const basicMarker = (iconUrl, size) =>
   new Icon({
@@ -10,6 +11,19 @@ export const basicMarker = (iconUrl, size) =>
     popupAnchor: [0, size * -0.6],
     className: 'marker',
   })
+
+const getBadge = (bestPvp) => {
+  switch (bestPvp) {
+    case 1:
+      return 'first'
+    case 2:
+      return 'second'
+    case 3:
+      return 'third'
+    default:
+      return ''
+  }
+}
 
 export const fancyMarker = (
   iconUrl,
@@ -23,23 +37,13 @@ export const fancyMarker = (
   userSettings,
 ) => {
   const { pokemon: pokemonMod, weather: weatherMod } = Icons.modifiers
-  let badge
-  switch (pkmn.bestPvp) {
-    case 1:
-      badge = 'first'
-      break
-    case 2:
-      badge = 'second'
-      break
-    case 3:
-      badge = 'third'
-      break
-    default:
-      break
-  }
+  const badge = getBadge(pkmn.best_pvp)
 
   const ReactIcon = (
-    <div className="marker-image-holder top-overlay">
+    <div
+      className="marker-image-holder top-overlay"
+      style={{ opacity: getOpacity(pkmn.expire_timestamp) }}
+    >
       <img
         src={iconUrl}
         alt={pkmn.pokemon_id}
@@ -127,7 +131,7 @@ export const fancyMarker = (
     </div>
   )
 
-  return L.divIcon({
+  return divIcon({
     popupAnchor: [
       0 + pokemonMod.popupX,
       size * -0.7 * pokemonMod.offsetY + pokemonMod.popupY,

--- a/src/components/markers/pokestop.jsx
+++ b/src/components/markers/pokestop.jsx
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react'
 import { renderToString } from 'react-dom/server'
 import L from 'leaflet'
+import getOpacity from '@services/functions/getOpacity'
 
 export default function stopMarker(
   pokestop,
@@ -47,9 +48,10 @@ export default function stopMarker(
     invasions.forEach((invasion) => {
       if (invasion.grunt_type) {
         filterId = `i${invasion.grunt_type}`
-        invasionIcons.unshift(
-          Icons.getInvasions(invasion.grunt_type, invasion.confirmed),
-        )
+        invasionIcons.unshift({
+          icon: Icons.getInvasions(invasion.grunt_type, invasion.confirmed),
+          opacity: getOpacity(invasion.incident_expire_timestamp),
+        })
         invasionSizes.unshift(
           Icons.getSize('invasion', filters.filter[filterId]),
         )
@@ -231,12 +233,13 @@ export default function stopMarker(
           )}
         </Fragment>
       ))}
-      {invasionIcons.map((icon, i) => (
+      {invasionIcons.map((invasion, i) => (
         <img
-          key={icon}
-          src={icon}
-          alt={icon}
+          key={invasion.icon}
+          src={invasion.icon}
+          alt={invasion.icon}
           style={{
+            opacity: invasion.opacity,
             width: invasionSizes[i],
             height: invasionSizes[i],
             bottom: baseSize * 0.5 * invasionMod.offsetY + invasionSizes[i] * i,

--- a/src/components/tiles/Pokemon.jsx
+++ b/src/components/tiles/Pokemon.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-bitwise */
-import React, { memo, useRef, useState } from 'react'
+import React, { memo, useRef, useState, useMemo } from 'react'
 import { Marker, Popup, Circle } from 'react-leaflet'
 
 import useMarkerTimer from '@hooks/useMarkerTimer'
@@ -107,10 +107,13 @@ const PokemonTile = ({
   const pvpCheck = item.bestPvp !== null && item.bestPvp < 4
   const weatherCheck = item.weather && userSettings.weatherIndicator
 
-  const finalLocation =
-    item.seen_type?.startsWith('nearby') || item.seen_type?.includes('lure')
-      ? getOffset([item.lat, item.lon], item.seen_type, item.id)
-      : [item.lat, item.lon]
+  const finalLocation = useMemo(
+    () =>
+      item.seen_type?.startsWith('nearby') || item.seen_type?.includes('lure')
+        ? getOffset([item.lat, item.lon], item.seen_type, item.id)
+        : [item.lat, item.lon],
+    [item.seen_type],
+  )
 
   useForcePopup(item.id, markerRef, params, setParams, done)
 

--- a/src/services/functions/getOpacity.js
+++ b/src/services/functions/getOpacity.js
@@ -1,0 +1,8 @@
+export default function getOpacity(timestamp) {
+  const now = Math.floor(Date.now() / 1000)
+  const diff = timestamp - now
+  if (!diff || diff > 600) return 1
+  if (diff > 300) return 0.75
+  if (diff > 60) return 0.5
+  return 0.25
+}


### PR DESCRIPTION
- Sets opacity of the marker based on the despawn time
- Active for pokemon, invasions, and raids
- Follows these rules:
  - < 1 min = 25%
  - < 5min = 50%
  - < 10min = 75%
  - More than 10min = 100%
- This does not interact with the marker memoization equality checks for performance reasons. In order to update opacity, you'll have to move the marker off screen and back again to rerender it

Resolves #683 