### PR TITLE
refactor: scanner cooldown

### DIFF
--- a/server/src/graphql/resolvers.js
+++ b/server/src/graphql/resolvers.js
@@ -548,6 +548,13 @@ const resolvers = {
     },
     scanner: (_, args, { req, perms }) => {
       const { category, method, data } = args
+      if (data?.cooldown) {
+        req.session.cooldown = Math.max(
+          req.session.cooldown || 0,
+          data.cooldown || 0,
+        )
+        req.session.save()
+      }
       if (category === 'getQueue') {
         return scannerApi(category, method, data, req?.user)
       }

--- a/server/src/services/functions/getServerSettings.js
+++ b/server/src/services/functions/getServerSettings.js
@@ -12,6 +12,7 @@ function getServerSettings(req) {
   const user = {
     ...(req.user ? req.user : req.session),
     loggedIn: !!req.user,
+    cooldown: req.session?.cooldown || 0,
   }
 
   const { clientValues, clientMenus } = clientOptions(user.perms)

--- a/src/components/Config.jsx
+++ b/src/components/Config.jsx
@@ -10,6 +10,7 @@ import { deepMerge } from '@services/functions/deepMerge'
 import { Navigate } from 'react-router-dom'
 import { checkHoliday } from '@services/functions/checkHoliday'
 import { useHideElement } from '@hooks/useHideElement'
+import { useScannerSessionStorage } from './layout/dialogs/scanner/store'
 
 export default function Config({ children }) {
   const { t } = useTranslation()
@@ -87,6 +88,9 @@ export default function Config({ children }) {
         ),
       }
 
+      useScannerSessionStorage.setState((prev) => ({
+        cooldown: Math.max(prev.cooldown, data.user.cooldown || 0),
+      }))
       useStatic.setState({
         auth: {
           strategy: data.user?.strategy || '',

--- a/src/components/layout/FloatingBtn.jsx
+++ b/src/components/layout/FloatingBtn.jsx
@@ -26,12 +26,8 @@ import { DomEvent } from 'leaflet'
 
 import { FAB_BUTTONS } from '@services/queries/config'
 import useLocation from '@hooks/useLocation'
-import {
-  useLayoutStore,
-  useScanStore,
-  useStatic,
-  useStore,
-} from '@hooks/useStore'
+import { useLayoutStore, useStatic, useStore } from '@hooks/useStore'
+import { useScanStore } from './dialogs/scanner/store'
 
 import { I } from './general/I'
 import { setModeBtn, useWebhookStore } from './dialogs/webhooks/store'

--- a/src/components/layout/dialogs/scanner/ContextProvider.jsx
+++ b/src/components/layout/dialogs/scanner/ContextProvider.jsx
@@ -1,7 +1,7 @@
 // @ts-check
 import { createContext } from 'react'
 
-export const DEFAULT = /** @type {import('@hooks/useStore').ScanConfig} */ ({
+export const DEFAULT = /** @type {import('./store').ScanConfig} */ ({
   scannerType: '',
   showScanCount: false,
   showScanQueue: false,

--- a/src/components/layout/dialogs/scanner/Marker.jsx
+++ b/src/components/layout/dialogs/scanner/Marker.jsx
@@ -2,8 +2,8 @@
 import * as React from 'react'
 import { Marker, useMap } from 'react-leaflet'
 
-import { useScanStore } from '@hooks/useStore'
 import fallbackIcon from '@components/markers/fallback'
+import { useScanStore } from './store'
 
 /**
  * @param {{ children: React.ReactNode }} props

--- a/src/components/layout/dialogs/scanner/Popup.jsx
+++ b/src/components/layout/dialogs/scanner/Popup.jsx
@@ -17,7 +17,7 @@ import { ConfigContext } from './ContextProvider'
 
 /**
  *
- * @param {{ children: React.ReactNode, mode: import('@hooks/useStore').ScanMode }} props
+ * @param {{ children: React.ReactNode, mode: import('./store').ScanMode }} props
  * @returns
  */
 export function ScanOnDemandPopup({ children, mode }) {

--- a/src/components/layout/dialogs/scanner/ScanDialog.jsx
+++ b/src/components/layout/dialogs/scanner/ScanDialog.jsx
@@ -5,7 +5,8 @@ import { useTranslation } from 'react-i18next'
 
 import Header from '@components/layout/general/Header'
 import Footer from '@components/layout/general/Footer'
-import { useScanStore } from '@hooks/useStore'
+
+import { useScanStore } from './store'
 
 const { setScanMode } = useScanStore.getState()
 

--- a/src/components/layout/dialogs/scanner/Shared.jsx
+++ b/src/components/layout/dialogs/scanner/Shared.jsx
@@ -10,12 +10,12 @@ import {
   Divider,
   ListSubheader,
 } from '@mui/material'
+import { Trans, useTranslation } from 'react-i18next'
 import { Circle } from 'react-leaflet'
 import PermScanWifiIcon from '@mui/icons-material/PermScanWifi'
 import ClearIcon from '@mui/icons-material/Clear'
-import { useScanStore, useStore } from '@hooks/useStore'
 
-import { Trans, useTranslation } from 'react-i18next'
+import { useScanStore, useScannerSessionStorage } from './store'
 
 const StyledListItem = styled(ListItem)(() => ({
   padding: '2px 16px',
@@ -70,26 +70,26 @@ export function ScanQueue() {
 
 /**
  *
- * @param {{ mode: import('@hooks/useStore').ScanMode }} props
+ * @param {{ mode: import('./store').ScanMode }} props
  * @returns
  */
 export function ScanConfirm({ mode }) {
   const { t } = useTranslation()
-  const scannerCooldown = useStore((s) => s.scannerCooldown)
+  const cooldown = useScannerSessionStorage((s) => s.cooldown)
   const valid = useScanStore((s) => s.valid)
   const estimatedDelay = useScanStore((s) => s.estimatedDelay)
 
-  const [remainder, setRemainder] = React.useState(scannerCooldown - Date.now())
+  const [remainder, setRemainder] = React.useState(cooldown - Date.now())
 
   React.useEffect(() => {
-    if (scannerCooldown - Date.now() > 0) {
+    if (cooldown - Date.now() > 0) {
       const interval = setTimeout(() => {
-        setRemainder(scannerCooldown - Date.now())
+        setRemainder(cooldown - Date.now())
       }, 1000)
       return () => clearTimeout(interval)
     }
     setRemainder(0)
-  }, [remainder, scannerCooldown])
+  }, [remainder, cooldown])
 
   return (
     <StyledListButton
@@ -130,7 +130,7 @@ export function InAllowedArea() {
 
 /**
  *
- * @param {{ mode: import('@hooks/useStore').ScanMode}} props
+ * @param {{ mode: import('./store').ScanMode}} props
  * @returns
  */
 export function ScanCancel({ mode }) {

--- a/src/components/layout/dialogs/scanner/scanNext/PopupContent.jsx
+++ b/src/components/layout/dialogs/scanner/scanNext/PopupContent.jsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { Button, ButtonGroup, ListItem } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 
-import { useScanStore } from '@hooks/useStore'
+import { useScanStore } from '../store'
 
 const SIZES = /** @type {const} */ (['S', 'M', 'XL'])
 

--- a/src/components/layout/dialogs/scanner/scanNext/getCoords.js
+++ b/src/components/layout/dialogs/scanner/scanNext/getCoords.js
@@ -14,8 +14,8 @@ const DISTANCE = {
 /**
  * Get scan next coords
  * @param {[number, number]} center
- * @param {import('@hooks/useStore').UseScanStore['scanNextSize']} size
- * @returns {import('@hooks/useStore').UseScanStore['scanCoords']}
+ * @param {import('../store').UseScanStore['scanNextSize']} size
+ * @returns {import('../store').UseScanStore['scanCoords']}
  */
 export const getScanNextCoords = (center, size) => {
   const coords = [center]

--- a/src/components/layout/dialogs/scanner/scanNext/index.jsx
+++ b/src/components/layout/dialogs/scanner/scanNext/index.jsx
@@ -1,13 +1,12 @@
 // @ts-check
 import * as React from 'react'
 
-import { useScanStore } from '@hooks/useStore'
-
 import { ScanCircle, ScanCircles } from '../Shared'
 import { useCheckValid } from '../useCheckValid'
 import { ScanNextPopup } from './PopupContent'
 import { ScanOnDemandMarker } from '../Marker'
 import { ScanOnDemandPopup } from '../Popup'
+import { useScanStore } from '../store'
 
 const POKEMON_RADIUS = 70
 const GYM_RADIUS = 750

--- a/src/components/layout/dialogs/scanner/scanZone/PopupContent.jsx
+++ b/src/components/layout/dialogs/scanner/scanZone/PopupContent.jsx
@@ -5,10 +5,10 @@ import { useTranslation } from 'react-i18next'
 import debounce from 'lodash.debounce'
 
 import AdvancedAccordion from '@components/layout/custom/AdvancedAccordion'
-import { useScanStore } from '@hooks/useStore'
 
 import { StyledSubHeader } from '../Shared'
 import { ConfigContext } from '../ContextProvider'
+import { useScanStore } from '../store'
 
 const RADIUS_CHOICES = /** @type {const} */ (['pokemon', 'gym'])
 
@@ -54,7 +54,7 @@ export function ScanZonePopup() {
 /**
  *
  * @param {{
- *  name: keyof import("@rm/types").OnlyType<import('@hooks/useStore').UseScanStore, number>,
+ *  name: keyof import("@rm/types").OnlyType<import('../store').UseScanStore, number>,
  * } & import('@mui/material').SliderProps} props
  * @returns
  */

--- a/src/components/layout/dialogs/scanner/scanZone/getCoords.js
+++ b/src/components/layout/dialogs/scanner/scanZone/getCoords.js
@@ -18,7 +18,7 @@ const BEARINGS = {
  * @param {[number, number]} center
  * @param {number} radius
  * @param {number} spacing
- * @param {import('@hooks/useStore').UseScanStore['scanZoneSize']} scanZoneSize
+ * @param {import('../store').UseScanStore['scanZoneSize']} scanZoneSize
  * @returns
  */
 export const getScanZoneCoords = (center, radius, spacing, scanZoneSize) => {

--- a/src/components/layout/dialogs/scanner/store.js
+++ b/src/components/layout/dialogs/scanner/store.js
@@ -1,0 +1,65 @@
+import { create } from 'zustand'
+import { createJSONStorage, persist } from 'zustand/middleware'
+
+/**
+ * @typedef {'scanNext' | 'scanZone'} ScanMode
+ * @typedef {'' | 'mad' | 'rdm' | 'custom'} ScannerType
+ * @typedef {{
+ *   scannerType: ScannerType,
+ *   showScanCount: boolean,
+ *   showScanQueue: boolean,
+ *   advancedOptions: boolean,
+ *   pokemonRadius: number,
+ *   gymRadius: number,
+ *   spacing: number,
+ *   maxSize: number,
+ *   cooldown: number,
+ *   refreshQueue: number
+ *   enabled: boolean,
+ * }} ScanConfig
+ * @typedef {{
+ *  scanNextMode: '' | 'setLocation' | 'sendCoords' | 'loading' | 'confirmed' | 'error',
+ *  scanZoneMode: UseScanStore['scanNextMode']
+ *  queue: 'init' | '...' | number,
+ *  scanLocation: [number, number],
+ *  scanCoords: [number, number][],
+ *  validCoords: boolean[],
+ *  scanNextSize: 'S' | 'M' | 'L' | 'XL',
+ *  scanZoneSize: number,
+ *  userRadius: number,
+ *  userSpacing: number,
+ *  valid: 'none' | 'some' | 'all',
+ *  estimatedDelay: number,
+ *  setScanMode: <T extends `${ScanMode}Mode`>(mode: T, nextMode?: UseScanStore[T]) => void,
+ *  setScanSize: <T extends `${ScanMode}Size`>(mode: T, size: UseScanStore[T]) => void,
+ * }} UseScanStore
+ * @type {import("zustand").UseBoundStore<import("zustand").StoreApi<UseScanStore>>}
+ */
+export const useScanStore = create((set) => ({
+  scanNextMode: '',
+  scanZoneMode: '',
+  queue: 'init',
+  scanLocation: [0, 0],
+  scanCoords: [],
+  validCoords: [],
+  scanNextSize: 'S',
+  scanZoneSize: 1,
+  userRadius: 70,
+  userSpacing: 1,
+  valid: 'none',
+  estimatedDelay: 0,
+  setScanMode: (mode, nextMode = '') => set({ [mode]: nextMode }),
+  setScanSize: (mode, size) => set({ [mode]: size }),
+}))
+
+export const useScannerSessionStorage = create(
+  persist(
+    () => ({
+      cooldown: 0,
+    }),
+    {
+      name: 'scanner',
+      storage: createJSONStorage(() => sessionStorage),
+    },
+  ),
+)

--- a/src/components/layout/dialogs/scanner/useCheckValid.js
+++ b/src/components/layout/dialogs/scanner/useCheckValid.js
@@ -1,13 +1,13 @@
 // @ts-check
 import { useQuery } from '@apollo/client'
-import { useScanStore } from '@hooks/useStore'
 import { CHECK_VALID_SCAN } from '@services/queries/scanner'
 import { useContext, useEffect } from 'react'
 import { ConfigContext } from './ContextProvider'
+import { useScanStore } from './store'
 
 /**
  * Checks the server to see if the scan location is valid, returns a color
- * @param {import('@hooks/useStore').ScanMode} mode
+ * @param {import('./store').ScanMode} mode
  * @returns
  */
 export function useCheckValid(mode) {
@@ -25,7 +25,7 @@ export function useCheckValid(mode) {
 
   useEffect(() => {
     if (data?.checkValidScan) {
-      /** @type {import('@hooks/useStore').UseScanStore['valid']} */
+      /** @type {import('./store').UseScanStore['valid']} */
       let valid = 'none'
       if (data.checkValidScan.every(Boolean)) {
         valid = 'all'

--- a/src/hooks/useRefresh.js
+++ b/src/hooks/useRefresh.js
@@ -38,7 +38,11 @@ export default function useRefresh() {
       const existing = useStatic.getState().Icons
       const Icons = existing ?? new UIcons(icons, masterfile.questRewardTypes)
 
-      Icons.build(structuredClone(icons.styles))
+      Icons.build(
+        typeof structuredClone === 'function'
+          ? structuredClone(icons.styles)
+          : JSON.parse(JSON.stringify(icons.styles)),
+      )
       if (icons.defaultIcons && !existing) {
         Icons.setSelection(icons.defaultIcons)
       }

--- a/src/hooks/useStore.js
+++ b/src/hooks/useStore.js
@@ -23,7 +23,6 @@ import { persist, createJSONStorage } from 'zustand/middleware'
  *   searchTab: string,
  *   search: string,
  *   filters: object,
- *   scannerCooldown: number
  *   icons: Record<string, string>
  *   userSettings: Record<string, any>
  *   profiling: boolean
@@ -101,7 +100,6 @@ export const useStore = create(
         names: true,
       },
       motdIndex: 0,
-      scannerCooldown: 0,
       profiling: false,
     }),
     {
@@ -281,57 +279,6 @@ export const toggleDialog = (open, category, type, filter) => (event) => {
     }))
   }
 }
-
-/**
- * @typedef {'scanNext' | 'scanZone'} ScanMode
- * @typedef {'' | 'mad' | 'rdm' | 'custom'} ScannerType
- * @typedef {{
- *   scannerType: ScannerType,
- *   showScanCount: boolean,
- *   showScanQueue: boolean,
- *   advancedOptions: boolean,
- *   pokemonRadius: number,
- *   gymRadius: number,
- *   spacing: number,
- *   maxSize: number,
- *   cooldown: number,
- *   refreshQueue: number
- *   enabled: boolean,
- * }} ScanConfig
- * @typedef {{
- *  scanNextMode: '' | 'setLocation' | 'sendCoords' | 'loading' | 'confirmed' | 'error',
- *  scanZoneMode: UseScanStore['scanNextMode']
- *  queue: 'init' | '...' | number,
- *  scanLocation: [number, number],
- *  scanCoords: [number, number][],
- *  validCoords: boolean[],
- *  scanNextSize: 'S' | 'M' | 'L' | 'XL',
- *  scanZoneSize: number,
- *  userRadius: number,
- *  userSpacing: number,
- *  valid: 'none' | 'some' | 'all',
- *  estimatedDelay: number,
- *  setScanMode: <T extends `${ScanMode}Mode`>(mode: T, nextMode?: UseScanStore[T]) => void,
- *  setScanSize: <T extends `${ScanMode}Size`>(mode: T, size: UseScanStore[T]) => void,
- * }} UseScanStore
- * @type {import("zustand").UseBoundStore<import("zustand").StoreApi<UseScanStore>>}
- */
-export const useScanStore = create((set) => ({
-  scanNextMode: '',
-  scanZoneMode: '',
-  queue: 'init',
-  scanLocation: [0, 0],
-  scanCoords: [],
-  validCoords: [],
-  scanNextSize: 'S',
-  scanZoneSize: 1,
-  userRadius: 70,
-  userSpacing: 1,
-  valid: 'none',
-  estimatedDelay: 0,
-  setScanMode: (mode, nextMode = '') => set({ [mode]: nextMode }),
-  setScanSize: (mode, size) => set({ [mode]: size }),
-}))
 
 /**
  * @template {string | number | boolean} T


### PR DESCRIPTION
- Moves the client scanner storage to its own file, in a more appropriate folder
- Moves scanner cooldown property from `localStorage` to `sessionStorage`
- Also stores it in the cookie to deter it from easily being clearable with various checks to keep in sync