### PR TITLE
feat: Wayfarer enhancements

### DIFF
--- a/packages/locales/lib/human/en.json
+++ b/packages/locales/lib/human/en.json
@@ -672,5 +672,7 @@
   "fast": "Fast",
   "charged": "Charged",
   "offline_mode": "Offline Mode",
-  "include_sponsored": "Include Sponsored"
+  "include_sponsored": "Include Sponsored",
+  "showcase_color": "Showcase Color",
+  "partner_color": "Partner Color"
 }

--- a/packages/locales/lib/human/en.json
+++ b/packages/locales/lib/human/en.json
@@ -671,5 +671,6 @@
   "done": "Done",
   "fast": "Fast",
   "charged": "Charged",
-  "offline_mode": "Offline Mode"
+  "offline_mode": "Offline Mode",
+  "include_sponsored": "Include Sponsored"
 }

--- a/packages/types/lib/general.d.ts
+++ b/packages/types/lib/general.d.ts
@@ -36,6 +36,8 @@ export interface PoI {
   id: string
   lat: number
   lon: number
+  showcase: boolean
+  partner: boolean
 }
 
 export interface BaseCell {

--- a/packages/types/lib/scanner.d.ts
+++ b/packages/types/lib/scanner.d.ts
@@ -53,6 +53,7 @@ export interface Gym {
   total_cp: number
   first_seen_timestamp: number
   sponsor_id: number
+  partner_id: number
   raid_pokemon_costume: number
   raid_pokemon_gender: number
   raid_pokemon_evolution: number
@@ -161,6 +162,7 @@ export interface Pokestop {
   pokestop_display: number
   first_seen_timestamp: number
   sponsor_id: number
+  partner_id: number
   ar_scan_eligible: boolean
   quests: Quest[]
   invasions: Invasion[]
@@ -168,6 +170,10 @@ export interface Pokestop {
   power_up_level: number
   power_up_points: number
   power_up_end_timestamp: number
+  showcase_expiry?: number
+  showcase_pokemon_id?: number
+  showcase_ranking_standard?: number
+  showcase_rankings?: ShowcaseDetails | string
 }
 
 export type FullPokestop = FullModel<Pokestop, PokestopModel>

--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -412,6 +412,8 @@
       "darkMapBorder": "#ff0000",
       "cellBlocked": "#000000",
       "poiColor": "#03ffff",
+      "showcaseColor": "#D365F5",
+      "partnerColor": "#F60042",
       "enablePortalPopupCoords": false
     },
     "s2cells": {
@@ -554,7 +556,8 @@
       "enabled": false,
       "rings": true,
       "s17Cells": true,
-      "s14Cells": true
+      "s14Cells": true,
+      "includeSponsored": true
     },
     "s2cells": {
       "enabled": false,

--- a/server/src/graphql/typeDefs/map.graphql
+++ b/server/src/graphql/typeDefs/map.graphql
@@ -131,6 +131,8 @@ type PoI {
   id: ID
   lat: Float
   lon: Float
+  showcase: Boolean
+  partner: Boolean
 }
 
 type SubmissionCell {

--- a/server/src/graphql/typeDefs/scanner.graphql
+++ b/server/src/graphql/typeDefs/scanner.graphql
@@ -37,6 +37,7 @@ type Gym {
   total_cp: Int
   first_seen_timestamp: Int
   sponsor_id: Int
+  partner_id: Int
   raid_pokemon_costume: Int
   raid_pokemon_gender: Int
   raid_pokemon_evolution: Int
@@ -140,6 +141,7 @@ type Pokestop {
   pokestop_display: Int
   first_seen_timestamp: Int
   sponsor_id: Int
+  partner_id: Int
   ar_scan_eligible: Boolean
   quests: [Quest]
   invasions: [Invasion]

--- a/server/src/models/PoI.js
+++ b/server/src/models/PoI.js
@@ -4,11 +4,15 @@ class PoI {
    * @param {string} id
    * @param {number} lat
    * @param {number} lon
+   * @param {boolean} [partner]
+   * @param {boolean} [showcase]
    */
-  constructor(id, lat, lon) {
+  constructor(id, lat, lon, partner = false, showcase = false) {
     this.id = id
     this.lat = lat
     this.lon = lon
+    this.partner = partner
+    this.showcase = showcase
   }
 }
 

--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -1723,9 +1723,9 @@ class Pokestop extends Model {
       .first()
   }
 
-  static getSubmissions(perms, args, { isMad }) {
+  static getSubmissions(perms, args, { isMad, hasShowcaseData }) {
     const {
-      filters: { onlyAreas = [] },
+      filters: { onlyAreas = [], onlyIncludeSponsored = true },
       minLat,
       minLon,
       maxLat,
@@ -1744,9 +1744,15 @@ class Pokestop extends Model {
     if (isMad) {
       query.select(['pokestop_id AS id', 'latitude AS lat', 'longitude AS lon'])
     } else {
-      query.select(['id', 'lat', 'lon']).andWhere((poi) => {
-        poi.whereNull('sponsor_id').orWhere('sponsor_id', 0)
-      })
+      query.select(['id', 'lat', 'lon', 'partner_id'])
+      if (!onlyIncludeSponsored) {
+        query.andWhere((poi) => {
+          poi.whereNull('partner_id').orWhere('partner_id', 0)
+        })
+      }
+      if (hasShowcaseData) {
+        query.select('showcase_expiry')
+      }
     }
     if (!getAreaSql(query, perms.areaRestrictions, onlyAreas, isMad)) {
       return []

--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -62,6 +62,18 @@ class Pokestop extends Model {
     return 'pokestop'
   }
 
+  /**
+   *
+   * @param {import('objection').QueryBuilder<Pokestop, Pokestop[]>} query
+   * @param {boolean} isMad
+   */
+  static onlyValid(query, isMad) {
+    query.andWhere('enabled', true)
+    if (!isMad) {
+      query.andWhere('deleted', false)
+    }
+  }
+
   static async getAll(
     perms,
     args,
@@ -176,7 +188,8 @@ class Pokestop extends Model {
     query
       .whereBetween(isMad ? 'latitude' : 'lat', [args.minLat, args.maxLat])
       .andWhereBetween(isMad ? 'longitude' : 'lon', [args.minLon, args.maxLon])
-      .andWhere(isMad ? 'enabled' : 'deleted', isMad)
+
+    Pokestop.onlyValid(query, isMad)
     if (!getAreaSql(query, areaRestrictions, onlyAreas, isMad)) {
       return []
     }
@@ -1557,13 +1570,13 @@ class Pokestop extends Model {
         isMad ? 'image AS url' : 'url',
         distance,
       ])
-      .where(isMad ? 'enabled' : 'deleted', isMad)
       .whereRaw(`LOWER(name) LIKE '%${search}%'`)
       .limit(searchResultsLimit)
       .orderBy('distance')
     if (!getAreaSql(query, perms.areaRestrictions, onlyAreas, isMad)) {
       return []
     }
+    Pokestop.onlyValid(query, isMad)
     return query
   }
 
@@ -1606,7 +1619,6 @@ class Pokestop extends Model {
         isMad ? 'quest_reward AS quest_rewards' : 'quest_rewards',
         distance,
       ])
-      .where(isMad ? 'enabled' : 'deleted', isMad)
       .andWhere('quest_timestamp', '>=', midnight || 0)
       .andWhere((quests) => {
         quests
@@ -1628,6 +1640,8 @@ class Pokestop extends Model {
     if (!getAreaSql(query, perms.areaRestrictions, onlyAreas, isMad)) {
       return []
     }
+    Pokestop.onlyValid(query, isMad)
+
     const results = await query
     const mapped = results.map((q) => ({ ...q, with_ar: q.with_ar ?? true }))
 
@@ -1697,7 +1711,6 @@ class Pokestop extends Model {
           : 'lure_expire_timestamp',
         distance,
       ])
-      .where(isMad ? 'enabled' : 'deleted', isMad)
       .andWhere(
         isMad ? 'lure_expiration' : 'lure_expire_timestamp',
         '>=',
@@ -1709,6 +1722,8 @@ class Pokestop extends Model {
     if (!getAreaSql(query, perms.areaRestrictions, onlyAreas, isMad)) {
       return []
     }
+    Pokestop.onlyValid(query, isMad)
+
     const results = await query
     return results
   }
@@ -1740,7 +1755,6 @@ class Pokestop extends Model {
         minLon - 0.025,
         maxLon + 0.025,
       ])
-      .andWhere(isMad ? 'enabled' : 'deleted', isMad)
     if (isMad) {
       query.select(['pokestop_id AS id', 'latitude AS lat', 'longitude AS lon'])
     } else {
@@ -1757,6 +1771,8 @@ class Pokestop extends Model {
     if (!getAreaSql(query, perms.areaRestrictions, onlyAreas, isMad)) {
       return []
     }
+    Pokestop.onlyValid(query, isMad)
+
     return query
   }
 }

--- a/server/src/services/filters/builder/base.js
+++ b/server/src/services/filters/builder/base.js
@@ -158,6 +158,7 @@ function buildDefaultFilters(perms, database) {
             rings: defaultFilters.submissionCells.rings,
             s17Cells: defaultFilters.submissionCells.s17Cells,
             s14Cells: defaultFilters.submissionCells.s14Cells,
+            includeSponsored: defaultFilters.submissionCells.includeSponsored,
             filter: { global: new BaseFilter() },
           }
         : undefined,

--- a/server/src/services/functions/getPlacementCells.js
+++ b/server/src/services/functions/getPlacementCells.js
@@ -60,7 +60,16 @@ function getPlacementCells(filters, pokestops, gyms) {
       ? Object.values(indexedCells)
       : [],
     pois: filters.filters.onlyRings
-      ? allCoords.map((poi) => new PoI(poi.id, poi.lat, poi.lon))
+      ? allCoords.map(
+          (poi) =>
+            new PoI(
+              poi.id,
+              poi.lat,
+              poi.lon,
+              !!poi.partner_id,
+              'showcase_expiry' in poi ? !!poi.showcase_expiry : false,
+            ),
+        )
       : [],
   }
 }

--- a/server/src/services/ui/clientOptions.js
+++ b/server/src/services/ui/clientOptions.js
@@ -82,6 +82,8 @@ function clientOptions(perms) {
       darkMapBorder: { type: 'color', perm: ['submissionCells'] },
       cellBlocked: { type: 'color', perm: ['submissionCells'] },
       poiColor: { type: 'color', perm: ['submissionCells'] },
+      partnerColor: { type: 'color', perm: ['submissionCells'] },
+      showcaseColor: { type: 'color', perm: ['submissionCells'] },
     },
     s2cells: {
       lightMapBorder: { type: 'color', perm: ['s2cells'] },

--- a/server/src/services/ui/primary.js
+++ b/server/src/services/ui/primary.js
@@ -149,10 +149,13 @@ function generateUi(req, perms) {
     wayfarer:
       perms.portals || perms.submissionCells
         ? {
-            portals: (perms.portals && Db.models.Portal) || undefined,
+            portals: !!(perms.portals && Db.models.Portal) || undefined,
             submissionCells:
-              (perms.submissionCells && Db.models.Pokestop && Db.models.Gym) ||
-              undefined,
+              !!(
+                perms.submissionCells &&
+                Db.models.Pokestop &&
+                Db.models.Gym
+              ) || undefined,
           }
         : undefined,
     s2cells: perms.s2cells ? { enabled: true, cells: true } : undefined,
@@ -164,9 +167,9 @@ function generateUi(req, perms) {
       perms.spawnpoints || perms.scanCells || perms.devices
         ? {
             spawnpoints:
-              (perms.spawnpoints && Db.models.Spawnpoint) || undefined,
-            scanCells: (perms.scanCells && Db.models.ScanCell) || undefined,
-            devices: (perms.devices && Db.models.Device) || undefined,
+              !!(perms.spawnpoints && Db.models.Spawnpoint) || undefined,
+            scanCells: !!(perms.scanCells && Db.models.ScanCell) || undefined,
+            devices: !!(perms.devices && Db.models.Device) || undefined,
           }
         : undefined,
     settings: true,

--- a/src/components/layout/drawer/Extras.jsx
+++ b/src/components/layout/drawer/Extras.jsx
@@ -195,23 +195,20 @@ export default function Extras({ category, subItem, data }) {
           alignItems="center"
           justifyContent="flex-end"
         >
-          <ListItem
-            secondaryAction={
-              <Switch
-                checked={filters[category]?.confirmed || false}
-                onChange={() => {
-                  setFilters({
-                    ...filters,
-                    [category]: {
-                      ...filters[category],
-                      confirmed: !filters[category].confirmed,
-                    },
-                  })
-                }}
-              />
-            }
-          >
+          <ListItem>
             <ListItemText sx={{ pl: 4 }} primary={t('only_confirmed')} />
+            <Switch
+              checked={filters[category]?.confirmed || false}
+              onChange={() => {
+                setFilters({
+                  ...filters,
+                  [category]: {
+                    ...filters[category],
+                    confirmed: !filters[category].confirmed,
+                  },
+                })
+              }}
+            />
           </ListItem>
         </CollapsibleItem>
       )
@@ -268,10 +265,21 @@ export default function Extras({ category, subItem, data }) {
   ) {
     return (
       <CollapsibleItem open={!!filters[subItem]?.enabled}>
-        {['rings', 's14Cells', 's17Cells'].map((item, i) => (
-          <ListItem
-            key={item}
-            secondaryAction={
+        {['rings', 'includeSponsored', 's14Cells', 's17Cells'].map(
+          (item, i) => (
+            <ListItem key={item}>
+              <ListItemText
+                sx={{ pl: 4 }}
+                primary={
+                  i > 1 ? (
+                    <Trans i18nKey="s2_cell_level">
+                      {{ level: item.substring(1, 3) }}
+                    </Trans>
+                  ) : (
+                    t(i ? 'include_sponsored' : 'poi')
+                  )
+                }
+              />
               <Switch
                 checked={!!filters[subItem]?.[item]}
                 onChange={() => {
@@ -285,21 +293,9 @@ export default function Extras({ category, subItem, data }) {
                 }}
                 disabled={filters[subItem]?.enabled === false}
               />
-            }
-          >
-            <ListItemText
-              primary={
-                i ? (
-                  <Trans i18nKey="s2_cell_level">
-                    {{ level: item.substring(1, 3) }}
-                  </Trans>
-                ) : (
-                  t('poi')
-                )
-              }
-            />
-          </ListItem>
-        ))}
+            </ListItem>
+          ),
+        )}
       </CollapsibleItem>
     )
   }

--- a/src/components/tiles/submissionCells/S14Cell.jsx
+++ b/src/components/tiles/submissionCells/S14Cell.jsx
@@ -42,7 +42,9 @@ const MemoS14Cell = React.memo(
     prev.cellColor === next.cellColor &&
     prev.oneStopTillNext === next.oneStopTillNext &&
     prev.twoStopsTillNext === next.twoStopsTillNext &&
-    prev.noMoreGyms === next.noMoreGyms,
+    prev.noMoreGyms === next.noMoreGyms &&
+    prev.count_gyms === next.count_gyms &&
+    prev.count_pokestops === next.count_pokestops,
 )
 
 export default MemoS14Cell

--- a/src/components/tiles/submissionCells/SubmissionCell.jsx
+++ b/src/components/tiles/submissionCells/SubmissionCell.jsx
@@ -14,6 +14,8 @@ import PoITile from './PoI'
  */
 const SubmissionCellTile = ({ level14Cells, level17Cells, pois }) => {
   const poiColor = useStore((s) => s.userSettings.wayfarer.poiColor)
+  const showcaseColor = useStore((s) => s.userSettings.wayfarer.showcaseColor)
+  const partnerColor = useStore((s) => s.userSettings.wayfarer.partnerColor)
   const cellBlocked = useStore((s) => s.userSettings.wayfarer.cellBlocked)
   const oneStopTillNext = useStore(
     (s) => s.userSettings.wayfarer.oneStopTillNext,
@@ -31,7 +33,17 @@ const SubmissionCellTile = ({ level14Cells, level17Cells, pois }) => {
   return (
     <>
       {pois?.map((ring) => (
-        <PoITile key={ring.id} {...ring} color={poiColor} />
+        <PoITile
+          key={ring.id}
+          {...ring}
+          color={
+            ring.showcase
+              ? showcaseColor
+              : ring.partner
+              ? partnerColor
+              : poiColor
+          }
+        />
       ))}
       {level17Cells?.map((cell) => (
         <Level17Tile

--- a/src/services/queries/submissionCells.js
+++ b/src/services/queries/submissionCells.js
@@ -32,6 +32,8 @@ const getAllSubmissionCells = gql`
         id
         lat
         lon
+        showcase
+        partner
       }
     }
   }


### PR DESCRIPTION
## Adds
- Different color POI to indicate if it's a normal POI, a partner POI, or has had a showcase at any point
- Filter to include or not include partner POIs in the Wayfarer counts / POI display
- Two additional client side options to set the color for a partner or showcase POI

## Config
- `defaultFilters.submissionCells.includeSponsored`
- `clientSideOptions.wayfarer.showcaseColor`
- `clientSideOptions.wayfarer.partnerColor`

## Translations
- `include_sponsored`
- `partner_color`
- `showcase_color`

Closes #870 