### PR TITLE
fix: pokestop with showcases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactmap",
-  "version": "1.27.1",
+  "version": "1.27.2",
   "private": true,
   "description": "React based frontend map.",
   "license": "MIT",

--- a/packages/locales/lib/human/en.json
+++ b/packages/locales/lib/human/en.json
@@ -676,5 +676,6 @@
   "showcase_color": "Showcase Color",
   "partner_color": "Partner Color",
   "disable": "Disable {{- name}}",
-  "profiling": "Profiling"
+  "profiling": "Profiling",
+  "showcase_block": "Blocked due to a showcase"
 }

--- a/packages/types/lib/scanner.d.ts
+++ b/packages/types/lib/scanner.d.ts
@@ -175,6 +175,7 @@ export interface Pokestop {
   showcase_pokemon_id?: number
   showcase_ranking_standard?: number
   showcase_rankings?: ShowcaseDetails | string
+  hasShowcase: boolean
 }
 
 export type FullPokestop = FullModel<Pokestop, PokestopModel>

--- a/server/src/graphql/typeDefs/scanner.graphql
+++ b/server/src/graphql/typeDefs/scanner.graphql
@@ -150,6 +150,7 @@ type Pokestop {
   power_up_level: Int
   power_up_points: Int
   power_up_end_timestamp: Int
+  hasShowcase: Boolean
 }
 
 type Pokemon {

--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -669,7 +669,7 @@ class Pokestop extends Model {
     const filteredResults = []
     for (let i = 0; i < queryResults.length; i += 1) {
       const pokestop = queryResults[i]
-      const filtered = {}
+      const filtered = { hasShowcase: pokestop.showcase_expiry > ts }
 
       this.fieldAssigner(filtered, pokestop, [
         'id',
@@ -710,10 +710,17 @@ class Pokestop extends Model {
           )
           .map((event) => ({
             event_expire_timestamp: event.incident_expire_timestamp,
-            showcase_pokemon_id: pokestop.showcase_pokemon_id,
-            showcase_pokemon_form_id: pokestop.showcase_pokemon_form_id,
-            showcase_rankings: showcaseData,
-            showcase_ranking_standard: pokestop.showcase_ranking_standard,
+            showcase_pokemon_id:
+              event.display_type === 9 ? pokestop.showcase_pokemon_id : null,
+            showcase_pokemon_form_id:
+              event.display_type === 9
+                ? pokestop.showcase_pokemon_form_id
+                : null,
+            showcase_rankings: event.display_type === 9 ? showcaseData : null,
+            showcase_ranking_standard:
+              event.display_type === 9
+                ? pokestop.showcase_ranking_standard
+                : null,
             display_type:
               isMad && !hasMultiInvasions
                 ? MAD_GRUNT_MAP[event.grunt_type] || 8

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -420,6 +420,10 @@ input[type='time']::-webkit-calendar-picker-indicator {
   filter: invert(100%) sepia(100%) hue-rotate(151deg) grayscale(1);
 }
 
+.disable-image {
+  filter: grayscale(1);
+}
+
 .expanded {
   transform: rotate(180deg);
 }

--- a/src/components/markers/usePokestopMarker.js
+++ b/src/components/markers/usePokestopMarker.js
@@ -43,7 +43,9 @@ export default function usePokestopMarker({
         ar_scan_eligible &&
           (userSettings.pokestops.showArBadge || power_up_level),
         power_up_level,
-        hasEvent ? events[0].display_type?.toString() : '',
+        hasEvent
+          ? Math.max(...events.map((event) => event.display_type)).toString()
+          : '',
       ),
       hasLure
         ? Icons.getSize(

--- a/src/components/popups/Pokestop.jsx
+++ b/src/components/popups/Pokestop.jsx
@@ -155,6 +155,7 @@ export default function PokestopPopup({
                           invasion.grunt_type,
                           invasion.confirmed,
                         )}
+                        disabled={pokestop.hasShowcase ? 'showcase_block' : ''}
                         until
                         tt={
                           invasion.grunt_type === 44 && !invasion.confirmed
@@ -173,9 +174,9 @@ export default function PokestopPopup({
                   {(hasQuest || hasLure || hasInvasion) && (
                     <Divider light flexItem className="popup-divider" />
                   )}
-                  {events.map(({ showcase_rankings = {}, ...event }, index) => {
+                  {events.map(({ showcase_rankings, ...event }, index) => {
                     const { contest_entries = [], ...showcase } =
-                      showcase_rankings
+                      showcase_rankings || { contest_entries: [] }
                     return (
                       <React.Fragment
                         key={`${event.display_type}-${event.event_expire_timestamp}`}
@@ -189,6 +190,11 @@ export default function PokestopPopup({
                             event.showcase_pokemon_id
                               ? `event_${event.display_type}`
                               : undefined
+                          }
+                          disabled={
+                            event.display_type !== 9 && pokestop.hasShowcase
+                              ? 'showcase_block'
+                              : ''
                           }
                           icon={
                             event.showcase_pokemon_id ? (

--- a/src/components/popups/common/TimeTile.jsx
+++ b/src/components/popups/common/TimeTile.jsx
@@ -19,6 +19,7 @@ import NameTT from './NameTT'
  *  expandKey?: string
  *  caption?: string
  *  children?: React.ReactNode
+ *  disabled?: string
  * }} param0
  * @returns
  */
@@ -31,6 +32,7 @@ export default function TimeTile({
   expandKey,
   caption,
   children,
+  disabled = '',
 }) {
   const endTime = new Date(expireTime * 1000)
   const expanded = useStore((state) => !!state.popups[expandKey])
@@ -40,14 +42,23 @@ export default function TimeTile({
       {icon && (
         <Grid item xs={size} style={{ textAlign: 'center' }}>
           {typeof icon === 'string' ? (
-            <NameTT id={tt}>
-              <img src={icon} className="quest-popup-img" alt={icon} />
+            <NameTT id={disabled || tt}>
+              <img
+                src={icon}
+                className={`quest-popup-img ${disabled ? 'disable-image' : ''}`}
+                alt={icon}
+              />
             </NameTT>
           ) : (
             icon
           )}
           {caption && (
-            <Typography variant="caption" className="ar-task" noWrap>
+            <Typography
+              variant="caption"
+              className="ar-task"
+              noWrap
+              color={disabled ? 'GrayText' : 'inherit'}
+            >
               {caption}
             </Typography>
           )}
@@ -59,8 +70,15 @@ export default function TimeTile({
           xs={icon ? (children ? 10 : 12) - size : children ? 10 : 12}
           style={{ textAlign: 'center' }}
         >
-          <Timer expireTime={expireTime} until={until} />
-          <Typography variant="caption">
+          <Timer
+            expireTime={expireTime}
+            until={until}
+            color={disabled ? 'GrayText' : 'inherit'}
+          />
+          <Typography
+            variant="caption"
+            color={disabled ? 'GrayText' : 'inherit'}
+          >
             {new Date(endTime).toLocaleTimeString(
               localStorage.getItem('i18nextLng') || 'en',
             )}
@@ -71,6 +89,7 @@ export default function TimeTile({
         <>
           <Grid item xs={2}>
             <IconButton
+              disabled={!!disabled}
               className={expanded ? 'expanded' : 'closed'}
               onClick={() =>
                 useStore.setState((prev) => ({

--- a/src/hooks/useOpacity.js
+++ b/src/hooks/useOpacity.js
@@ -4,8 +4,9 @@ import { useStore } from './useStore'
 
 /**
  * Returns dynamic opacity based on timestamp
- * @param {'pokemon' | 'gyms' | 'pokestops'} category
- * @param {'raid' | 'invasion'} [subCategory]
+ * @template {'pokemon' | 'gyms' | 'pokestops'} T
+ * @param {T} category
+ * @param {T extends 'pokestops' ? 'invasion' : T extends 'gyms' ? 'raid' : never} [subCategory]
  * @returns
  */
 export default function useOpacity(category, subCategory) {

--- a/src/services/queries/pokestop.js
+++ b/src/services/queries/pokestop.js
@@ -13,6 +13,7 @@ const core = gql`
     power_up_level
     power_up_points
     power_up_end_timestamp
+    hasShowcase
   }
 `
 


### PR DESCRIPTION
This fixes how pokestops and their popups are displayed when there is a showcase present.

- Detects if a showcase exists server side
- Sends a new `hasShowcase` bool value to client
- Still shows other `incidents`/`kecleon` like events if a showcase is present, but in a disabled state with a TT that says why