### PR TITLE
feat: cache all remote data for quicker startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,7 @@ src/**/*.custom.css
 server/src/models/queries/*
 /logs/*
 !/logs/.gitkeep
+
+# Cache
+server/.cache/*
+!/server/.cache/.gitkeep

--- a/packages/logger/lib/index.js
+++ b/packages/logger/lib/index.js
@@ -14,6 +14,7 @@ const HELPERS = /** @type {const} */ ({
   info: chalk.blue('ℹ'),
   warn: chalk.yellow('⚠'),
   error: chalk.red('✖'),
+
   telegram: chalk.hex('#26A8EA')('[TELEGRAM]'),
   discord: chalk.hex('#7289da')('[DISCORD]'),
   cache: chalk.blueBright('[CACHE]'),

--- a/packages/types/lib/config.d.ts
+++ b/packages/types/lib/config.d.ts
@@ -34,7 +34,9 @@ export interface Config<Client extends boolean = false>
     logLevel: LogLevelNames
     skipUpdateCheck?: boolean
   } & BaseConfig['devOptions']
-  areas: Awaited<ReturnType<typeof import('server/src/services/areas')>>
+  areas: Awaited<
+    ReturnType<typeof import('server/src/services/areas')['loadLatestAreas']>
+  >
   authentication: {
     areaRestrictions: { roles: string[]; areas: string[] }[]
     excludeFromTutorial: (keyof BaseConfig['authentication']['perms'])[]

--- a/server/src/routes/api/v1/area.js
+++ b/server/src/routes/api/v1/area.js
@@ -3,14 +3,14 @@ const router = require('express').Router()
 
 const config = require('@rm/config')
 const { log, HELPERS } = require('@rm/logger')
-const getAreas = require('../../../services/areas')
+const { loadLatestAreas } = require('../../../services/areas')
 
 const reactMapSecret = config.getSafe('api.reactMapSecret')
 
 router.get('/reload', async (req, res) => {
   try {
     if (reactMapSecret && req.headers['react-map-secret'] === reactMapSecret) {
-      const newAreas = await getAreas()
+      const newAreas = await loadLatestAreas()
       config.areas = newAreas
 
       res.status(200).json({ status: 'ok', message: 'reloaded areas' })

--- a/server/src/services/EventManager.js
+++ b/server/src/services/EventManager.js
@@ -9,6 +9,7 @@ const { log, HELPERS } = require('@rm/logger')
 const { generate, read } = require('@rm/masterfile')
 
 const PoracleAPI = require('./api/Poracle')
+const { getCache, setCache } = require('./cache')
 
 class EventManager {
   constructor() {
@@ -19,21 +20,33 @@ class EventManager {
       'invasions' in this.masterfile ? this.masterfile.invasions : {}
 
     /** @type {{[key in keyof import('@rm/types').Available]: string[] }} */
-    this.available = {
+    this.available = getCache('available.json', {
       gyms: [],
       pokestops: [],
       pokemon: [],
       nests: [],
-    }
-    this.uicons = []
-    this.uaudio = []
+    })
+    this.uicons = getCache('uicons.json', [])
+    this.uaudio = getCache('uaudio.json', [])
     this.uiconsBackup = {}
     this.uaudioBackup = {}
     this.baseUrl =
       'https://raw.githubusercontent.com/WatWowMap/wwm-uicons-webp/main'
 
     /** @type {Record<string, InstanceType<typeof PoracleAPI>>} */
-    this.webhookObj = {}
+    this.webhookObj = Object.fromEntries(
+      config
+        .getSafe('webhooks')
+        .filter((x) => x.enabled)
+        .map((webhook) => {
+          const api = new PoracleAPI(webhook)
+          if (api.initFromCache()) {
+            return [api.name, api]
+          }
+          return [api.name, null]
+        })
+        .filter(([, api]) => api),
+    )
     /** @type {import('./Clients').ClientObject} */
     this.Clients = {}
   }
@@ -91,6 +104,7 @@ class EventManager {
 
       return 0
     })
+    await setCache('available.json', this.available)
   }
 
   /**
@@ -295,6 +309,7 @@ class EventManager {
       }
     }
     this[type] = Object.values(this[`${type}Backup`])
+    await setCache(`${type}.json`, this[type])
   }
 
   /**
@@ -361,18 +376,22 @@ class EventManager {
   }
 
   async getWebhooks() {
-    await Promise.all(
+    const apis = await Promise.allSettled(
       config
         .getSafe('webhooks')
         .filter((x) => x.enabled)
         .map(async (webhook) => {
           const api = new PoracleAPI(webhook)
           await api.init()
-          Object.assign(this.webhookObj, {
-            [webhook.name]: api,
-          })
+          return api
         }),
     )
+    for (let i = 0; i < apis.length; i += 1) {
+      const item = apis[i]
+      if (item.status === 'fulfilled' && item.value) {
+        this.webhookObj[item.value.name] = item.value
+      }
+    }
   }
 }
 

--- a/server/src/services/api/Poracle.js
+++ b/server/src/services/api/Poracle.js
@@ -1,5 +1,6 @@
 const { log, HELPERS } = require('@rm/logger')
 const fetchJson = require('./fetchJson')
+const { setCache, getCache } = require('../cache')
 
 const PLATFORMS = /** @type {const} */ (['discord', 'telegram'])
 
@@ -180,6 +181,15 @@ class PoracleAPI {
     }
   }
 
+  initFromCache() {
+    const cached = getCache(`${this.name}-webhook.json`)
+    if (!cached) {
+      log.warn(HELPERS.webhooks, `${this.name} webhook not found in cache`)
+      return false
+    }
+    Object.assign(this, cached)
+  }
+
   async init() {
     try {
       await Promise.all([
@@ -190,6 +200,7 @@ class PoracleAPI {
       this.ui = this.generateUi()
       this.lastFetched = Date.now()
       log.info(HELPERS.webhooks, `${this.name} webhook initialized`)
+      await setCache(`${this.name}-webhook.json`, this)
     } catch (e) {
       log.error(HELPERS.webhooks, `Error initializing ${this.name} webhook`, e)
     }

--- a/server/src/services/areas.js
+++ b/server/src/services/areas.js
@@ -140,7 +140,7 @@ const loadScanPolygons = async (fileName, domain) => {
  */
 const loadAreas = (scanAreas) => {
   try {
-    /** @type {ReturnType<typeof loadAreas>} */
+    /** @type {import("@rm/types").RMGeoJSON} */
     const normalized = { type: 'FeatureCollection', features: [] }
     Object.values(scanAreas).forEach((area) => {
       if (area?.features.length) {

--- a/server/src/services/areas.js
+++ b/server/src/services/areas.js
@@ -7,6 +7,7 @@ const RTree = require('rtree')
 
 const config = require('@rm/config')
 const { log, HELPERS } = require('@rm/logger')
+const { setCache, getCache } = require('./cache')
 
 /** @type {import("@rm/types").RMGeoJSON} */
 const DEFAULT_RETURN = { type: 'FeatureCollection', features: [] }
@@ -37,7 +38,10 @@ const manualGeojson = {
     }),
 }
 
-/** @param {string} location */
+/**
+ * @param {string} location
+ * @returns {Promise<import("@rm/types").RMGeoJSON>}
+ */
 const getGeojson = async (location) => {
   try {
     if (location.startsWith('http')) {
@@ -50,16 +54,10 @@ const getGeojson = async (location) => {
         },
       })
         .then((res) => res.json())
-        .then((res) => {
+        .then(async (res) => {
           if (res?.data) {
             log.info(HELPERS.areas, 'Caching', location, 'from Kōji')
-            fs.writeFileSync(
-              resolve(
-                __dirname,
-                `../configs/koji_backups/${location.replace(/\//g, '__')}.json`,
-              ),
-              JSON.stringify(res.data),
-            )
+            await setCache(`${location.replace(/\//g, '__')}.json`, res.data)
             return res.data
           }
           return DEFAULT_RETURN
@@ -70,27 +68,10 @@ const getGeojson = async (location) => {
             'Failed to fetch Kōji geojson, attempting to read from backup',
             err,
           )
-          if (
-            fs.existsSync(
-              resolve(
-                __dirname,
-                `../configs/koji_backups/${location.replace(/\//g, '__')}.json`,
-              ),
-            )
-          ) {
+          const cached = getCache(`${location.replace(/\//g, '__')}.json`)
+          if (cached) {
             log.info(HELPERS.areas, 'Reading from koji_backups for', location)
-            return JSON.parse(
-              fs.readFileSync(
-                resolve(
-                  __dirname,
-                  `../configs/koji_backups/${location.replace(
-                    /\//g,
-                    '__',
-                  )}.json`,
-                ),
-                'utf-8',
-              ),
-            )
+            return cached
           }
           log.warn(HELPERS.areas, 'No backup found for', location)
           return DEFAULT_RETURN
@@ -107,7 +88,12 @@ const getGeojson = async (location) => {
   return DEFAULT_RETURN
 }
 
-// Load each areas.json
+/**
+ * Load each areas.json
+ * @param {string} fileName
+ * @param {string} [domain]
+ * @returns {Promise<import("@rm/types").RMGeoJSON>}
+ */
 const loadScanPolygons = async (fileName, domain) => {
   try {
     const geojson = await getGeojson(fileName)
@@ -124,7 +110,9 @@ const loadScanPolygons = async (fileName, domain) => {
             key: f.properties.parent
               ? `${f.properties.parent}-${f.properties.name}`
               : f.properties.name,
-            center: center(f).geometry.coordinates.reverse(),
+            center: /** @type {[number,number]} */ (
+              center(f).geometry.coordinates.reverse()
+            ),
           },
         })),
       ].sort((a, b) =>
@@ -133,12 +121,13 @@ const loadScanPolygons = async (fileName, domain) => {
           : 0,
       ),
     }
-  } catch {
+  } catch (e) {
     log.warn(
       HELPERS.areas,
       `Failed to load ${fileName} for ${
         domain || 'map'
       }. Using empty areas.json`,
+      e,
     )
     return DEFAULT_RETURN
   }
@@ -234,25 +223,11 @@ const parseAreas = (featureCollection) => {
   return { names, withoutParents, polygons }
 }
 
-// Check if an areas.json exists
-const getAreas = async () => {
-  const main = config.getSafe('map.general.geoJsonFileName')
-
-  /** @type {Record<string, import("@rm/types").RMGeoJSON>} */
-  const scanAreas = {
-    main: await loadScanPolygons(main),
-    ...Object.fromEntries(
-      await Promise.all(
-        config
-          .getSafe('multiDomains')
-          .map(async (d) => [
-            d.general?.geoJsonFileName ? d.domain.replaceAll('.', '_') : 'main',
-            await loadScanPolygons(d.general?.geoJsonFileName || main),
-          ]),
-      ),
-    ),
-  }
-
+/**
+ * @param {Record<string, import("@rm/types").RMGeoJSON>} scanAreas
+ * @returns
+ */
+const buildAreas = (scanAreas) => {
   const scanAreasMenu = Object.fromEntries(
     Object.entries(scanAreas).map(([domain, featureCollection]) => {
       const parents = {
@@ -335,4 +310,45 @@ const getAreas = async () => {
   }
 }
 
-module.exports = getAreas
+const loadLatestAreas = async () => {
+  const fileName = config.getSafe('map.general.geoJsonFileName')
+
+  /** @type {Record<string, import("@rm/types").RMGeoJSON>} */
+  const scanAreas = {
+    main: await loadScanPolygons(fileName),
+    ...Object.fromEntries(
+      await Promise.all(
+        config
+          .getSafe('multiDomains')
+          .map(async (d) => [
+            d.general?.geoJsonFileName ? d.domain.replaceAll('.', '_') : 'main',
+            await loadScanPolygons(d.general?.geoJsonFileName || fileName),
+          ]),
+      ),
+    ),
+  }
+  return buildAreas(scanAreas)
+}
+
+const loadCachedAreas = () => {
+  const fileName = config.getSafe('map.general.geoJsonFileName')
+
+  /** @type {Record<string, import("@rm/types").RMGeoJSON>} */
+  const scanAreas = {
+    main: getCache(`${fileName.replace(/\//g, '__')}.json`, DEFAULT_RETURN),
+    ...Object.fromEntries(
+      config
+        .getSafe('multiDomains')
+        .map((d) => [
+          d.general?.geoJsonFileName ? d.domain.replaceAll('.', '_') : 'main',
+          getCache(d.general?.geoJsonFileName || fileName, DEFAULT_RETURN),
+        ]),
+    ),
+  }
+  return buildAreas(scanAreas)
+}
+
+module.exports = {
+  loadLatestAreas,
+  loadCachedAreas,
+}

--- a/server/src/services/cache.js
+++ b/server/src/services/cache.js
@@ -1,0 +1,47 @@
+const fs = require('fs')
+const path = require('path')
+
+const { log, HELPERS } = require('@rm/logger')
+
+const CACHE_DIR = path.join(__dirname, '../../.cache')
+
+/**
+ * @template T
+ * @param {string} fileName
+ * @param {T} [fallback]
+ * @returns {T}
+ */
+const getCache = (fileName, fallback = null) => {
+  try {
+    if (!fs.existsSync(path.resolve(CACHE_DIR, fileName))) return fallback
+    const data = JSON.parse(
+      fs.readFileSync(path.resolve(CACHE_DIR, fileName), 'utf-8'),
+    )
+    log.info(HELPERS.cache, 'Loaded', fileName)
+    return data
+  } catch (e) {
+    return fallback
+  }
+}
+
+/**
+ * @param {string} fileName
+ * @param {object | string} data
+ */
+const setCache = async (fileName, data) => {
+  try {
+    if (!fs.existsSync(CACHE_DIR)) await fs.promises.mkdir(CACHE_DIR)
+    await fs.promises.writeFile(
+      path.resolve(CACHE_DIR, fileName),
+      typeof data === 'string' ? data : JSON.stringify(data),
+    )
+    log.info(HELPERS.cache, 'Cached', fileName)
+  } catch (e) {
+    log.error(HELPERS.cache, e)
+  }
+}
+
+module.exports = {
+  getCache,
+  setCache,
+}

--- a/server/src/services/config.js
+++ b/server/src/services/config.js
@@ -5,6 +5,7 @@ const config = require('@rm/config')
 
 const { log, HELPERS } = require('@rm/logger')
 const checkConfigJsons = require('./functions/checkConfigJsons')
+const { loadCachedAreas } = require('./areas')
 
 const allowedMenuItems = [
   'gyms',
@@ -330,5 +331,7 @@ if (
   )
   config.authentication.alwaysEnabledPerms = enabled
 }
+
+config.areas = loadCachedAreas()
 
 module.exports = config


### PR DESCRIPTION
This rapidly increases the startup time of the server by caching all remote objects and loading them synchronously at startup instead of waiting for them asynchronously. The async functions to replace the cached with the live data still all run immediately following the startup of the server, this just now provides a much quicker startup time.