### PR TITLE
Add route download

### DIFF
--- a/server/src/configs/custom-environment-variables.json
+++ b/server/src/configs/custom-environment-variables.json
@@ -452,6 +452,10 @@
       "expandAllScanAreas": {
         "__name": "MAP_MISC_EXPAND_ALL_SCAN_AREAS",
         "__format": "boolean"
+      },
+      "enableRouteDownload": {
+        "__name": "MAP_MISC_ENABLE_ROUTE_DOWNLOAD",
+        "__format": "boolean"
       }
     },
     "theme": {

--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -244,7 +244,8 @@
       "enablePokestopPopupCoordsSelector": false,
       "enablePortalPopupCoordsSelector": false,
       "customFloatingIcons": [],
-      "expandAllScanAreas": false
+      "expandAllScanAreas": false,
+      "enableRouteDownload": false
     },
     "theme": {
       "style": "dark",

--- a/src/components/popups/Route.jsx
+++ b/src/components/popups/Route.jsx
@@ -23,7 +23,7 @@ import DownloadIcon from '@mui/icons-material/Download'
 
 import Query from '@services/Query'
 import formatInterval from '@services/functions/formatInterval'
-import { useStore } from '@hooks/useStore'
+import { useStatic, useStore } from '@hooks/useStore'
 
 import Title from './common/Title'
 import TimeSince from './common/Timer'
@@ -131,6 +131,7 @@ function ExpandableWrapper({ disabled = false, children, expandKey, primary }) {
 export default function RoutePopup({ end, ...props }) {
   const [route, setRoute] = React.useState({ ...props, tags: [] })
   const { i18n } = useTranslation()
+  const { config } = useStatic.getState()
 
   const [getRoute, { data, called }] = useLazyQuery(Query.routes('getOne'), {
     variables: { id: props.id },
@@ -294,7 +295,9 @@ export default function RoutePopup({ end, ...props }) {
             lon={end ? route.end_lon : route.start_lon}
             size="small"
           />
-          <DownloadRouteGPX route={route} />
+          {config.misc.enableRouteDownload && (
+            <DownloadRouteGPX route={route} />
+          )}
         </Grid2>
       </Grid2>
     </Popup>

--- a/src/components/popups/Route.jsx
+++ b/src/components/popups/Route.jsx
@@ -19,6 +19,7 @@ import Box from '@mui/material/Box'
 import ArrowDropDown from '@mui/icons-material/ArrowDropDown'
 import ArrowDropUp from '@mui/icons-material/ArrowDropUp'
 import Typography from '@mui/material/Typography'
+import DownloadIcon from '@mui/icons-material/Download'
 
 import Query from '@services/Query'
 import formatInterval from '@services/functions/formatInterval'
@@ -293,8 +294,48 @@ export default function RoutePopup({ end, ...props }) {
             lon={end ? route.end_lon : route.start_lon}
             size="small"
           />
+          <DownloadRouteGPX route={route} />
         </Grid2>
       </Grid2>
     </Popup>
+  )
+}
+
+function DownloadRouteGPX({ route }) {
+  const GPXContent = React.useMemo(() => {
+    if (!route.waypoints.length) {
+      return null
+    }
+
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="ReactMap" xmlns="http://www.topografix.com/GPX/1/1">
+  <rte>
+    <name>${route.name}</name>
+    <desc>${route.description}</desc>
+    ${route.waypoints
+      .map(
+        (waypoint) =>
+          `<rtept lat="${waypoint.lat_degrees}" lon="${waypoint.lng_degrees}"><ele>${waypoint.elevation_in_meters}</ele></rtept>`,
+      )
+      .join('\n    ')}
+  </rte>
+</gpx>`
+  }, [route.name, route.description, route.waypoints])
+
+  if (!GPXContent) {
+    return null
+  }
+
+  return (
+    <IconButton
+      href={`data:application/gpx;charset=utf-8,${encodeURIComponent(
+        GPXContent,
+      )}`}
+      download={`${route.name}.gpx`}
+      size="small"
+      style={{ color: 'inherit' }}
+    >
+      <DownloadIcon />
+    </IconButton>
   )
 }

--- a/src/components/tiles/Route.jsx
+++ b/src/components/tiles/Route.jsx
@@ -33,13 +33,14 @@ const RouteTile = (route) => {
       {
         lat_degrees: route.start_lat,
         lng_degrees: route.start_lon,
-        elevation_in_meters: 0,
+        elevation_in_meters: route.waypoints[0]?.elevation_in_meters || 0,
       },
       ...route.waypoints,
       {
         lat_degrees: route.end_lat,
         lng_degrees: route.end_lon,
-        elevation_in_meters: 1,
+        elevation_in_meters:
+          route.waypoints[route.waypoints.length - 1]?.elevation_in_meters || 1,
       },
     ],
     [route],


### PR DESCRIPTION
Hi!

In this PR, I added a button to download a route as a GPX file. This simply adds a button on the route popup to trigger the action.
<img width="253" alt="image" src="https://github.com/WatWowMap/ReactMap/assets/757637/f5ea39f8-8503-4aa8-b350-af0efc642213">
Since this is a controversial feature, it's hidden behind a config. By default, it's disabled. To enable it, you need to set `map.misc.enableRouteDownload` to true. 

Thanks. 