### PR TITLE
perf: improve pokestop querying perf by 10x

### DIFF
--- a/server/src/services/DbCheck.js
+++ b/server/src/services/DbCheck.js
@@ -109,16 +109,18 @@ module.exports = class DbCheck {
    * @returns {ReturnType<typeof raw>}
    */
   getDistance(args, isMad) {
+    const radLat = args.lat * (Math.PI / 180)
+    const radLon = args.lon * (Math.PI / 180)
     return raw(
       `ROUND(( ${
         this.distanceUnit === 'mi' ? '3959' : '6371'
-      } * acos( cos( radians(${args.lat}) ) * cos( radians( ${
+      } * acos( cos( ${radLat} ) * cos( radians( ${
         isMad ? 'latitude' : 'lat'
-      } ) ) * cos( radians( ${isMad ? 'longitude' : 'lon'} ) - radians(${
-        args.lon
-      }) ) + sin( radians(${args.lat}) ) * sin( radians( ${
+      } ) ) * cos( radians( ${
+        isMad ? 'longitude' : 'lon'
+      } ) - ${radLon} ) + sin( ${radLat} ) * sin( radians( ${
         isMad ? 'latitude' : 'lat'
-      } ) ) ) ),2)`,
+      } ) ) ) ), 2)`,
     ).as('distance')
   }
 


### PR DESCRIPTION
:watwow: filters `enabled` and `deleted` in JS instead of SQL, this has improved general quest query times by 10x

Also made some optimizations to quest searching that improved performance substantially.