### PR TITLE
Fix MAD event and invasion support

### DIFF
--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -157,6 +157,7 @@ module.exports = class Pokestop extends Model {
             'pokestop_incident.character_display AS grunt_type',
             'pokestop_incident.incident_display_type AS display_type',
           ])
+          .whereRaw('incident_expiration > UTC_TIMESTAMP()')
       } else {
         query
           .leftJoin('incident', 'pokestop.id', 'incident.pokestop_id')
@@ -527,15 +528,17 @@ module.exports = class Pokestop extends Model {
         if (onlyInvasions && invasionPerms) {
           if (hasMultiInvasions) {
             stops.orWhere((invasion) => {
-              invasion.andWhere(
-                multiInvasionMs
-                  ? 'expiration_ms'
-                  : isMad
-                  ? 'incident_expiration'
-                  : 'expiration',
-                '>=',
-                safeTs * (multiInvasionMs ? 1000 : 1),
+              if(isMad) {
+                invasion.whereRaw('incident_expiration > UTC_TIMESTAMP()')
+              } else {
+                invasion.andWhere(
+                  multiInvasionMs
+                    ? 'expiration_ms'
+                    : 'expiration',
+                  '>=',
+                  safeTs * (multiInvasionMs ? 1000 : 1),
               )
+              }
               if (hasConfirmed && onlyConfirmed) {
                 invasion.andWhere('confirmed', onlyConfirmed)
               }
@@ -571,16 +574,14 @@ module.exports = class Pokestop extends Model {
                   isMad ? 'incident_grunt_type' : 'grunt_type',
                   invasions,
                 )
-                .andWhere(
-                  isMad ? 'incident_expiration' : 'expiration',
-                  '>=',
-                  isMad ? this.knex().fn.now() : safeTs,
-                )
-              if (isMad) {
+              if(isMad) {
+                invasion.whereRaw('incident_expiration > UTC_TIMESTAMP()')
                 invasion.whereNotIn(
                   'incident_grunt_type',
                   MADE_UP_MAD_INVASIONS,
                 )
+              } else {
+                invasion.andWhere('expiration','>=', safeTs)
               }
               if (hasConfirmed) {
                 invasion.andWhere('confirmed', onlyConfirmed)
@@ -596,9 +597,8 @@ module.exports = class Pokestop extends Model {
         if (onlyEventStops && eventStopPerms && displayTypes.length) {
           stops.orWhere((event) => {
             if (isMad && !hasMultiInvasions) {
-              event
-                .whereIn('incident_grunt_type', MADE_UP_MAD_INVASIONS)
-                .andWhere('incident_expiration', '>=', this.knex().fn.now())
+              event.where(function() { this.whereIn('incident_grunt_type', MADE_UP_MAD_INVASIONS).orWhere('character_display',0) })
+                .whereRaw('incident_expiration > UTC_TIMESTAMP()')
             } else {
               event
                 .whereIn(
@@ -606,15 +606,17 @@ module.exports = class Pokestop extends Model {
                   displayTypes,
                 )
                 .andWhere(isMad ? 'character_display' : 'character', 0)
-                .andWhere(
-                  multiInvasionMs
-                    ? 'expiration_ms'
-                    : isMad
-                    ? 'incident_expiration'
-                    : 'expiration',
-                  '>=',
-                  safeTs * (multiInvasionMs ? 1000 : 1),
-                )
+            }
+            if(isMad && hasMultiInvasions) {
+              event.whereRaw('incident_expiration > UTC_TIMESTAMP()')
+            } else {
+              event.where(
+                multiInvasionMs
+                  ? 'expiration_ms'
+                  : 'expiration',
+                '>=',
+                safeTs * (multiInvasionMs ? 1000 : 1),
+              )
             }
           })
         }
@@ -694,10 +696,10 @@ module.exports = class Pokestop extends Model {
         }
         filtered.events = pokestop.invasions
           .filter((event) =>
-            isMad && !hasMultiInvasions
-              ? MADE_UP_MAD_INVASIONS.includes(event.grunt_type)
-              : !event.grunt_type && filters[`b${event.display_type}`],
-          )
+          isMad && !hasMultiInvasions
+          ? (MADE_UP_MAD_INVASIONS.includes(event.grunt_type) || (!event.grunt_type && filters[`b${event.display_type}`]))
+          : !event.grunt_type && filters[`b${event.display_type}`]
+      )
           .map((event) => ({
             event_expire_timestamp: event.incident_expire_timestamp,
             showcase_pokemon_id: pokestop.showcase_pokemon_id,
@@ -1268,9 +1270,10 @@ module.exports = class Pokestop extends Model {
             'pokestop.pokestop_id',
             'pokestop_incident.pokestop_id',
           )
-          .select('pokestop_incident.character_display AS grunt_type')
-          .where('pokestop_incident.character_display', '>', 0)
-          .andWhere('incident_expiration', this.knex().fn.now())
+          .select('pokestop_incident.character_display AS grunt_type',
+                  'pokestop_incident.incident_display_type as display_type')
+          .where('pokestop_incident.incident_display_type', '>', 0)
+          .whereRaw('incident_expiration > UTC_TIMESTAMP()')
           .orderBy('pokestop_incident.character_display')
       } else {
         queries.invasions = this.query()
@@ -1285,15 +1288,21 @@ module.exports = class Pokestop extends Model {
           .orderBy('incident.character', 'incident.display_type')
       }
     } else {
-      queries.invasions = this.query()
+      if(isMad) {
+        queries.invasions = this.query()
+          .distinct('incident_grunt_type AS grunt_type')
+          .where('incident_grunt_type', '>', 0)
+          .whereRaw('incident_expiration > UTC_TIMESTAMP()')
+          .orderBy('grunt_type')
+      } else {
+        queries.invasions = this.query()
         .distinct(isMad ? 'incident_grunt_type AS grunt_type' : 'grunt_type')
         .where(isMad ? 'incident_grunt_type' : 'grunt_type', '>', 0)
         .andWhere(
-          isMad ? 'incident_expiration' : 'incident_expire_timestamp',
-          '>=',
-          isMad ? this.knex().fn.now() : ts,
+          'incident_expire_timestamp','>=',ts,
         )
         .orderBy('grunt_type')
+      }
     }
     if (isMad && !hasMultiInvasions) {
       queries.invasions.whereNotIn('incident_grunt_type', MADE_UP_MAD_INVASIONS)

--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -157,7 +157,7 @@ module.exports = class Pokestop extends Model {
             'pokestop_incident.character_display AS grunt_type',
             'pokestop_incident.incident_display_type AS display_type',
           ])
-          .whereRaw('incident_expiration > UTC_TIMESTAMP()')
+          .whereRaw('(pokestop_incident.pokestop_id is null OR incident_expiration > UTC_TIMESTAMP())')
       } else {
         query
           .leftJoin('incident', 'pokestop.id', 'incident.pokestop_id')


### PR DESCRIPTION
Fixes MAD support for event pokestops and also (I think) invasion filtering.

TLDR; MAD DB speaks datetime columns, and some of these are in UTC. 

Also the model to get available events was out of order.

This should in theory work for any lost soul still running on legacy branch of MAD, but I only tested it on async.