### PR TITLE
fix: custom components normalizing

### DIFF
--- a/src/components/layout/custom/CustomButton.jsx
+++ b/src/components/layout/custom/CustomButton.jsx
@@ -21,10 +21,12 @@ export default function CustomButton({
   sx,
   icon = null,
   children,
+  className,
 }) {
   const isMuiColor = THEME_COLORS.has(color)
   return (
     <Button
+      className={className}
       size={size}
       color={isMuiColor ? color : undefined}
       bgcolor={isMuiColor ? undefined : color}

--- a/src/components/layout/custom/CustomText.jsx
+++ b/src/components/layout/custom/CustomText.jsx
@@ -1,9 +1,22 @@
 import * as React from 'react'
 import Typography from '@mui/material/Typography'
 
-export default function CustomText({ variant, sx, color, style, children }) {
+export default function CustomText({
+  className,
+  variant,
+  sx,
+  color,
+  style,
+  children,
+}) {
   return (
-    <Typography variant={variant} color={color} style={style} sx={sx}>
+    <Typography
+      className={className}
+      variant={variant}
+      color={color}
+      style={style}
+      sx={sx}
+    >
       {children}
     </Typography>
   )

--- a/src/components/layout/custom/CustomTile.jsx
+++ b/src/components/layout/custom/CustomTile.jsx
@@ -18,6 +18,7 @@ export default function CustomTile({ block, defaultReturn }) {
   ) : (
     <Grid
       {...Utility.getSizes(block.gridSizes)}
+      className={block.className}
       style={block.gridStyle}
       sx={block.sx}
     >

--- a/src/components/layout/custom/Generator.jsx
+++ b/src/components/layout/custom/Generator.jsx
@@ -48,7 +48,12 @@ export default function Generator({ block = {}, defaultReturn = null }) {
     case 'discord':
       return <DiscordLogin href={block.link}>{children}</DiscordLogin>
     case 'localLogin':
-      return <LocalLogin href={block.localAuthUrl} style={props.style} />
+      return (
+        <LocalLogin
+          href={block.localAuthUrl || block.link}
+          style={props.style}
+        />
+      )
     case 'localeSelection':
       return <LocaleSelection />
     case 'parent':

--- a/src/components/layout/custom/Generator.jsx
+++ b/src/components/layout/custom/Generator.jsx
@@ -15,8 +15,8 @@ import LocaleSelection from '../general/LocaleSelection'
 import LinkWrapper from './LinkWrapper'
 
 export default function Generator({ block = {}, defaultReturn = null }) {
-  const { content = null, ...props } = block
-  const children = Utility.getBlockContent(content)
+  const { content = null, text = null, ...props } = block
+  const children = Utility.getBlockContent(content || text)
   switch (block.type) {
     case 'img':
       return (
@@ -46,7 +46,7 @@ export default function Generator({ block = {}, defaultReturn = null }) {
         />
       )
     case 'discord':
-      return <DiscordLogin href={block.link}>{block.text}</DiscordLogin>
+      return <DiscordLogin href={block.link}>{children}</DiscordLogin>
     case 'localLogin':
       return <LocalLogin href={block.localAuthUrl} style={props.style} />
     case 'localeSelection':
@@ -56,11 +56,12 @@ export default function Generator({ block = {}, defaultReturn = null }) {
         <Grid
           container
           {...Utility.getSizes(block.gridSizes)}
+          className={block.className}
+          alignItems={block.alignItems}
+          justifyContent={block.justifyContent}
           spacing={block.spacing}
           style={block.style}
           sx={block.sx}
-          alignItems={block.alignItems}
-          justifyContent={block.justifyContent}
         >
           {block.components.map((subBlock, i) =>
             subBlock.type === 'parent' ? (
@@ -73,7 +74,7 @@ export default function Generator({ block = {}, defaultReturn = null }) {
               <Grid
                 key={i}
                 {...Utility.getSizes(subBlock.gridSizes)}
-                {...subBlock.gridStyle}
+                className={block.className}
                 style={subBlock.gridStyle}
                 sx={subBlock.gridSx}
               >

--- a/src/components/layout/custom/LinkWrapper.jsx
+++ b/src/components/layout/custom/LinkWrapper.jsx
@@ -7,37 +7,46 @@ import Link from '@mui/material/Link'
  * Wraps div in a link if the block has one, otherwise returns children
  * @param {{
  *  link?: string,
+ *  href?: string,
  *  target?: string,
- *  linkColor?: string,
+ *  color?: string,
  *  underline?: import("@mui/material/Link").LinkProps['underline'],
  *  style?: import('react').CSSProperties,
+ *  referrerPolicy?: import('react-router-dom').LinkProps['referrerPolicy'],
  *  sx?: import("@mui/system").SxProps,
  *  children: React.ReactNode
+ *  className?: string
  * }} props
  * @returns {React.ReactNode}
  */
 export default function LinkWrapper({
   link,
+  href,
   target,
-  linkColor,
+  color,
+  referrerPolicy,
   underline,
   style,
   sx,
   children,
+  className,
 }) {
-  if (!link) return children
-  const external = link.startsWith('http')
+  const url = link || href
+  if (!url) return children
+  const external = url.startsWith('http') || url.startsWith('/auth')
 
   return (
     <Link
-      href={external ? link : null}
-      to={external ? null : link}
-      rel={external ? 'noopener noreferrer' : null}
-      target={target ?? (external ? '_blank' : null)}
-      color={linkColor}
-      underline={underline}
-      sx={[style, ...(Array.isArray(sx) ? sx : [sx])]}
+      className={className}
+      href={external ? url : null}
+      to={external ? null : url}
       component={external ? 'a' : RouterLink}
+      referrerPolicy={referrerPolicy}
+      target={target}
+      color={color}
+      underline={underline}
+      style={style}
+      sx={sx}
     >
       {children}
     </Link>


### PR DESCRIPTION
## Changes (not breaking, yet)
- Deprecation of `href`, always use `link` - falls back for now
- Deprecation of `text`, always use `content` - falls back for now
- Deprecation of `localAuthUrl`, use `link` - falls back for now
- Adds support for `className` prop

### General Reminder
If you are wanting to use a Discord login button, use `type: "discord"`, not a button type. These are preconfigured to make it easier for you!