### PR TITLE
fix: use correct modifier getters

### DIFF
--- a/src/components/layout/general/ActiveWeather.jsx
+++ b/src/components/layout/general/ActiveWeather.jsx
@@ -21,7 +21,7 @@ export default function ActiveWeather({
   const location = useStore((state) => state.location)
   const [open, setOpen] = useState(false)
 
-  const { disableColorShift = false } = Icons.getModifiers('weather')
+  const [{ disableColorShift = false }] = Icons.getModifiers('weather')
   const active = weather.find(
     (cell) =>
       cell && booleanPointInPolygon(point(location), polygon([cell.polygon])),

--- a/src/components/markers/device.js
+++ b/src/components/markers/device.js
@@ -2,7 +2,7 @@ import { Icon } from 'leaflet'
 
 export default function getDeviceMarkers(isOnline, Icons) {
   const size = Icons.getSize('device')
-  const { offsetX, offsetY, popupX, popupY, sizeMultiplier } =
+  const [{ offsetX, offsetY, popupX, popupY, sizeMultiplier }] =
     Icons.getModifiers('device')
   return new Icon({
     iconUrl: Icons.getDevices(isOnline),

--- a/src/components/markers/gym.jsx
+++ b/src/components/markers/gym.jsx
@@ -37,7 +37,7 @@ export default function GymMarker(
     ex_raid_eligible,
     ar_scan_eligible,
   } = gym
-  const { gym: gymMod, raid: raidMod } = Icons.modifiers
+  const [gymMod, raidMod] = Icons.getModifiers('gym', 'raid')
 
   const filledSlots = available_slots !== null ? 6 - available_slots : 0
   let filterId =

--- a/src/components/markers/nest.jsx
+++ b/src/components/markers/nest.jsx
@@ -13,15 +13,9 @@ export default function nestMarker(
   const { types } = pokemon
   const filterId = `${nest.pokemon_id}-${nest.pokemon_form}`
   const size = Icons.getSize('nest', filters.filter[filterId])
-  const {
-    offsetX,
-    offsetY,
-    popupX,
-    popupY,
-    sizeMultiplier,
-    nestMonSizeMulti = 1,
-  } = Icons.getModifiers('nest')
-  const { nest: nestMod } = Icons.modifiers
+  const [
+    { offsetX, offsetY, popupX, popupY, sizeMultiplier, nestMonSizeMulti = 1 },
+  ] = Icons.getModifiers('nest')
   const opacity = recent ? 1 : 0.5
 
   const ReactIcon = (
@@ -56,8 +50,8 @@ export default function nestMarker(
         style={{
           width: size * nestMonSizeMulti,
           height: size * nestMonSizeMulti,
-          bottom: nestMod.offsetY - 1,
-          left: nestMod.offsetX - 1,
+          bottom: offsetY - 1,
+          left: offsetX - 1,
           opacity,
         }}
       />
@@ -68,8 +62,8 @@ export default function nestMarker(
     iconSize: [size * sizeMultiplier, size * sizeMultiplier],
     iconAnchor: [(size / 2) * offsetX, (size / 0.75) * offsetY],
     popupAnchor: [
-      0 + popupX - nestMod.offsetX * 0.6 + nestMod.popupX,
-      -8 - size + popupY - nestMod.offsetY * 0.6 + nestMod.popupY,
+      0 + popupX - offsetX * 0.6 + popupX,
+      -8 - size + popupY - offsetY * 0.6 + popupY,
     ],
     className: 'nest-marker',
     html: renderToString(ReactIcon),

--- a/src/components/markers/pokemon.jsx
+++ b/src/components/markers/pokemon.jsx
@@ -37,7 +37,7 @@ export const fancyMarker = (
   userSettings,
   levelCircle,
 ) => {
-  const { pokemon: pokemonMod, weather: weatherMod } = Icons.modifiers
+  const [pokemonMod, weatherMod] = Icons.getModifiers('pokemon', 'weather')
   const badge = getBadge(pkmn.bestPvp)
 
   const ReactIcon = (

--- a/src/components/markers/pokestop.jsx
+++ b/src/components/markers/pokestop.jsx
@@ -14,11 +14,11 @@ export default function stopMarker(
   hasEvent,
 ) {
   const { lure_id, ar_scan_eligible, power_up_level, events } = pokestop
-  const {
-    invasion: invasionMod,
-    pokestop: pokestopMod,
-    reward: rewardMod,
-  } = Icons.modifiers
+  const [invasionMod, pokestopMod, rewardMod] = Icons.getModifiers(
+    'invasion',
+    'pokestop',
+    'reward',
+  )
 
   let filterId = 's0'
   let popupYOffset = 1.3

--- a/src/components/markers/weather.jsx
+++ b/src/components/markers/weather.jsx
@@ -3,14 +3,16 @@ import { renderToString } from 'react-dom/server'
 import L from 'leaflet'
 
 export default function weatherMarker(weather, Icons, timeOfDay) {
-  const {
-    offsetX,
-    offsetY,
-    popupX,
-    popupY,
-    sizeMultiplier,
-    disableColorShift = false,
-  } = Icons.getModifiers('weather')
+  const [
+    {
+      offsetX,
+      offsetY,
+      popupX,
+      popupY,
+      sizeMultiplier,
+      disableColorShift = false,
+    },
+  ] = Icons.getModifiers('weather')
 
   return L.divIcon({
     iconAnchor: [17 * offsetX, 17 * offsetY],

--- a/src/components/tiles/Spawnpoint.jsx
+++ b/src/components/tiles/Spawnpoint.jsx
@@ -5,7 +5,7 @@ import { Marker, Circle, Popup } from 'react-leaflet'
 import PopupContent from '../popups/Spawnpoint'
 
 const SpawnpointTile = ({ item, Icons, ts }) => {
-  const modifiers = Icons.getModifiers('spawnpoint')
+  const [modifiers] = Icons.getModifiers('spawnpoint')
   const popup = (
     <Popup position={[item.lat, item.lon]}>
       <PopupContent spawnpoint={item} ts={ts} />

--- a/src/services/Icons.js
+++ b/src/services/Icons.js
@@ -166,18 +166,18 @@ export default class UIcons {
     }
   }
 
-  getSize(category, filterId) {
+  getSize(category, filter) {
     const refSizes = this.sizes[category]
-    const baseSize = filterId ? refSizes[filterId.size] : refSizes.md
+    const baseSize = filter ? refSizes[filter.size] : refSizes.md
     return this.modifiers[category]
       ? baseSize * this.modifiers[category].sizeMultiplier
       : baseSize
   }
 
-  getModifiers(category) {
-    return this.modifiers[category]
-      ? this.modifiers[category]
-      : this.modifiers.base
+  getModifiers(...categories) {
+    return categories.map((category) =>
+      this.modifiers[category] ? this.modifiers[category] : this.modifiers.base,
+    )
   }
 
   getIconById(id) {


### PR DESCRIPTION
- Fixes some spots that weren't accessing icon modifiers correctly (directly, rather than the getter function)
- Modifiers the getter function to accept unlimited args in one call
- Results are now returned as an array
- Resolves an issue when the fallback icon is triggered

@plinytheelder, please be sure to update your custom pokestop marker file accordingly