### PR TITLE
fix: scan on demand cooldowns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactmap",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "description": "React based frontend map.",
   "main": "ReactMap.js",
   "author": "TurtIeSocks <58572875+TurtIeSocks@users.noreply.github.com>",

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -7,6 +7,7 @@ import L from 'leaflet'
 import Utility from '@services/Utility'
 import { useStatic, useStore } from '@hooks/useStore'
 import useTileLayer from '@hooks/useTileLayer'
+import useCooldown from '@hooks/useCooldown'
 
 import Nav from './layout/Nav'
 import QueryData from './QueryData'
@@ -40,6 +41,7 @@ export default function Map({
   Utility.analytics(window.location.pathname)
 
   const map = useMap()
+  useCooldown()
   map.attributionControl.setPrefix(config.attributionPrefix || '')
 
   const theme = useTheme()

--- a/src/components/layout/dialogs/scanner/ScanOnDemand.jsx
+++ b/src/components/layout/dialogs/scanner/ScanOnDemand.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-no-useless-fragment */
 import React, { useEffect, useState } from 'react'
 import { useQuery, useLazyQuery } from '@apollo/client'
-import { useStatic, useStore } from '@hooks/useStore'
+import { useStore } from '@hooks/useStore'
 import Query from '@services/Query'
 import ScanNextTarget from './ScanNextTarget'
 import ScanZoneTarget from './ScanZoneTarget'
@@ -36,7 +36,6 @@ export default function ScanOnDemand({
   const [scanCoords, setScanCoords] = useState([location])
   const [scanNextType, setScanNextType] = useState('S')
   const [scanZoneSize, setScanZoneSize] = useState(1)
-  const scannerCooldown = useStatic((s) => s.scannerCooldown)
 
   const { data: scanAreas } = useQuery(Query.scanAreas())
   const [demandScan, { error: scannerError, data: scannerResponse }] =
@@ -73,10 +72,10 @@ export default function ScanOnDemand({
       demandScan()
       setScanMode('loading')
       const timer = mode === 'scanNext' ? scanNextCooldown : scanZoneCooldown
-      useStatic.setState({
+      useStore.setState({
         scannerCooldown:
           (typeof timer === 'number' ? Math.floor(timer) : 0) *
-          (mode === 'scanNext' ? scanCoords.length : scanZoneSize),
+          scanCoords.length,
       })
     }
   }, [scanMode])
@@ -116,16 +115,6 @@ export default function ScanOnDemand({
       scannerQueueResponse.scanner = {}
     }
   }, [!!scannerQueueResponse?.scanner])
-
-  useEffect(() => {
-    if (scannerCooldown > 0) {
-      const timeout = setInterval(() => {
-        const newTime = scannerCooldown - 1
-        useStatic.setState({ scannerCooldown: newTime })
-      }, 1000)
-      return () => clearInterval(timeout)
-    }
-  }, [scannerCooldown])
 
   return (
     <>

--- a/src/components/layout/dialogs/scanner/Shared.jsx
+++ b/src/components/layout/dialogs/scanner/Shared.jsx
@@ -7,7 +7,7 @@ import {
 } from '@material-ui/core'
 import PermScanWifiIcon from '@material-ui/icons/PermScanWifi'
 import ClearIcon from '@material-ui/icons/Clear'
-import { useStatic } from '@hooks/useStore'
+import { useStore } from '@hooks/useStore'
 
 import { Trans, useTranslation } from 'react-i18next'
 
@@ -42,7 +42,7 @@ export function ScanQueue({ queue = 0 }) {
 
 export function ScanConfirm({ isInAllowedArea, setMode, areaRestrictions }) {
   const { t } = useTranslation()
-  const scannerCooldown = useStatic((s) => s.scannerCooldown)
+  const scannerCooldown = useStore((s) => s.scannerCooldown)
 
   return (
     <StyledListItem

--- a/src/hooks/useCooldown.js
+++ b/src/hooks/useCooldown.js
@@ -1,0 +1,16 @@
+import { useEffect } from 'react'
+import { useStore } from './useStore'
+
+export default function useCooldown() {
+  const scannerCooldown = useStore((s) => s.scannerCooldown)
+
+  useEffect(() => {
+    if (scannerCooldown > 0) {
+      const timeout = setInterval(() => {
+        const newTime = scannerCooldown - 1
+        useStore.setState({ scannerCooldown: newTime })
+      }, 1000)
+      return () => clearInterval(timeout)
+    }
+  }, [scannerCooldown])
+}

--- a/src/hooks/useStore.js
+++ b/src/hooks/useStore.js
@@ -83,6 +83,7 @@ export const useStore = create(
       setPopups: (popups) => set({ popups }),
       motdIndex: 0,
       setMotdIndex: (motdIndex) => set({ motdIndex }),
+      scannerCooldown: 0,
     }),
     {
       name: 'local-state',
@@ -156,5 +157,4 @@ export const useStatic = create((set) => ({
   setResetFilters: (resetFilters) => set({ resetFilters }),
   extraUserFields: [],
   setExtraUserFields: (extraUserFields) => set({ extraUserFields }),
-  scannerCooldown: 0,
 }))


### PR DESCRIPTION
- externalizes the cooldown into a hook so it works even when scanNext/scanZone isn't open
- persists the cooldown state between refreshes, but only in localStorage. Technically this can be worked around if someone cleared local storage but that's incredibly tedious and I think unlikely that any user will be abusing it that way. Maybe long term we could add it server side but for now I'm not that worried about it.