### PR TITLE
feat: remove quick gym button for poracle

### DIFF
--- a/public/base-locales/de.json
+++ b/public/base-locales/de.json
@@ -339,7 +339,7 @@
   "popup": "Popup",
   "pvp_level": "Level {{level}} PVP Stats",
   "pvp_mega": "Mega PVP Stats",
-  "webhook_entry": "Füge {{category}} zu {{name}} hinzu",
+  "webhook_entry": "Füge zu {{name}} hinzu",
   "distance": "Distanz",
   "gym": "Arena",
   "egg": "Ei",

--- a/public/base-locales/en.json
+++ b/public/base-locales/en.json
@@ -328,7 +328,8 @@
   "popup": "Popup",
   "pvp_level": "Level {{level}} PVP Stats",
   "pvp_mega": "Mega PVP Stats",
-  "webhook_entry": "Add {{category}} to {{name}}",
+  "webhook_entry": "Add to {{name}}",
+  "remove_webhook_entry": "Remove from {{name}}",
   "distance": "Distance",
   "gym": "Gym",
   "egg": "Egg",
@@ -603,5 +604,6 @@
   "denied": "Denied",
   "showcase": "Showcase",
   "unknown_event": "Unknown Event",
-  "scanner_countdown": "Available in {{time}}s"
+  "scanner_countdown": "Available in {{time}}s",
+  "success": "Success"
 }

--- a/public/base-locales/es.json
+++ b/public/base-locales/es.json
@@ -351,7 +351,7 @@
   "galarian": "Galariano",
   "finish": "Terminar",
   "submission_cells_subtitle": "Muestra información útil para enviar nuevos PDI.",
-  "webhook_entry": "Agregar {{category}} a {{name}}",
+  "webhook_entry": "Agregar a {{name}}",
   "distance": "Distancia",
   "gym": "Gimnasio",
   "egg": "Huevo",

--- a/public/base-locales/fr.json
+++ b/public/base-locales/fr.json
@@ -372,7 +372,7 @@
   "has_quest_indicator": "Couleur alternative pour afficher les Quêtes",
   "show_ar_badge": "Afficher les Badges RA",
   "pvp_mega": "Stats PvP Méga",
-  "webhook_entry": "Ajouter {{category}} à {{name}}",
+  "webhook_entry": "Ajouter à {{name}}",
   "distance": "Distance",
   "gym": "Arène",
   "egg": "Œuf",

--- a/public/base-locales/it.json
+++ b/public/base-locales/it.json
@@ -365,7 +365,7 @@
   "popup": "Apparire",
   "pvp_level": "Statistiche PVP di livello {{level}}",
   "pvp_mega": "Mega statistiche PVP",
-  "webhook_entry": "Aggiungi {{category}} a {{name}}",
+  "webhook_entry": "Aggiungi a {{name}}",
   "pokestops": "PokéStop",
   "spawnpoints": "punti di spawn",
   "distance": "Distanza",

--- a/public/base-locales/ja.json
+++ b/public/base-locales/ja.json
@@ -329,7 +329,7 @@
   "popup": "現れる",
   "pvp_level": "レベル{{level}} PVP統計",
   "pvp_mega": "メガPVP統計",
-  "webhook_entry": "{{category}}を{{name}}に追加します",
+  "webhook_entry": "を{{name}}に追加します",
   "distance": "距離",
   "gym": "ジム",
   "egg": "卵",

--- a/public/base-locales/ko.json
+++ b/public/base-locales/ko.json
@@ -397,7 +397,7 @@
   "popup": "팝업",
   "pvp_level": "레벨 {{level}} PVP 통계",
   "pvp_mega": "메가 PVP 통계",
-  "webhook_entry": "{{name}}에 {{category}} 추가",
+  "webhook_entry": "{{name}}에 추가",
   "distance": "거리",
   "gym": "헬스장",
   "egg": "계란",

--- a/public/base-locales/nl.json
+++ b/public/base-locales/nl.json
@@ -304,7 +304,7 @@
   "popup": "Popup",
   "pvp_level": "Level {{level}} PVP Statistieken",
   "pvp_mega": "Mega PVP Statistieken",
