### PR TITLE
Add GeoURI navigation option to defaults

### DIFF
--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -875,6 +875,10 @@
     {
       "name": "Intel",
       "url": "https://intel.ingress.com/intel?pll={x},{y}"
+    },
+    {
+      "name": "GeoURI",
+      "url": "geo:{x},{y}"
     }
   ],
   "icons": {


### PR DESCRIPTION
On an Android device it is possible to select the Tesla app as the default handler for Geo URIs.

This allows tapping on a link from your android device to trigger navigation in your Tesla without needing to go through another app and share the link again from there.