### PR TITLE
Route support for MAD db schema

### DIFF
--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -157,6 +157,7 @@ module.exports = class Pokestop extends Model {
             'pokestop_incident.character_display AS grunt_type',
             'pokestop_incident.incident_display_type AS display_type',
           ])
+          .whereRaw('incident_expiration > UTC_TIMESTAMP()')
       } else {
         query
           .leftJoin('incident', 'pokestop.id', 'incident.pokestop_id')
@@ -527,15 +528,17 @@ module.exports = class Pokestop extends Model {
         if (onlyInvasions && invasionPerms) {
           if (hasMultiInvasions) {
             stops.orWhere((invasion) => {
-              invasion.andWhere(
-                multiInvasionMs
-                  ? 'expiration_ms'
-                  : isMad
-                  ? 'incident_expiration'
-                  : 'expiration',
-                '>=',
-                safeTs * (multiInvasionMs ? 1000 : 1),
+              if(isMad) {
+                invasion.whereRaw('incident_expiration > UTC_TIMESTAMP()')
+              } else {
+                invasion.andWhere(
+                  multiInvasionMs
+                    ? 'expiration_ms'
+                    : 'expiration',
+                  '>=',
+                  safeTs * (multiInvasionMs ? 1000 : 1),
               )
+              }
               if (hasConfirmed && onlyConfirmed) {
                 invasion.andWhere('confirmed', onlyConfirmed)
               }
@@ -571,16 +574,14 @@ module.exports = class Pokestop extends Model {
                   isMad ? 'incident_grunt_type' : 'grunt_type',
                   invasions,
                 )
-                .andWhere(
-                  isMad ? 'incident_expiration' : 'expiration',
-                  '>=',
-                  isMad ? this.knex().fn.now() : safeTs,
-                )
-              if (isMad) {
+              if(isMad) {
+                invasion.whereRaw('incident_expiration > UTC_TIMESTAMP()')
                 invasion.whereNotIn(
                   'incident_grunt_type',
                   MADE_UP_MAD_INVASIONS,
                 )
+              } else {
+                invasion.andWhere('expiration','>=', safeTs)
               }
               if (hasConfirmed) {
                 invasion.andWhere('confirmed', onlyConfirmed)
@@ -596,9 +597,8 @@ module.exports = class Pokestop extends Model {
         if (onlyEventStops && eventStopPerms && displayTypes.length) {
           stops.orWhere((event) => {
             if (isMad && !hasMultiInvasions) {
-              event
-                .whereIn('incident_grunt_type', MADE_UP_MAD_INVASIONS)
-                .andWhere('incident_expiration', '>=', this.knex().fn.now())
+              event.where(function() { this.whereIn('incident_grunt_type', MADE_UP_MAD_INVASIONS).orWhere('character_display',0) })
+                .whereRaw('incident_expiration > UTC_TIMESTAMP()')
             } else {
               event
                 .whereIn(
@@ -606,15 +606,17 @@ module.exports = class Pokestop extends Model {
                   displayTypes,
                 )
                 .andWhere(isMad ? 'character_display' : 'character', 0)
-                .andWhere(
-                  multiInvasionMs
-                    ? 'expiration_ms'
-                    : isMad
-                    ? 'incident_expiration'
-                    : 'expiration',
-                  '>=',
-                  safeTs * (multiInvasionMs ? 1000 : 1),
-                )
+            }
+            if(isMad && hasMultiInvasions) {
+              event.whereRaw('incident_expiration > UTC_TIMESTAMP()')
+            } else {
+              event.where(
+                multiInvasionMs
+                  ? 'expiration_ms'
+                  : 'expiration',
+                '>=',
+                safeTs * (multiInvasionMs ? 1000 : 1),
+              )
             }
           })
         }
@@ -694,10 +696,10 @@ module.exports = class Pokestop extends Model {
         }
         filtered.events = pokestop.invasions
           .filter((event) =>
-            isMad && !hasMultiInvasions
-              ? MADE_UP_MAD_INVASIONS.includes(event.grunt_type)
-              : !event.grunt_type && filters[`b${event.display_type}`],
-          )
+          isMad && !hasMultiInvasions
+          ? (MADE_UP_MAD_INVASIONS.includes(event.grunt_type) || (!event.grunt_type && filters[`b${event.display_type}`]))
+          : !event.grunt_type && filters[`b${event.display_type}`]
+      )
           .map((event) => ({
             event_expire_timestamp: event.incident_expire_timestamp,
             showcase_pokemon_id: pokestop.showcase_pokemon_id,
@@ -1268,9 +1270,10 @@ module.exports = class Pokestop extends Model {
             'pokestop.pokestop_id',
             'pokestop_incident.pokestop_id',
           )
-          .select('pokestop_incident.character_display AS grunt_type')
-          .where('pokestop_incident.character_display', '>', 0)
-          .andWhere('incident_expiration', this.knex().fn.now())
+          .select('pokestop_incident.character_display AS grunt_type',
+                  'pokestop_incident.incident_display_type as display_type')
+          .where('pokestop_incident.incident_display_type', '>', 0)
+          .whereRaw('incident_expiration > UTC_TIMESTAMP()')
           .orderBy('pokestop_incident.character_display')
       } else {
         queries.invasions = this.query()
@@ -1285,15 +1288,21 @@ module.exports = class Pokestop extends Model {
           .orderBy('incident.character', 'incident.display_type')
       }
     } else {
-      queries.invasions = this.query()
+      if(isMad) {
+        queries.invasions = this.query()
+          .distinct('incident_grunt_type AS grunt_type')
+          .where('incident_grunt_type', '>', 0)
+          .whereRaw('incident_expiration > UTC_TIMESTAMP()')
+          .orderBy('grunt_type')
+      } else {
+        queries.invasions = this.query()
         .distinct(isMad ? 'incident_grunt_type AS grunt_type' : 'grunt_type')
         .where(isMad ? 'incident_grunt_type' : 'grunt_type', '>', 0)
         .andWhere(
-          isMad ? 'incident_expiration' : 'incident_expire_timestamp',
-          '>=',
-          isMad ? this.knex().fn.now() : ts,
+          'incident_expire_timestamp','>=',ts,
         )
         .orderBy('grunt_type')
+      }
     }
     if (isMad && !hasMultiInvasions) {
       queries.invasions.whereNotIn('incident_grunt_type', MADE_UP_MAD_INVASIONS)

--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -157,7 +157,7 @@ module.exports = class Pokestop extends Model {
             'pokestop_incident.character_display AS grunt_type',
             'pokestop_incident.incident_display_type AS display_type',
           ])
-          .whereRaw('incident_expiration > UTC_TIMESTAMP()')
+          .whereRaw('(pokestop_incident.pokestop_id is null OR incident_expiration > UTC_TIMESTAMP())')
       } else {
         query
           .leftJoin('incident', 'pokestop.id', 'incident.pokestop_id')

--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -147,13 +147,11 @@ module.exports = class Pokestop extends Model {
     if (hasMultiInvasions) {
       if (isMad) {
         query
-          .leftJoin(
-            'pokestop_incident', join => {
-              join.on('pokestop.pokestop_id', '=', 'pokestop_incident.pokestop_id')
-                  .andOn('incident_expiration', '>=', raw('UTC_TIMESTAMP()'))
-            }
-            ,
-          )
+          .leftJoin('pokestop_incident', (join) => {
+            join
+              .on('pokestop.pokestop_id', '=', 'pokestop_incident.pokestop_id')
+              .andOn('incident_expiration', '>=', raw('UTC_TIMESTAMP()'))
+          })
           .select([
             'incident_id AS incidentId',
             'pokestop_incident.character_display AS grunt_type',
@@ -529,16 +527,14 @@ module.exports = class Pokestop extends Model {
         if (onlyInvasions && invasionPerms) {
           if (hasMultiInvasions) {
             stops.orWhere((invasion) => {
-              if(isMad) {
+              if (isMad) {
                 invasion.whereRaw('incident_expiration > UTC_TIMESTAMP()')
               } else {
                 invasion.andWhere(
-                  multiInvasionMs
-                    ? 'expiration_ms'
-                    : 'expiration',
+                  multiInvasionMs ? 'expiration_ms' : 'expiration',
                   '>=',
                   safeTs * (multiInvasionMs ? 1000 : 1),
-              )
+                )
               }
               if (hasConfirmed && onlyConfirmed) {
                 invasion.andWhere('confirmed', onlyConfirmed)
@@ -570,19 +566,18 @@ module.exports = class Pokestop extends Model {
             })
           } else {
             stops.orWhere((invasion) => {
-              invasion
-                .whereIn(
-                  isMad ? 'incident_grunt_type' : 'grunt_type',
-                  invasions,
-                )
-              if(isMad) {
+              invasion.whereIn(
+                isMad ? 'incident_grunt_type' : 'grunt_type',
+                invasions,
+              )
+              if (isMad) {
                 invasion.whereRaw('incident_expiration > UTC_TIMESTAMP()')
                 invasion.whereNotIn(
                   'incident_grunt_type',
                   MADE_UP_MAD_INVASIONS,
                 )
               } else {
-                invasion.andWhere('expiration','>=', safeTs)
+                invasion.andWhere('expiration', '>=', safeTs)
               }
               if (hasConfirmed) {
                 invasion.andWhere('confirmed', onlyConfirmed)
@@ -598,10 +593,12 @@ module.exports = class Pokestop extends Model {
         if (onlyEventStops && eventStopPerms && displayTypes.length) {
           stops.orWhere((event) => {
             if (isMad && !hasMultiInvasions) {
-              event.where((gruntType) => {
-                gruntType.whereIn('incident_grunt_type', MADE_UP_MAD_INVASIONS)
-                         .orWhere('character_display',0) 
-              })
+              event
+                .where((gruntType) => {
+                  gruntType
+                    .whereIn('incident_grunt_type', MADE_UP_MAD_INVASIONS)
+                    .orWhere('character_display', 0)
+                })
                 .whereRaw('incident_expiration > UTC_TIMESTAMP()')
             } else {
               event
@@ -611,13 +608,11 @@ module.exports = class Pokestop extends Model {
                 )
                 .andWhere(isMad ? 'character_display' : 'character', 0)
             }
-            if(isMad && hasMultiInvasions) {
+            if (isMad && hasMultiInvasions) {
               event.whereRaw('incident_expiration > UTC_TIMESTAMP()')
             } else {
               event.where(
-                multiInvasionMs
-                  ? 'expiration_ms'
-                  : 'expiration',
+                multiInvasionMs ? 'expiration_ms' : 'expiration',
                 '>=',
                 safeTs * (multiInvasionMs ? 1000 : 1),
               )
@@ -700,10 +695,11 @@ module.exports = class Pokestop extends Model {
         }
         filtered.events = pokestop.invasions
           .filter((event) =>
-          isMad && !hasMultiInvasions
-          ? (MADE_UP_MAD_INVASIONS.includes(event.grunt_type) || (!event.grunt_type && filters[`b${event.display_type}`]))
-          : !event.grunt_type && filters[`b${event.display_type}`]
-      )
+            isMad && !hasMultiInvasions
+              ? MADE_UP_MAD_INVASIONS.includes(event.grunt_type) ||
+                (!event.grunt_type && filters[`b${event.display_type}`])
+              : !event.grunt_type && filters[`b${event.display_type}`],
+          )
           .map((event) => ({
             event_expire_timestamp: event.incident_expire_timestamp,
             showcase_pokemon_id: pokestop.showcase_pokemon_id,
@@ -1274,8 +1270,10 @@ module.exports = class Pokestop extends Model {
             'pokestop.pokestop_id',
             'pokestop_incident.pokestop_id',
           )
-          .select('pokestop_incident.character_display AS grunt_type',
-                  'pokestop_incident.incident_display_type as display_type')
+          .select(
+            'pokestop_incident.character_display AS grunt_type',
+            'pokestop_incident.incident_display_type as display_type',
+          )
           .where('pokestop_incident.incident_display_type', '>', 0)
           .whereRaw('incident_expiration > UTC_TIMESTAMP()')
           .orderBy('pokestop_incident.character_display')
@@ -1292,7 +1290,7 @@ module.exports = class Pokestop extends Model {
           .orderBy('incident.character', 'incident.display_type')
       }
     } else {
-      if(isMad) {
+      if (isMad) {
         queries.invasions = this.query()
           .distinct('incident_grunt_type AS grunt_type')
           .where('incident_grunt_type', '>', 0)
@@ -1300,12 +1298,10 @@ module.exports = class Pokestop extends Model {
           .orderBy('grunt_type')
       } else {
         queries.invasions = this.query()
-        .distinct(isMad ? 'incident_grunt_type AS grunt_type' : 'grunt_type')
-        .where(isMad ? 'incident_grunt_type' : 'grunt_type', '>', 0)
-        .andWhere(
-          'incident_expire_timestamp','>=',ts,
-        )
-        .orderBy('grunt_type')
+          .distinct(isMad ? 'incident_grunt_type AS grunt_type' : 'grunt_type')
+          .where(isMad ? 'incident_grunt_type' : 'grunt_type', '>', 0)
+          .andWhere('incident_expire_timestamp', '>=', ts)
+          .orderBy('grunt_type')
       }
     }
     if (isMad && !hasMultiInvasions) {

--- a/server/src/models/Route.js
+++ b/server/src/models/Route.js
@@ -46,7 +46,7 @@ class Route extends Model {
     const distanceMeters = isMad ? 'route_distance_meters' : 'distance_meters'
     const endLatitude = isMad ? 'end_poi_latitude' : 'end_lat'
     const endLongitude = isMad ? 'end_poi_longitude' : 'end_lon'
-    //route_distance_meters
+    
     const query = this.query()
       .select(isMad ? GET_MAD_ALL_SELECT : GET_ALL_SELECT)
       .whereBetween(startLatitude, [args.minLat, args.maxLat])
@@ -86,7 +86,7 @@ class Route extends Model {
    * @param {boolean} isMad true if DB schema is MAD
    */
   static async getOne(id, { isMad }) {
-    let result = isMad ? 
+    const result = isMad ? 
     await this.query() .select({
         id: 'route_id',
         name: 'name',

--- a/server/src/models/Route.js
+++ b/server/src/models/Route.js
@@ -79,7 +79,8 @@ class Route extends Model {
   /**
    * Returns the full route after querying it, generally from the Popup
    * @param {number} id
-   * @param {boolean} isMad true if DB schema is MAD
+   * @param {import('..types').DbContext} ctx
+   * @param {boolean} ctx.isMad true if DB schema is MAD
    */
   static async getOne(id, { isMad }) {
     const result = isMad
@@ -134,7 +135,8 @@ class Route extends Model {
 
   /**
    * returns route context
-   * @param {boolean} isMad true if DB schema is MAD
+   * @param {import('..types').DbContext} ctx
+   * @param {boolean} ctx.isMad true if DB schema is MAD
    * @returns {{ max_distance: number, max_duration: number }}
    */
   static async getFilterContext({ isMad }) {

--- a/server/src/models/Route.js
+++ b/server/src/models/Route.js
@@ -1,4 +1,4 @@
-const { Model } = require('objection')
+const { Model, raw } = require('objection')
 const getAreaSql = require('../services/functions/getAreaSql')
 
 const GET_ALL_SELECT = /** @type {const} */ ([
@@ -84,8 +84,35 @@ class Route extends Model {
    * Returns the full route after querying it, generally from the Popup
    * @param {number} id
    */
-  static async getOne(id) {
-    const result = await this.query().findById(id)
+  static async getOne(id, { isMad }) {
+    let result = null;
+
+    if(isMad) {
+      result = await this.query().select({
+        id: 'route_id',
+        name: 'name',
+        description: 'description',
+        distance_meters: 'route_distance_meters',
+        duration_seconds: 'route_duration_seconds',
+        start_fort_id: 'start_poi_fort_id',
+        start_lat: 'start_poi_latitude',
+        start_lon: 'start_poi_longitude',
+        start_image: 'start_poi_image_url',
+        end_fort_id: 'end_poi_fort_id',
+        end_lat: 'end_poi_latitude',
+        end_lon: 'end_poi_longitude',
+        end_image: 'end_poi_image_url',
+        image: 'image',
+        image_border_color: 'image_border_color_hex',
+        reversible: 'reversible',
+        tags: 'tags',
+        type: 'type',
+        version: 'version',
+        waypoints: 'waypoints',
+      }).select(raw('UNIX_TIMESTAMP(last_updated)').as('updated')).findOne( {route_id: id})
+    } else {
+      result = await this.query().findById(id)
+    }
     if (typeof result.waypoints === 'string') {
       result.waypoints = JSON.parse(result.waypoints)
     } else if (result.waypoints === null) {

--- a/server/src/models/Route.js
+++ b/server/src/models/Route.js
@@ -38,7 +38,6 @@ class Route extends Model {
     const { areaRestrictions } = perms
     const { onlyAreas, onlyDistance } = args.filters
 
-
     const distanceInMeters = (onlyDistance || [0.5, 100]).map((x) => x * 1000)
 
     const startLatitude = isMad ? 'start_poi_latitude' : 'start_lat'
@@ -46,14 +45,13 @@ class Route extends Model {
     const distanceMeters = isMad ? 'route_distance_meters' : 'distance_meters'
     const endLatitude = isMad ? 'end_poi_latitude' : 'end_lat'
     const endLongitude = isMad ? 'end_poi_longitude' : 'end_lon'
-    
+
     const query = this.query()
       .select(isMad ? GET_MAD_ALL_SELECT : GET_ALL_SELECT)
       .whereBetween(startLatitude, [args.minLat, args.maxLat])
       .andWhereBetween(startLongitude, [args.minLon, args.maxLon])
       .andWhereBetween(distanceMeters, distanceInMeters)
       .union((qb) => {
-
         qb.select(isMad ? GET_MAD_ALL_SELECT : GET_ALL_SELECT)
           .whereBetween(endLatitude, [args.minLat, args.maxLat])
           .andWhereBetween(endLongitude, [args.minLon, args.maxLon])
@@ -63,9 +61,7 @@ class Route extends Model {
         getAreaSql(qb, areaRestrictions, onlyAreas, isMad, 'route_end')
       })
 
-    if (
-      !getAreaSql(query, areaRestrictions, onlyAreas, isMad, 'route_start')
-    ) {
+    if (!getAreaSql(query, areaRestrictions, onlyAreas, isMad, 'route_start')) {
       return []
     }
     const results = await query
@@ -86,30 +82,33 @@ class Route extends Model {
    * @param {boolean} isMad true if DB schema is MAD
    */
   static async getOne(id, { isMad }) {
-    const result = isMad ? 
-    await this.query() .select({
-        id: 'route_id',
-        name: 'name',
-        description: 'description',
-        distance_meters: 'route_distance_meters',
-        duration_seconds: 'route_duration_seconds',
-        start_fort_id: 'start_poi_fort_id',
-        start_lat: 'start_poi_latitude',
-        start_lon: 'start_poi_longitude',
-        start_image: 'start_poi_image_url',
-        end_fort_id: 'end_poi_fort_id',
-        end_lat: 'end_poi_latitude',
-        end_lon: 'end_poi_longitude',
-        end_image: 'end_poi_image_url',
-        image: 'image',
-        image_border_color: 'image_border_color_hex',
-        reversible: 'reversible',
-        tags: 'tags',
-        type: 'type',
-        version: 'version',
-        waypoints: 'waypoints',
-      }).select(raw('UNIX_TIMESTAMP(last_updated)').as('updated')).findOne({ route_id: id }) : 
-      await this.query().findById(id)
+    const result = isMad
+      ? await this.query()
+          .select({
+            id: 'route_id',
+            name: 'name',
+            description: 'description',
+            distance_meters: 'route_distance_meters',
+            duration_seconds: 'route_duration_seconds',
+            start_fort_id: 'start_poi_fort_id',
+            start_lat: 'start_poi_latitude',
+            start_lon: 'start_poi_longitude',
+            start_image: 'start_poi_image_url',
+            end_fort_id: 'end_poi_fort_id',
+            end_lat: 'end_poi_latitude',
+            end_lon: 'end_poi_longitude',
+            end_image: 'end_poi_image_url',
+            image: 'image',
+            image_border_color: 'image_border_color_hex',
+            reversible: 'reversible',
+            tags: 'tags',
+            type: 'type',
+            version: 'version',
+            waypoints: 'waypoints',
+          })
+          .select(raw('UNIX_TIMESTAMP(last_updated)').as('updated'))
+          .findOne({ route_id: id })
+      : await this.query().findById(id)
 
     if (typeof result.waypoints === 'string') {
       result.waypoints = JSON.parse(result.waypoints)
@@ -154,7 +153,6 @@ class Route extends Model {
       .first()
 
     return result
-
   }
 }
 

--- a/server/src/services/functions/getAreaSql.js
+++ b/server/src/services/functions/getAreaSql.js
@@ -30,6 +30,10 @@ module.exports = function getAreaRestrictionSql(
     }
     if (category === 'pokemon') {
       columns = columns.map((each) => `pokemon.${each}`)
+    } else if (category === 'route_start') {
+      columns = columns.map((each) => `start_poi_${each}`)
+    } else if (category === 'route_end') {
+      columns = columns.map((each) => `end_poi_${each}`)
     }
   } else if (category === 'device') {
     columns = columns.map((each) => `last_${each}`)


### PR DESCRIPTION
This PR will allow people on MAD backend to display routes in RM

this PR needs to be tested by someone with a Golbat backend, to make sure it ain't breaking stuff there
it also needs to be tested by other MAD users

Fixes MAD support for event pokestops and also (I think) invasion filtering.

TLDR; MAD DB speaks datetime columns, and some of these are in UTC.

Also the model to get available events was out of order.

This should in theory work for any lost soul still running on legacy branch of MAD, but I only tested it on async.