### PR TITLE
fix: add routes to auth log

### DIFF
--- a/server/src/models/Pokemon.js
+++ b/server/src/models/Pokemon.js
@@ -73,7 +73,7 @@ module.exports = class Pokemon extends Model {
   }
 
   /**
-   * @param {import("../types").Perms} perms
+   * @param {import("../types").Permissions} perms
    * @param {object} args
    * @param {import("../types").DbContext} ctx
    * @returns {{ filterMap: Record<string, PkmnFilter>, globalFilter: PkmnFilter }}
@@ -118,7 +118,7 @@ module.exports = class Pokemon extends Model {
   }
 
   /**
-   * @param {import("../types").Perms} perms
+   * @param {import("../types").Permissions} perms
    * @param {object} args
    * @param {import("../types").DbContext} ctx
    * @returns {Promise<Partial<import('../types').Pokemon>[]>}
@@ -409,7 +409,7 @@ module.exports = class Pokemon extends Model {
   }
 
   /**
-   * @param {import("../types").Perms} perms
+   * @param {import("../types").Permissions} perms
    * @param {object} args
    * @param {import("../types").DbContext} ctx
    * @returns {Promise<Partial<import('../types').Pokemon>[]>}
@@ -556,7 +556,7 @@ module.exports = class Pokemon extends Model {
   }
 
   /**
-   * @param {import("../types").Perms} perms
+   * @param {import("../types").Permissions} perms
    * @param {object} args
    * @param {import("../types").DbContext} ctx
    * @param {number} distance

--- a/server/src/services/DbCheck.js
+++ b/server/src/services/DbCheck.js
@@ -376,7 +376,7 @@ module.exports = class DbCheck {
   /**
    * @template {import('../types').BaseRecord} T
    * @param {import("../models").ScannerModelKeys} model
-   * @param {import("../types").Perms} perms
+   * @param {import("../types").Permissions} perms
    * @param {object} args
    * @param {number} userId
    * @param {'getAll' | string} method
@@ -415,7 +415,7 @@ module.exports = class DbCheck {
   /**
    * @template {import('../types').BaseRecord} T
    * @param {import("../models").ScannerModelKeys} model
-   * @param {import("../types").Perms} perms
+   * @param {import("../types").Permissions} perms
    * @param {object} args
    * @param {'search' | string} method
    * @returns {Promise<T[]>}
@@ -441,7 +441,7 @@ module.exports = class DbCheck {
   }
 
   /**
-   * @param {import("../types").Perms} perms
+   * @param {import("../types").Permissions} perms
    * @param {object} args
    * @returns {Promise<[
    *  import('../types').BaseRecord[],

--- a/server/src/services/logUserAuth.js
+++ b/server/src/services/logUserAuth.js
@@ -1,6 +1,12 @@
-const fetch = require('node-fetch')
+// @ts-check
+const { default: fetch } = require('node-fetch')
 const { log, HELPERS } = require('./logger')
 
+/**
+ * Convert camelCase to Capitalized Words
+ * @param {string} str
+ * @returns
+ */
 const capCamel = (str) =>
   str
     .replace(/([a-z](?=[A-Z]))/g, '$1 ')
@@ -8,6 +14,11 @@ const capCamel = (str) =>
     .map((str2) => str2.charAt(0).toUpperCase() + str2.slice(1))
     .join(' ')
 
+/**
+ * Map permissions to a string
+ * @param {string[]} perms
+ * @param {import('../types').Permissions} userPerms
+ */
 const mapPerms = (perms, userPerms) =>
   perms
     .map(
@@ -15,12 +26,19 @@ const mapPerms = (perms, userPerms) =>
     )
     .join('\n')
 
-module.exports = async function getAuthInfo(req, user, strategy = 'custom') {
+/**
+ * Log user authentication to Discord
+ * @param {import('express').Request} req
+ * @param {import('../types').User} user
+ * @param {string} strategy
+ * @returns
+ */
+async function getAuthInfo(req, user, strategy = 'custom') {
   const ip =
     req.headers['cf-connecting-ip'] ||
-    (req.headers['x-forwarded-for'] || '').split(', ')[0] ||
+    `${req.headers['x-forwarded-for'] || ''}`.split(', ')[0] ||
     (req.connection.remoteAddress || req.connection.localAddress).match(
-      '[0-9]+.[0-9].+[0-9]+.[0-9]+$',
+      /[0-9]+.[0-9].+[0-9]+.[0-9]+$/,
     )[0]
 
   const geo = await fetch(
@@ -76,17 +94,17 @@ module.exports = async function getAuthInfo(req, user, strategy = 'custom') {
       },
       {
         name: 'Mobile',
-        value: `${Boolean(geo.mobile)}`,
+        value: `${!!geo.mobile}`,
         inline: true,
       },
       {
         name: 'Proxy',
-        value: `${Boolean(geo.proxy)}`,
+        value: `${!!geo.proxy}`,
         inline: true,
       },
       {
         name: 'Hosting',
-        value: `${Boolean(geo.hosting)}`,
+        value: `${!!geo.hosting}`,
         inline: true,
       },
       {
@@ -120,7 +138,7 @@ module.exports = async function getAuthInfo(req, user, strategy = 'custom') {
       {
         name: 'Other',
         value: mapPerms(
-          ['nests', 'weather', 'scanAreas', 'donor', 'backups'],
+          ['nests', 'weather', 'scanAreas', 'donor', 'backups', 'routes'],
           user.perms,
         ),
         inline: true,
@@ -183,3 +201,5 @@ module.exports = async function getAuthInfo(req, user, strategy = 'custom') {
   }
   return embed
 }
+
+module.exports = getAuthInfo

--- a/server/src/types.d.ts
+++ b/server/src/types.d.ts
@@ -41,33 +41,14 @@ export interface DbContext {
   hasAlignment: boolean
 }
 
-export interface Perms {
-  map: boolean
-  pokemon: boolean
-  iv: boolean
-  pvp: boolean
-  gyms: boolean
-  raids: boolean
-  pokestops: boolean
-  eventStops: boolean
-  quests: boolean
-  lures: boolean
-  portals: boolean
-  submissionCells: boolean
-  invasions: boolean
-  nests: boolean
-  scanAreas: boolean
-  weather: boolean
-  spawnpoints: boolean
-  s2cells: boolean
-  scanCells: boolean
-  devices: boolean
-  donor: boolean
-  gymBadges: boolean
-  backups: boolean
-  areaRestrictions: string[]
-  webhooks: string[]
-  scanner: string[]
+export interface User {
+  perms: Permissions
+  valid: boolean
+  id: number
+  discordId: string
+  username: string
+  telegramId: string
+  avatar: string
 }
 
 export interface Pokemon {
@@ -237,6 +218,8 @@ export interface Permissions {
   gymBadges: boolean
   backups: boolean
   routes: boolean
+  blocked: boolean
+  blockedGuildNames: string[]
   scanner: string[]
   areaRestrictions: string[]
   webhooks: string[]


### PR DESCRIPTION
- Add `routes` permission to the discord auth log embed
- Fix and force typing in the `logUserAuth.js` file
- Cleanup types, somehow had a duplicate `Permissions` and `Perms` interface

Resolves #798 