### PR TITLE
Fix Google Map Link

### DIFF
--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -883,7 +883,7 @@
   "navigation": [
     {
       "name": "Google Maps",
-      "url": "https://www.google.com/maps/place/{x},{y}"
+      "url": "https://maps.google.com/maps/place/{x},{y}"
     },
     {
       "name": "Apple Maps",


### PR DESCRIPTION
It seems that the old link does not navigate to the coordinates anymore. It should work with the new URL.