### PR TITLE
Leaflet bug fixes

### DIFF
--- a/src/components/Container.jsx
+++ b/src/components/Container.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { MapContainer, Pane } from 'react-leaflet'
+import { MapContainer } from 'react-leaflet'
 
 import useGenerate from '@hooks/useGenerate'
 import useRefresh from '@hooks/useRefresh'
@@ -21,10 +21,6 @@ export default function Container({ serverSettings, params, location, zoom }) {
           : zoom
       }
       zoomControl={false}
-      // style={{
-      //   width: '100vw',
-      //   height: '100vh',
-      // }}
       maxBounds={[
         [-90, -210],
         [90, 210],
@@ -34,9 +30,6 @@ export default function Container({ serverSettings, params, location, zoom }) {
       {serverSettings.user && serverSettings.user.perms.map && (
         <Map serverSettings={serverSettings} params={params} />
       )}
-      <Pane name="geojson" style={{ zIndex: 501 }} />
-      <Pane name="circlePane" style={{ zIndex: 450, pointerEvents: 'none' }} />
-      <Pane name="scanCells" style={{ zIndex: 400 }} />
     </MapContainer>
   )
 }

--- a/src/components/Container.jsx
+++ b/src/components/Container.jsx
@@ -37,7 +37,6 @@ export default function Container({ serverSettings, params, location, zoom }) {
       <Pane name="geojson" style={{ zIndex: 501 }} />
       <Pane name="circlePane" style={{ zIndex: 450, pointerEvents: 'none' }} />
       <Pane name="scanCells" style={{ zIndex: 400 }} />
-      <Pane name="routes" style={{ zIndex: 399 }} />
     </MapContainer>
   )
 }

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -4,6 +4,7 @@ import React, { Component } from 'react'
 import { Grid, Typography, Button } from '@mui/material'
 import Refresh from '@mui/icons-material/Refresh'
 import { withTranslation } from 'react-i18next'
+import Notification from './layout/general/Notification'
 
 // This component uses React Classes due to componentDidCatch() not being available in React Hooks
 // Do not use this as a base for other components
@@ -12,21 +13,21 @@ class ErrorBoundary extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      hasError: false,
       message: '',
+      errorCount: 0,
     }
   }
 
   componentDidCatch(error) {
     console.error(error)
-    this.setState({
-      hasError: true,
+    this.setState((prev) => ({
       message: error?.message || '',
-    })
+      errorCount: prev.errorCount + 1,
+    }))
   }
 
   render() {
-    return this.state.hasError ? (
+    return this.state.errorCount > 5 ? (
       <Grid
         container
         justifyContent="center"
@@ -63,7 +64,18 @@ class ErrorBoundary extends Component {
         </Grid>
       </Grid>
     ) : (
-      this.props.children
+      <>
+        <Notification
+          open={this.state.errorCount > 0}
+          messages={this.state.message}
+          cb={() => this.setState({ errorCount: 0 })}
+          severity="error"
+          title="react_error"
+        >
+          <Typography>{this.state.message}</Typography>
+        </Notification>
+        {this.props.children || null}
+      </>
     )
   }
 }

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useEffect, useCallback, useLayoutEffect } from 'react'
 import { useMap, ZoomControl, TileLayer } from 'react-leaflet'
 import { useMediaQuery, useTheme } from '@mui/material'
-import L from 'leaflet'
+import { control } from 'leaflet'
 
 import Utility from '@services/Utility'
 import { useStatic, useStore } from '@hooks/useStore'
@@ -104,18 +104,21 @@ export default function Map({
     }
   }, [windowState])
 
