### PR TITLE
Remove duplicate admin key in de.json

### DIFF
--- a/packages/locales/lib/human/de.json
+++ b/packages/locales/lib/human/de.json
@@ -668,6 +668,5 @@
   "download": "download",
   "playground": "Playground",
   "locale": "Sprachen",
-  "admin": "Admin",
   "admin_subtitle": "codebasierter WYSIWYG-Editor für benutzerdefinierten Komponenten"
 }


### PR DESCRIPTION
Remove a duplicate admin translation in the German translation file.

[L65](https://github.com/sanderDijkxhoorn/ReactMap/blob/0b1e3b1429e2c08e66a1e8cdf357eef110c0d295/packages/locales/lib/human/de.json#L65) & [L671](https://github.com/sanderDijkxhoorn/ReactMap/blob/0b1e3b1429e2c08e66a1e8cdf357eef110c0d295/packages/locales/lib/human/de.json#L671)