### PR TITLE
Bring back map markers when using scanZone

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -135,7 +135,7 @@ export default function Map({
         Object.entries({ ...ui, ...ui.wayfarer, ...ui.admin }).map(
           ([category, value]) => {
             let enabled = false
-            if (scanZoneMode === 'setLocation') return null
+
             switch (category) {
               case 'scanAreas':
                 if (


### PR DESCRIPTION
In https://github.com/WatWowMap/ReactMap/pull/580 map markers were disabled on scanZone feature due to performance issues. I think we're past these issues so we can bring markers back. 
I ran some tests locally on desktop and mobile and I hardly can see any difference when using map with markers or map with markers and scanZone on top

Btw I hope that's the only change that needs to be done ;)