-  "webhook_entry": "Voeg {{category}} toe aan {{name}}",
+  "webhook_entry": "Voeg toe aan {{name}}",
   "distance": "Afstand",
   "gym": "Gym",
   "egg": "Egg",

--- a/public/base-locales/pl.json
+++ b/public/base-locales/pl.json
@@ -347,7 +347,7 @@
   "alola": "Alola",
   "galarian": "galarian",
   "submission_cells_subtitle": "Wyświetla informacje przydatne w dodawaniu nowych POI",
-  "webhook_entry": "Dodaj {{category}} do {{name}}",
+  "webhook_entry": "Dodaj do {{name}}",
   "distance": "Dystans",
   "gym": "Gym",
   "egg": "Jajko",

--- a/public/base-locales/pt-br.json
+++ b/public/base-locales/pt-br.json
@@ -303,7 +303,7 @@
   "popup": "Aparecer",
   "pvp_level": "Nível {{level}} Estatísticas PVP",
   "pvp_mega": "Mega PVP Stats",
-  "webhook_entry": "Adicione {{category}} a {{name}}",
+  "webhook_entry": "Adicione a {{name}}",
   "distance": "Distância",
   "gym": "Academia",
   "egg": "Ovo",

--- a/public/base-locales/ru.json
+++ b/public/base-locales/ru.json
@@ -329,7 +329,7 @@
   "popup": "Неожиданно возникнуть",
   "pvp_level": "Уровень {{level}} PVP Статистика",
   "pvp_mega": "Мега статистика PVP",
-  "webhook_entry": "Добавить {{category}} в {{name}}",
+  "webhook_entry": "Добавить в {{name}}",
   "distance": "Расстояние",
   "gym": "Спортзал",
   "egg": "Яйцо",

--- a/public/base-locales/sv.json
+++ b/public/base-locales/sv.json
@@ -302,7 +302,7 @@
   "popup": "Dyka upp",
   "pvp_level": "Nivå {{level}} PVP-statistik",
   "pvp_mega": "Mega PVP-statistik",
-  "webhook_entry": "Lägg till {{category}} till {{name}}",
+  "webhook_entry": "Lägg till {{name}}",
   "distance": "Distans",
   "gym": "Gym",
   "egg": "Ägg",

--- a/public/base-locales/th.json
+++ b/public/base-locales/th.json
@@ -302,7 +302,7 @@
   "popup": "ป๊อปอัพ",
   "pvp_level": "ระดับ {{level}} สถิติ PVP",
   "pvp_mega": "สถิติเมก้า PVP",
-  "webhook_entry": "เพิ่ม {{category}} ใน {{name}}",
+  "webhook_entry": "เพิ่ม ใน {{name}}",
   "distance": "ระยะทาง",
   "gym": "โรงยิม",
   "egg": "ไข่",

--- a/public/base-locales/zh-tw.json
+++ b/public/base-locales/zh-tw.json
@@ -303,7 +303,7 @@
   "popup": "彈出",
   "pvp_level": "等級 {{level}} PVP 統計",
   "pvp_mega": "超級 PVP 統計",
-  "webhook_entry": "將 {{category}} 添加到 {{name}}",
+  "webhook_entry": "將 添加到 {{name}}",
   "distance": "距離",
   "gym": "健身房",
   "egg": "蛋",

--- a/server/src/services/Fetch.js
+++ b/server/src/services/Fetch.js
@@ -22,11 +22,11 @@ module.exports = class Fetch {
     return fetchNests()
   }
 