-  useEffect(() => {
-    const lc = L.control.locate({
-      position: 'bottomright',
-      icon: 'fas fa-crosshairs',
-      keepCurrentZoomLevel: true,
-      setView: 'untilPan',
-    })
-    if (settings.navigationControls === 'leaflet') {
-      lc.addTo(map)
+  useLayoutEffect(() => {
+    if (settings.navigationControls === 'leaflet' && map) {
+      const lc = control
+        .locate({
+          position: 'bottomright',
+          icon: 'fas fa-crosshairs',
+          keepCurrentZoomLevel: true,
+          setView: 'untilPan',
+        })
+        .addTo(map)
+      return () => {
+        lc.remove()
+      }
     }
-    return () => lc.remove()
-  }, [settings.navigationControls])
+  }, [settings.navigationControls, map])
 
   useEffect(() => {
     useStatic.setState({ isMobile, isTablet })

--- a/src/components/layout/general/Notification.jsx
+++ b/src/components/layout/general/Notification.jsx
@@ -29,10 +29,12 @@ export default function Notification({
   React.useEffect(() => {
     setAlert(open)
 
-    const timer = setTimeout(() => {
-      handleClose()
-    }, 5000)
-    return () => clearTimeout(timer)
+    if (open) {
+      const timer = setTimeout(() => {
+        handleClose()
+      }, 5000)
+      return () => clearTimeout(timer)
+    }
   }, [open])
 
   return (

--- a/src/components/layout/general/Notification.jsx
+++ b/src/components/layout/general/Notification.jsx
@@ -3,6 +3,7 @@ import Alert from '@mui/material/Alert'
 import Snackbar from '@mui/material/Snackbar'
 import Slide from '@mui/material/Slide'
 import { useTranslation, Trans } from 'react-i18next'
+import { AlertTitle } from '@mui/material'
 
 function SlideTransition(props) {
   // eslint-disable-next-line react/jsx-props-no-spreading
@@ -15,6 +16,7 @@ export default function Notification({
   i18nKey,
   messages,
   cb,
+  title,
 }) {
   const { t } = useTranslation()
   const [alert, setAlert] = React.useState(true)
@@ -26,6 +28,11 @@ export default function Notification({
 
   React.useEffect(() => {
     setAlert(open)
+
+    const timer = setTimeout(() => {
+      handleClose()
+    }, 5000)
+    return () => clearTimeout(timer)
   }, [open])
 
   return (
@@ -40,6 +47,7 @@ export default function Notification({
         variant="filled"
         style={{ textAlign: 'center', color: 'white' }}
       >
+        {title && <AlertTitle>{t(title)}</AlertTitle>}
         {i18nKey
           ? messages.map((message, i) => (
               <React.Fragment key={message.key}>

--- a/src/components/tiles/Route.jsx
+++ b/src/components/tiles/Route.jsx
@@ -4,7 +4,6 @@ import * as React from 'react'
 import { Marker, Polyline, useMapEvents } from 'react-leaflet'
 import { darken } from '@mui/material'
 
-import ErrorBoundary from '@components/ErrorBoundary'
 import RoutePopup from '@components/popups/Route'
 
 import routeMarker from '../markers/route'
@@ -62,13 +61,6 @@ const RouteTile = ({ item, Icons }) => {
         setHover('')
       }
     },
-    /** @param {{ target: import('leaflet').Map }} args */
-    zoom: ({ target }) => {
-      const pane = target.getPane('routes')
-      if (pane) {
-        pane.hidden = target.getZoom() < 13
-      }
-    },
   })
 
   return (
@@ -104,38 +96,35 @@ const RouteTile = ({ item, Icons }) => {
           />
         </Marker>
       ))}
-      <ErrorBoundary>
-        <Polyline
-          ref={lineRef}
-          pane="routes"
-          eventHandlers={{
-            click: ({ originalEvent }) => {
-              originalEvent.preventDefault()
-              setClicked((prev) => !prev)
-            },
-            mouseover: ({ target }) => {
-              if (target && !clicked) {
-                target.setStyle({ color: darkened, opacity: 1 })
-              }
-            },
-            mouseout: ({ target }) => {
-              if (target && !clicked) {
-                target.setStyle({ color, opacity: LINE_OPACITY })
-              }
-            },
-          }}
-          dashArray={item.reversible ? undefined : '5, 5'}
-          positions={waypoints.map((waypoint) => [
-            waypoint.lat_degrees,
-            waypoint.lng_degrees,
-          ])}
-          pathOptions={{
-            color: clicked || hover ? darkened : color,
-            opacity: clicked || hover ? 1 : LINE_OPACITY,
-            weight: 4,
-          }}
-        />
-      </ErrorBoundary>
+      <Polyline
+        ref={lineRef}
+        eventHandlers={{
+          click: ({ originalEvent }) => {
+            originalEvent.preventDefault()
+            setClicked((prev) => !prev)
+          },
+          mouseover: ({ target }) => {
+            if (target && !clicked) {
+              target.setStyle({ color: darkened, opacity: 1 })
+            }
+          },
+          mouseout: ({ target }) => {
+            if (target && !clicked) {
+              target.setStyle({ color, opacity: LINE_OPACITY })
+            }
+          },
+        }}
+        dashArray={item.reversible ? undefined : '5, 5'}
+        positions={waypoints.map((waypoint) => [
+          waypoint.lat_degrees,
+          waypoint.lng_degrees,
+        ])}
+        pathOptions={{
+          color: clicked || hover ? darkened : color,
+          opacity: clicked || hover ? 1 : LINE_OPACITY,
+          weight: 4,
+        }}
+      />
     </>
   )
 }

--- a/src/components/tiles/ScanArea.jsx
+++ b/src/components/tiles/ScanArea.jsx
@@ -24,7 +24,6 @@ export function ScanAreaTile({
         search === '' ||
         f.properties.key.toLowerCase().includes(search.toLowerCase())
       }
-      pane="geojson"
       eventHandlers={{
         click: ({ propagatedFrom: layer }) => {
           if (!layer.feature) return

--- a/src/components/tiles/submissionCells/Ring.jsx
+++ b/src/components/tiles/submissionCells/Ring.jsx
@@ -10,7 +10,6 @@ const RingTile = ({ ring, userSettings }) => (
       fillColor: userSettings.poiColor,
       color: userSettings.poiColor,
     }}
-    pane="circlePane"
   />
 )
 


### PR DESCRIPTION
Solves a few bugs:

- When routes are enabled, sometimes when navigating to the login page from the map, then hitting the back button to go back to the map can cause the whole thing to crash. This is presumably a React leaflet bug 
- Some other navigation bugs related to panes
- Changes the behavior of the `ErrorBoundary` component to not hard crash, rather try to re-render the components first up to 5 times, similar behavior as Kōji.