### PR TITLE
feat: display raid level in popup

### DIFF
--- a/src/components/popups/Gym.jsx
+++ b/src/components/popups/Gym.jsx
@@ -368,7 +368,9 @@ const RaidImage = ({
         />
       </Grid>
       <Grid item xs={12} style={{ textAlign: 'center' }}>
-        <Typography variant="caption">{t(`raid_${raid_level}`)}</Typography>
+        <Typography variant="caption">
+          {t(`raid_${raid_level}`)} ({raid_level})
+        </Typography>
       </Grid>
       {raid_pokemon_id > 0 &&
         getRaidTypes(raid_pokemon_id, raid_pokemon_form).map((type) => (


### PR DESCRIPTION
Small PR that adds the actual raid number to the gym popup if a user wants to know what proto # it is for adding to Poracle etc. 