-  static async webhookApi(category, discordId, method, name, data) {
-    return webhookApi(category, discordId, method, name, data)
+  static async webhookApi(...args) {
+    return webhookApi(...args)
   }
 
-  static async scannerApi(category, method, data, user) {
-    return scannerApi(category, method, data, user)
+  static async scannerApi(...args) {
+    return scannerApi(...args)
   }
 }

--- a/src/components/popups/Gym.jsx
+++ b/src/components/popups/Gym.jsx
@@ -131,7 +131,7 @@ export default function GymPopup({
   )
 }
 
-const MenuActions = ({ gym, perms, hasRaid, t, badge, setBadge }) => {
+const MenuActions = ({ gym, perms, hasRaid, badge, setBadge }) => {
   const hideList = useStatic((state) => state.hideList)
   const setHideList = useStatic((state) => state.setHideList)
   const excludeList = useStatic((state) => state.excludeList)
@@ -141,6 +141,7 @@ const MenuActions = ({ gym, perms, hasRaid, t, badge, setBadge }) => {
   const { gymValidDataLimit } = useStatic((state) => state.config)
 
   const selectedWebhook = useStore((state) => state.selectedWebhook)
+  const webhookData = useStatic((state) => state.webhookData)
 
   const filters = useStore((state) => state.filters)
   const setFilters = useStore((state) => state.setFilters)
@@ -149,6 +150,16 @@ const MenuActions = ({ gym, perms, hasRaid, t, badge, setBadge }) => {
   const [badgeMenu, setBadgeMenu] = useState(false)
 
   const addWebhook = useWebhook({ category: 'quickGym', selectedWebhook })
+  const hasGymHook = webhookData?.[selectedWebhook]?.gym?.find(
+    (x) => x.gym_id === gym.id,
+  )
+  const hasRaidHook = webhookData?.[selectedWebhook]?.raid?.find(
+    (x) => x.gym_id === gym.id,
+  )
+  const hasEggHook = webhookData?.[selectedWebhook]?.egg?.find(
+    (x) => x.gym_id === gym.id,
+  )
+  const hasWebhook = !!hasGymHook || !!hasRaidHook || !!hasEggHook
   const {
     id,
     team_id,
@@ -248,12 +259,19 @@ const MenuActions = ({ gym, perms, hasRaid, t, badge, setBadge }) => {
   perms.webhooks.forEach((hook) => {
     options.push({
       name: (
-        <Trans i18nKey="webhook_entry">
-          {{ category: t('gym') }}
+        <Trans i18nKey={hasWebhook ? 'remove_webhook_entry' : 'webhook_entry'}>
           {{ name: hook }}
         </Trans>
       ),
-      action: () => addWebhook(gym),
+      action: () => {
+        if (hasWebhook) {
+          if (hasGymHook) addWebhook(hasGymHook.uid, 'gym-delete')
+          if (hasRaidHook) addWebhook(hasRaidHook.uid, 'raid-delete')
+          if (hasEggHook) addWebhook(hasEggHook.uid, 'egg-delete')
+        } else {
+          addWebhook(gym, 'quickGym')
+        }
+      },
       key: hook,
     })
   })

--- a/src/hooks/useWebhook.js
+++ b/src/hooks/useWebhook.js
@@ -18,11 +18,19 @@ export default function useWebhook({ category, selectedWebhook }) {
           `webhook_success_${category.replace('quick', '').toLowerCase()}`,
         )
       }
-      setWebhookAlert({
-        open: true,
-        severity: data.webhook.status,
-        message: data.webhook.message,
-      })
+      if (data.webhook.status === 'ok') {
+        setWebhookAlert({
+          open: true,
+          severity: 'success',
+          message: t('success'),
+        })
+      } else {
+        setWebhookAlert({
+          open: true,
+          severity: data.webhook.status,
+          message: data.webhook.message,
+        })
+      }
       if (webhookData?.[selectedWebhook]) {
         return setWebhookData({
           ...webhookData,
@@ -35,10 +43,10 @@ export default function useWebhook({ category, selectedWebhook }) {
     }
   }, [data])
 
-  const addWebhook = (incomingData) => {
+  const addWebhook = (incomingData, cat) => {
     syncWebhook({
       variables: {
-        category,
+        category: cat,
         data: incomingData,
         name: selectedWebhook,
         status: 'POST',


### PR DESCRIPTION
- Allows you to remove gym, raid, and egg tracking from the gym popup menu if you're already tracking one, instead of only allowing you to add the same ones, even when you were already tracking it

Resolves #615 