### PR TITLE
Update Poracle Translation DE and new ones

### DIFF
--- a/packages/locales/lib/human/de.json
+++ b/packages/locales/lib/human/de.json
@@ -432,7 +432,7 @@
   "webhook_success_gym": "Raids, Eier, und Team Wechsel Alarme wurden hinzugefügt!",
   "slot_changes": "Platzänderungen",
   "confirm_delete": "Dadurch wird die Tracking-Funktion für dieses Profil entfernt, bist du sicher?",
-  "confirm_copy": "Wähle das Profil, das du zu \"{{profile}}\" kopieren möchtest, dadurch wird dieses Profil vollständig überschrieben.",
+  "confirm_copy": "Wähle das Profil aus, in das du \"{{profile}}\" kopieren möchtest. Dadurch wird dieses Profil vollständig überschrieben.",
   "webhook_error": "{{name}} konnte das nicht verarbeiten.\nBitte versuche es später nochmals.",
   "profile_error": "Muss eindeutig und gültig sein",
   "team_0": "Neutral",

--- a/packages/locales/lib/human/de.json
+++ b/packages/locales/lib/human/de.json
@@ -432,7 +432,7 @@
   "webhook_success_gym": "Raids, Eier, und Team Wechsel Alarme wurden hinzugefügt!",
   "slot_changes": "Platzänderungen",
   "confirm_delete": "Dadurch wird die Tracking-Funktion für dieses Profil entfernt, bist du sicher?",
-  "confirm_copy": "Wähle das Profil aus, in das du \"{{profile}}\" kopieren möchtest. Dadurch wird dieses Profil vollständig überschrieben.",
+  "confirm_copy": "Wähle das Profil aus, in das du \"{{profile}}\" kopieren möchtest. Dadurch wird das ausgewählte Profil vollständig überschrieben.",
   "webhook_error": "{{name}} konnte das nicht verarbeiten.\nBitte versuche es später nochmals.",
   "profile_error": "Muss eindeutig und gültig sein",
   "team_0": "Neutral",

--- a/packages/locales/lib/human/de.json
+++ b/packages/locales/lib/human/de.json
@@ -432,7 +432,7 @@
   "webhook_success_gym": "Raids, Eier, und Team Wechsel Alarme wurden hinzugefügt!",
   "slot_changes": "Platzänderungen",
   "confirm_delete": "Dadurch wird die Tracking-Funktion für dieses Profil entfernt, bist du sicher?",
-  "confirm_copy": "Wähle das Profil aus, in das du \"{{profile}}\" kopieren möchtest. Dadurch wird das ausgewählte Profil vollständig überschrieben.",
+  "confirm_copy": "Wähle das Profil, in das du \"{{profile}}\" kopieren möchtest. Dadurch wird das ausgewählte Profil vollständig überschrieben.",
   "webhook_error": "{{name}} konnte das nicht verarbeiten.\nBitte versuche es später nochmals.",
   "profile_error": "Muss eindeutig und gültig sein",
   "team_0": "Neutral",

--- a/packages/locales/lib/human/de.json
+++ b/packages/locales/lib/human/de.json
@@ -671,6 +671,6 @@
   "admin_subtitle": "codebasierter WYSIWYG-Editor für benutzerdefinierten Komponenten",
   "reported_error": "Dieser Fehler wurde dem Server mit Kennung gemeldet",
   "dark_mode": "Dunkelmodus",
-  "load_from_autosave": "Laden aus Autosave",
+  "load_from_autosave": "Aus Autosave laden",
   "done": "Erledigt"
 }

--- a/packages/locales/lib/human/de.json
+++ b/packages/locales/lib/human/de.json
@@ -668,5 +668,9 @@
   "download": "download",
   "playground": "Playground",
   "locale": "Sprachen",
-  "admin_subtitle": "codebasierter WYSIWYG-Editor für benutzerdefinierten Komponenten"
+  "admin_subtitle": "codebasierter WYSIWYG-Editor für benutzerdefinierten Komponenten",
+  "reported_error": "Dieser Fehler wurde dem Server mit Kennung gemeldet",
+  "dark_mode": "Dunkelmodus",
+  "load_from_autosave": "Laden aus Autosave",
+  "done": "Erledigt"
 }


### PR DESCRIPTION
fix poracle confirm_copy translation

Unfortunately the wording before was bit misleading. not it should be more clean.
When we click on the copy button we want to copy this profile to another. The text says pls choose a profile to copy to this.

@ReuschelCGN your thoughts?