### PR TITLE
Cache refinement (and others)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,4 +4,4 @@ public/missing-locales
 public/images/custom
 public/images/uicons
 server/src/configs/
-packages/types/**/*.d.ts
+packages/**/*.d.ts

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "packages/*"
   ],
   "scripts": {
+    "postinstall": "yarn masterfile",
     "build": "vite build",
     "config:check": "yarn workspace @rm/config run check",
     "config:env": "yarn workspace @rm/config run generate",
@@ -45,7 +46,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "eslint --fix"
+      "eslint \"**/*.{js,jsx}\" --fix"
     ],
     "**/*": [
       "prettier --write --ignore-unknown"
@@ -155,7 +156,7 @@
     "morgan": "^1.10.0",
     "mysql2": "^3.4.0",
     "node-cache": "^5.1.2",
-    "node-fetch": "2",
+    "node-fetch": "2.6.7",
     "node-geocoder": "^4.2.0",
     "nodes2ts": "^2.0.0",
     "objection": "^3.0.1",
@@ -186,6 +187,7 @@
     "@sentry/vite-plugin": "2.10.3",
     "@types/dlv": "^1.1.2",
     "@types/node": "^18",
+    "@types/node-fetch": "2.6.1",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.0.9",
     "@vitejs/plugin-react": "4.2.1",
@@ -206,6 +208,7 @@
     "prettier": "^2.8.8",
     "rollup-plugin-delete": "^2.0.0",
     "semantic-release": "^19.0.5",
+    "typescript": "^5.3.3",
     "vite": "5.0.12",
     "vite-plugin-checker": "0.6.0"
   },

--- a/packages/locales/lib/create.js
+++ b/packages/locales/lib/create.js
@@ -1,4 +1,6 @@
 // @ts-check
+const { default: fetch } = require('node-fetch')
+
 const config = require('@rm/config')
 const { log, HELPERS } = require('@rm/logger')
 

--- a/packages/locales/lib/utils.js
+++ b/packages/locales/lib/utils.js
@@ -1,6 +1,7 @@
 // @ts-check
 const { promises: fs, readdirSync } = require('fs')
 const { resolve } = require('path')
+const { default: fetch } = require('node-fetch')
 
 const { log, HELPERS } = require('@rm/logger')
 

--- a/packages/locales/package.json
+++ b/packages/locales/package.json
@@ -18,6 +18,10 @@
     "@rm/config": "*",
     "@rm/logger": "*",
     "dotenv": "^16.3.1",
+    "node-fetch": "2.6.7",
     "openai": "^4.24.1"
+  },
+  "devDependencies": {
+    "@types/node-fetch": "2.6.1"
   }
 }

--- a/packages/logger/lib/index.js
+++ b/packages/logger/lib/index.js
@@ -39,6 +39,7 @@ const HELPERS = /** @type {const} */ ({
   fetch: chalk.hex('#880e4f')('[FETCH]'),
   scanner: chalk.hex('#b39ddb')('[SCANNER]'),
   build: chalk.hex('#ef6c00')('[BUILD]'),
+  ReactMap: chalk.hex('#ff3d00')('[ReactMap]'),
 
   pokemon: chalk.hex('#f44336')('[POKEMON]'),
   pokestops: chalk.hex('#e91e63')('[POKESTOPS]'),

--- a/packages/masterfile/lib/index.d.ts
+++ b/packages/masterfile/lib/index.d.ts
@@ -1,0 +1,85 @@
+import type { AdvCategories, Rarity } from '@rm/types'
+
+export interface MasterfileForm {
+  name: string
+  rarity?: string
+  isCostume?: boolean
+  category?: AdvCategories
+}
+
+export interface MasterfilePokemon {
+  name: string
+  pokedexId: number
+  defaultFormId: number
+  types: number[]
+  quickMoves: number[]
+  chargedMoves: number[]
+  genId: number
+  forms: {
+    [formId: string]: MasterfileForm
+  }
+  height?: number
+  weight?: number
+  family?: number
+  legendary?: boolean
+  mythical?: boolean
+  ultraBeast?: boolean
+  rarity?: string
+  historic?: string
+  tempEvolutions?: {
+    [evolutionId: string]: {}
+  }
+}
+
+export interface MasterfileObject {
+  [typeId: string]: string
+}
+
+export interface MasterfileMove {
+  name: string
+  type: number
+}
+
+export interface InvasionPokemon {
+  id: number
+  form: number
+}
+
+export interface InvasionRewards {
+  first: InvasionPokemon[]
+  second: InvasionPokemon[]
+  third: InvasionPokemon[]
+}
+
+export interface Invasion {
+  type: string
+  gender: number
+  grunt: string
+  firstReward: boolean
+  secondReward: boolean
+  thirdReward: boolean
+  encounters: InvasionRewards
+}
+
+export interface MasterfileWeather {
+  name: string
+  types: number[]
+}
+
+export interface Masterfile {
+  pokemon: Record<string, MasterfilePokemon>
+  types: MasterfileObject
+  items: MasterfileObject
+  questRewardTypes: MasterfileObject
+  moves: Record<string, MasterfileMove>
+  invasions: Record<string, Invasion>
+  weather: Record<string, MasterfileWeather>
+}
+
+export declare function generate(
+  save?: boolean,
+  historicRarity?: Rarity,
+  dbRarity?: Rarity,
+): Promise<Masterfile>
+
+export declare function read(): Masterfile

--- a/packages/masterfile/lib/index.js
+++ b/packages/masterfile/lib/index.js
@@ -1,6 +1,7 @@
 // @ts-check
 const fs = require('fs')
 const { resolve } = require('path')
+const { default: fetch } = require('node-fetch')
 
 const config = require('@rm/config')
 const { log, HELPERS } = require('@rm/logger')
@@ -20,13 +21,7 @@ Object.entries(defaultRarity).forEach(([tier, pokemon]) => {
   }
 })
 
-/**
- *
- * @param {boolean} save
- * @param {import('@rm/types').Rarity} historicRarity
- * @param {import('@rm/types').Rarity} dbRarity
- * @returns
- */
+/** @type {import('.').generate} */
 const generate = async (save = false, historicRarity = {}, dbRarity = {}) => {
   log.info(HELPERS.masterfile, 'generating masterfile')
   try {
@@ -91,6 +86,7 @@ if (require.main === module) {
   generate(true).then(() => log.info(HELPERS.masterfile, 'OK'))
 }
 
+/** @type {import('.').read} */
 const read = () => {
   try {
     return JSON.parse(
@@ -101,7 +97,7 @@ const read = () => {
       HELPERS.masterfile,
       'Unable to read masterfile, generating a new one for you now',
     )
-    return generate(true)
+    generate(true)
   }
 }
 

--- a/packages/masterfile/package.json
+++ b/packages/masterfile/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "scripts": {
     "generate": "node ./lib",
     "sort": "npx sort-package-json",
@@ -15,6 +16,10 @@
   "dependencies": {
     "@rm/config": "*",
     "@rm/logger": "*",
-    "@rm/types": "*"
+    "@rm/types": "*",
+    "node-fetch": "2.6.7"
+  },
+  "devDependencies": {
+    "@types/node-fetch": "2.6.1"
   }
 }

--- a/packages/types/lib/augmentations.d.ts
+++ b/packages/types/lib/augmentations.d.ts
@@ -1,6 +1,6 @@
 import { ButtonProps } from '@mui/material'
 import { Config, GetSafeConfig } from './config'
-import { ExpressUser } from './server'
+import { ExpressUser, Permissions } from './server'
 import { Request } from 'express'
 
 declare module 'config' {
@@ -47,6 +47,13 @@ declare module '@mui/material/styles' {
       fuchsia: string
       red: string
     }
+  }
+}
+
+declare module 'express-session' {
+  interface SessionData {
+    cooldown?: number
+    perms?: Permissions
   }
 }
 

--- a/packages/types/lib/general.d.ts
+++ b/packages/types/lib/general.d.ts
@@ -27,11 +27,8 @@ export type RMGeoJSON = {
   features: RMFeature[]
 }
 
-import masterfile = require('packages/masterfile/lib/data/masterfile.json')
 import { Config } from './config'
 import { SliderProps } from '@mui/material'
-
-export type Masterfile = typeof masterfile
 
 export type Strategy = 'discord' | 'telegram' | 'local'
 
@@ -88,9 +85,7 @@ export interface UICONS {
     egg: UiconImage[]
   }
   reward: {
-    [
-      key: Masterfile['questRewardTypes'][keyof Masterfile['questRewardTypes']]
-    ]: UiconImage[]
+    [key: string]: UiconImage[]
   }
   spawnpoint: UiconImage[]
   team: UiconImage[]

--- a/packages/vite-plugins/lib/favicon.js
+++ b/packages/vite-plugins/lib/favicon.js
@@ -2,36 +2,43 @@
 const { resolve } = require('path')
 const fs = require('fs')
 
+const { log, HELPERS } = require('@rm/logger')
+
 /**
  * @param {boolean} isDevelopment
  * @returns {import('vite').Plugin}
  */
 const faviconPlugin = (isDevelopment) => {
-  const favicon = fs.existsSync(
-    resolve(__dirname, '../../../public/favicon/favicon.ico'),
-  )
-    ? resolve(__dirname, '../../../public/favicon/favicon.ico')
-    : resolve(__dirname, '../../../public/favicon/fallback.ico')
-  return {
-    name: 'vite-plugin-locales',
-    generateBundle() {
-      if (isDevelopment) return
-      this.emitFile({
-        type: 'asset',
-        fileName: 'favicon.ico',
-        source: fs.readFileSync(favicon),
-      })
-    },
-    configureServer(server) {
-      server.middlewares.use((req, res, next) => {
-        if (req.url === '/favicon.ico') {
-          res.writeHead(200, { 'Content-Type': 'image/x-icon' })
-          res.end(fs.readFileSync(favicon))
-          return
-        }
-        next()
-      })
-    },
+  try {
+    const favicon = fs.existsSync(
+      resolve(__dirname, '../../../public/favicon/favicon.ico'),
+    )
+      ? resolve(__dirname, '../../../public/favicon/favicon.ico')
+      : resolve(__dirname, '../../../public/favicon/fallback.ico')
+    return {
+      name: 'vite-plugin-favicon',
+      generateBundle() {
+        if (isDevelopment) return
+        this.emitFile({
+          type: 'asset',
+          fileName: 'favicon.ico',
+          source: fs.readFileSync(favicon),
+        })
+      },
+      configureServer(server) {
+        server.middlewares.use((req, res, next) => {
+          if (req.url === '/favicon.ico') {
+            res.writeHead(200, { 'Content-Type': 'image/x-icon' })
+            res.end(fs.readFileSync(favicon))
+            return
+          }
+          next()
+        })
+      },
+    }
+  } catch (e) {
+    log.error(HELPERS.build, 'Error loading favicon', e)
+    return { name: 'vite-plugin-favicon' }
   }
 }
 

--- a/packages/vite-plugins/lib/muteWarnings.js
+++ b/packages/vite-plugins/lib/muteWarnings.js
@@ -7,7 +7,7 @@
 const muteWarningsPlugin = (warningsToIgnore) => {
   const mutedMessages = new Set()
   return {
-    name: 'mute-warnings',
+    name: 'vite-mute-warnings',
     enforce: 'pre',
     config: (userConfig) => ({
       build: {

--- a/packages/vite-plugins/package.json
+++ b/packages/vite-plugins/package.json
@@ -12,7 +12,8 @@
     "prettier:fix": "prettier --write \"**/*.{css,html,js,jsx,yml}\""
   },
   "dependencies": {
-    "@rm/locales": "*"
+    "@rm/locales": "*",
+    "@rm/logger": "*"
   },
   "devDependencies": {
     "vite": "5.0.12"

--- a/server/src/graphql/resolvers.js
+++ b/server/src/graphql/resolvers.js
@@ -497,7 +497,7 @@ const resolvers = {
           category,
           status,
         )
-        if (category === 'pokemon') {
+        if (category === 'pokemon' && result.pokemon) {
           result.pokemon = result.pokemon.map((x) => ({
             ...x,
             allForms: !x.form,
@@ -506,13 +506,13 @@ const resolvers = {
             xl: x.min_weight !== 0,
           }))
         }
-        if (category === 'invasion') {
+        if (category === 'invasion' && result.invasion) {
           result.invasion = result.invasion.map((x) => ({
             ...x,
             real_grunt_id: PoracleAPI.getRealGruntId(x, Event.invasions),
           }))
         }
-        if (category === 'raid') {
+        if (category === 'raid' && result.raid) {
           result.raid = result.raid.map((x) => ({
             ...x,
             allMoves: x.move === 9000,
@@ -656,7 +656,7 @@ const resolvers = {
           status,
           data,
         )
-        if (category === 'pokemon') {
+        if (category === 'pokemon' && result.pokemon) {
           result.pokemon = result.pokemon.map((x) => ({
             ...x,
             allForms: !x.form,
@@ -665,13 +665,13 @@ const resolvers = {
             xl: x.min_weight !== 0,
           }))
         }
-        if (category === 'invasion') {
+        if (category === 'invasion' && result.invasion) {
           result.invasion = result.invasion.map((x) => ({
             ...x,
             real_grunt_id: PoracleAPI.getRealGruntId(x, Event.invasions),
           }))
         }
-        if (category === 'raid') {
+        if (category === 'raid' && result.raid) {
           result.raid = result.raid.map((x) => ({
             ...x,
             allMoves: x.move === 9000,

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -304,6 +304,12 @@ connection.migrate
   .then(() => Db.getDbContext())
   .then(async () => {
     httpServer.listen(config.getSafe('port'), config.getSafe('interface'))
+    log.info(
+      HELPERS.ReactMap,
+      `Server is now listening at http://${config.getSafe(
+        'interface',
+      )}:${config.getSafe('port')}`,
+    )
     await Promise.all([
       Db.historicalRarity(),
       Db.getFilterContext(),
@@ -325,11 +331,7 @@ connection.migrate
         .toISOString()
         .split('.')[0]
         .split('T')
-        .join(
-          ' ',
-        )} [ReactMap] Server is now listening at http://${config.getSafe(
-        'interface',
-      )}:${config.getSafe('port')}`,
+        .join(' ')} [ReactMap] has fully started`,
     )
     setTimeout(() => text.stop(), 1_000)
   })

--- a/server/src/routes/api/v1/config.js
+++ b/server/src/routes/api/v1/config.js
@@ -1,29 +1,31 @@
+// @ts-check
 const path = require('path')
 const router = require('express').Router()
 const config = require('@rm/config')
 const { log, HELPERS } = require('@rm/logger')
 
+const api = config.getSafe('api')
+
 router.get('/', (req, res) => {
   try {
     if (
-      config.api.reactMapSecret &&
-      req.headers['react-map-secret'] === config.api.reactMapSecret
+      api.reactMapSecret &&
+      req.headers['react-map-secret'] === api.reactMapSecret
     ) {
       res.status(200).json({
+        ...config,
         api: {
-          ...config.api,
+          ...api,
           reactMapSecret: undefined,
         },
         ...config,
         database: {
           ...config.database,
-          schemas: config.api.showSchemasInConfigApi
-            ? config.database.schemas
-            : [],
+          schemas: api.showSchemasInConfigApi ? config.database.schemas : [],
         },
         authentication: {
           ...config.authentication,
-          strategies: config.api.showStrategiesInConfigApi
+          strategies: api.showStrategiesInConfigApi
             ? config.authentication.strategies
             : [],
         },

--- a/server/src/services/DbCheck.js
+++ b/server/src/services/DbCheck.js
@@ -6,7 +6,7 @@ const config = require('@rm/config')
 
 const { log, HELPERS } = require('@rm/logger')
 const { getBboxFromCenter } = require('./functions/getBbox')
-const { setCache, getCache } = require('./cache')
+const { getCache } = require('./cache')
 
 const softLimit = config.getSafe('api.searchSoftKmLimit')
 const hardLimit = config.getSafe('api.searchHardKmLimit')
@@ -248,7 +248,7 @@ module.exports = class DbCheck {
    * @param {boolean} historical
    * @returns {void}
    */
-  async setRarity(results, historical = false) {
+  setRarity(results, historical = false) {
     const base = {}
     const mapKey = historical ? 'historical' : 'rarity'
     let total = 0
@@ -279,7 +279,6 @@ module.exports = class DbCheck {
         this[mapKey][id] = 'common'
       }
     })
-    await setCache(`${mapKey}.json`, this[mapKey])
   }
 
   async historicalRarity() {
@@ -295,7 +294,7 @@ module.exports = class DbCheck {
                 .groupBy('pokemon_id'),
         ),
       )
-      await this.setRarity(
+      this.setRarity(
         results.map((result) =>
           Object.fromEntries(
             result.map((pkmn) => [`${pkmn.pokemon_id}`, +pkmn.total]),
@@ -595,10 +594,9 @@ module.exports = class DbCheck {
               Object.values(titles),
             ]),
           )
-          await setCache('questConditions.json', this.questConditions)
         }
         if (model === 'Pokemon') {
-          await this.setRarity(results, false)
+          this.setRarity(results, false)
         }
         if (results.length === 1) return results[0].available
         if (results.length > 1) {
@@ -642,7 +640,6 @@ module.exports = class DbCheck {
           ...results.map((result) => result.max_duration),
         )
         log.info(HELPERS.db, 'Updating filter context for routes')
-        await setCache('filterContext.json', this.filterContext)
       } catch (e) {
         log.error(
           HELPERS.db,

--- a/server/src/services/api/Poracle.js
+++ b/server/src/services/api/Poracle.js
@@ -1235,7 +1235,7 @@ class PoracleAPI {
   /**
    *
    * @param {import('@rm/types').PoracleInvasion} item
-   * @param {import('@rm/types').Masterfile['invasions']} invasions
+   * @param {import('@rm/masterfile').Masterfile['invasions']} invasions
    */
   static getRealGruntId(item, invasions) {
     return (

--- a/server/src/services/api/fetchJson.js
+++ b/server/src/services/api/fetchJson.js
@@ -2,7 +2,7 @@
 const fs = require('fs')
 const { resolve } = require('path')
 
-const { default: fetch } = require('node-fetch')
+const { default: fetch, Response } = require('node-fetch')
 
 const config = require('@rm/config')
 const { log, HELPERS } = require('@rm/logger')
@@ -31,6 +31,12 @@ async function fetchJson(url, options = undefined) {
     return response.json()
   } catch (e) {
     if (e instanceof Error) {
+      if (
+        e.cause instanceof Response &&
+        e.cause.status === 404 &&
+        url.includes('/api/pokemon/id')
+      )
+        return e.cause
       log.error(HELPERS.fetch, `Unable to fetch ${url}`, '\n', e)
       if (options) {
         fs.writeFileSync(

--- a/server/src/services/cache.js
+++ b/server/src/services/cache.js
@@ -1,3 +1,4 @@
+// @ts-check
 const fs = require('fs')
 const path = require('path')
 
@@ -5,13 +6,18 @@ const { log, HELPERS } = require('@rm/logger')
 
 const CACHE_DIR = path.join(__dirname, '../../.cache')
 
+/** @param {string} str */
+const fsFriendlyName = (str) =>
+  str.startsWith('http') ? `${str.replace(/\//g, '__')}.json` : str
+
 /**
  * @template T
- * @param {string} fileName
+ * @param {string} unsafeName
  * @param {T} [fallback]
  * @returns {T}
  */
-const getCache = (fileName, fallback = null) => {
+const getCache = (unsafeName, fallback = null) => {
+  const fileName = fsFriendlyName(unsafeName)
   try {
     if (!fs.existsSync(path.resolve(CACHE_DIR, fileName))) return fallback
     const data = JSON.parse(
@@ -30,10 +36,11 @@ const getCache = (fileName, fallback = null) => {
 }
 
 /**
- * @param {string} fileName
+ * @param {string} unsafeName
  * @param {object | string} data
  */
-const setCache = async (fileName, data) => {
+const setCache = async (unsafeName, data) => {
+  const fileName = fsFriendlyName(unsafeName)
   try {
     if (!fs.existsSync(CACHE_DIR)) await fs.promises.mkdir(CACHE_DIR)
     await fs.promises.writeFile(

--- a/server/src/services/initialization.js
+++ b/server/src/services/initialization.js
@@ -1,9 +1,13 @@
 // @ts-check
+const NodeCache = require('node-cache')
+
 const config = require('@rm/config')
+const { log, HELPERS } = require('@rm/logger')
 
 const DbCheck = require('./DbCheck')
 const EventManager = require('./EventManager')
 const PvpWrapper = require('./PvpWrapper')
+const { getCache, setCache } = require('./cache')
 
 const Db = new DbCheck()
 const Pvp = config.getSafe('api.pvp.reactMapHandlesPvp')
@@ -11,10 +15,58 @@ const Pvp = config.getSafe('api.pvp.reactMapHandlesPvp')
   : null
 const Event = new EventManager()
 
+const userCache = new NodeCache({ stdTTL: 60 * 60 * 24 })
+
+Object.entries(getCache('scanUserHistory.json', {})).forEach(([k, v]) =>
+  userCache.set(k, v),
+)
+
 Event.setTimers(Db, Pvp)
+
+/** @param {NodeJS.Signals} e */
+const onShutdown = async (e) => {
+  log.info(HELPERS.ReactMap, 'received signal', e, 'writing cache...')
+  const cacheObj = {}
+  userCache.keys().forEach((key) => {
+    cacheObj[key] = userCache.get(key)
+  })
+  await Promise.all([
+    setCache('scanUserHistory.json', cacheObj),
+    setCache('rarity.json', Db.rarity),
+    setCache('historical.json', Db.historical),
+    setCache('available.json', Event.available),
+    setCache('filterContext.json', Db.filterContext),
+    setCache('questConditions.json', Db.questConditions),
+    setCache('uaudio.json', Event.uaudio),
+    setCache('uicons.json', Event.uicons),
+  ])
+  log.info(HELPERS.ReactMap, 'exiting...')
+}
+
+process.on('SIGINT', async (e) => {
+  await onShutdown(e)
+  process.exit(0)
+})
+process.on('SIGTERM', async (e) => {
+  await onShutdown(e)
+  process.exit(0)
+})
+process.on('SIGUSR1', async (e) => {
+  await onShutdown(e)
+  process.exit(0)
+})
+process.on('SIGUSR2', async (e) => {
+  await onShutdown(e)
+  process.exit(0)
+})
+process.on('uncaughtException', async () => {
+  await onShutdown('SIGBREAK')
+  process.exit(99)
+})
 
 module.exports = {
   Db,
   Pvp,
   Event,
+  userCache,
 }

--- a/src/assets/mui/global.jsx
+++ b/src/assets/mui/global.jsx
@@ -1,3 +1,4 @@
+// @ts-check
 import * as React from 'react'
 import GlobalStyles from '@mui/material/GlobalStyles'
 import { darken, lighten } from '@mui/material/styles'

--- a/src/components/ClearStorage.jsx
+++ b/src/components/ClearStorage.jsx
@@ -6,20 +6,22 @@ import { useMemory } from '@hooks/useMemory'
 import { useStorage } from '@hooks/useStorage'
 
 export default function ClearStorage() {
-  localStorage.clear()
-  sessionStorage.clear()
-
   React.useEffect(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+
+    const { filters, menus } = useMemory.getState()
     useStorage.setState({
-      filters: {},
-      menus: {},
+      filters: structuredClone(filters),
+      menus: structuredClone(menus),
       location: [
         CONFIG.map.general.startLat || 0,
         CONFIG.map.general.startLon || 0,
       ],
       zoom: CONFIG.map.general.startZoom,
     })
-    useMemory.setState({ Icons: null })
+    useMemory.setState({ Icons: null, Audio: null })
   }, [])
+
   return <Navigate to="/" />
 }

--- a/src/components/layout/dialogs/filters/FilterMenu.jsx
+++ b/src/components/layout/dialogs/filters/FilterMenu.jsx
@@ -30,6 +30,7 @@ export default function FilterMenu() {
     setTempFilters(filters?.filter)
   }, [category, filters?.filter])
 
+  if (!category || !type) return null
   return (
     <DialogWrapper
       open={open && type === 'filters' && !!tempFilters}

--- a/src/components/layout/general/Menu.jsx
+++ b/src/components/layout/general/Menu.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import * as React from 'react'
 import Box from '@mui/material/Box'
 import DialogContent from '@mui/material/DialogContent'
 import Typography from '@mui/material/Typography'
@@ -22,11 +22,12 @@ import { GenericSearch } from '../drawer/ItemSearch'
 import { applyToAllWebhooks, useWebhookStore } from '../dialogs/webhooks/store'
 
 /**
+ * @template {import('@rm/types').AdvCategories} T
  * @param {{
- *  category: string
+ *  category: T
  *  webhookCategory?: string
- *  tempFilters: import('@rm/types').Filters
- *  children: (item: import('@rm/types').MenuItem, key: string) => React.ReactNode
+ *  tempFilters: import('@rm/types').AllFilters[T]
+ *  children: (index: number, key: string) => React.ReactNode
  *  categories?: import('@rm/types').Available[]
  *  title: string
  *  titleAction: () => void
@@ -51,7 +52,7 @@ export default function Menu({
   const { t } = useTranslation()
   const menus = useStorage((state) => state.menus)
 
-  const [filterDrawer, setFilterDrawer] = useState(false)
+  const [filterDrawer, setFilterDrawer] = React.useState(false)
 
   const { filteredArr, count } = useFilter(
     tempFilters,
@@ -74,55 +75,57 @@ export default function Menu({
   )
 
   const footerButtons = React.useMemo(
-    () => [
-      {
-        name: 'help',
-        action: () =>
-          useLayoutStore.setState({ help: { open: true, category } }),
-        icon: 'HelpOutline',
-      },
-      {
-        name: '',
-        disabled: true,
-      },
-      {
-        name: 'apply_to_all',
-        action: () =>
-          (webhookCategory ? useWebhookStore : useLayoutStore).setState({
-            [webhookCategory ? 'advanced' : 'advancedFilter']: {
-              open: true,
-              id: 'global',
-              category: webhookCategory || category,
-              selectedIds: filteredArr,
-            },
-          }),
-        icon: category === 'pokemon' || webhookCategory ? 'Tune' : 'FormatSize',
-      },
-      {
-        name: 'disable_all',
-        action: () =>
-          webhookCategory
-            ? applyToAllWebhooks(false, filteredArr)
-            : applyToAll({ enabled: false }, category, filteredArr),
-        icon: 'Clear',
-        color: 'error',
-      },
-      {
-        name: 'enable_all',
-        action: () =>
-          webhookCategory
-            ? applyToAllWebhooks(true, filteredArr)
-            : applyToAll(
-                { enabled: true },
-                category,
-                filteredArr,
-                !webhookCategory,
-              ),
-        icon: 'Check',
-        color: 'success',
-      },
-      ...(extraButtons ?? []),
-    ],
+    () =>
+      /** @type {import('@components/layout/general/Footer').FooterButton[]} */ ([
+        {
+          name: 'help',
+          action: () =>
+            useLayoutStore.setState({ help: { open: true, category } }),
+          icon: 'HelpOutline',
+        },
+        {
+          name: '',
+          disabled: true,
+        },
+        {
+          name: 'apply_to_all',
+          action: () =>
+            (webhookCategory ? useWebhookStore : useLayoutStore).setState({
+              [webhookCategory ? 'advanced' : 'advancedFilter']: {
+                open: true,
+                id: 'global',
+                category: webhookCategory || category,
+                selectedIds: filteredArr,
+              },
+            }),
+          icon:
+            category === 'pokemon' || webhookCategory ? 'Tune' : 'FormatSize',
+        },
+        {
+          name: 'disable_all',
+          action: () =>
+            webhookCategory
+              ? applyToAllWebhooks(false, filteredArr)
+              : applyToAll({ enabled: false }, category, filteredArr),
+          icon: 'Clear',
+          color: 'error',
+        },
+        {
+          name: 'enable_all',
+          action: () =>
+            webhookCategory
+              ? applyToAllWebhooks(true, filteredArr)
+              : applyToAll(
+                  { enabled: true },
+                  category,
+                  filteredArr,
+                  !webhookCategory,
+                ),
+          icon: 'Check',
+          color: 'success',
+        },
+        ...(extraButtons ?? []),
+      ]),
     [category, webhookCategory, extraButtons, filteredArr, tempFilters],
   )
 

--- a/src/hooks/useLayoutStore.js
+++ b/src/hooks/useLayoutStore.js
@@ -25,7 +25,7 @@ import { useStorage } from './useStorage'
  *  },
  *  dialog: {
  *    open: boolean,
- *    category: string,
+ *    category: import('@rm/types').AdvCategories | '',
  *    type: string,
  *  },
  *  gymBadge: {

--- a/src/hooks/useLocation.js
+++ b/src/hooks/useLocation.js
@@ -10,7 +10,9 @@ import 'leaflet.locatecontrol'
  */
 export default function useLocation() {
   const map = useMap()
-  const [color, setColor] = useState('inherit')
+  const [color, setColor] = useState(
+    /** @type {import('@mui/material').ButtonProps['color']} */ ('inherit'),
+  )
   const { t } = useTranslation()
 
   const lc = useMemo(() => {

--- a/src/hooks/useMemory.js
+++ b/src/hooks/useMemory.js
@@ -30,8 +30,9 @@ import { create } from 'zustand'
  *      scanner: number,
  *    },
  *   },
+ *   menus: Record<string, any>
  *   filters: import('@rm/types').AllFilters,
- *   masterfile: import('@rm/types').Masterfile
+ *   masterfile: import('@rm/masterfile').Masterfile
  *   polling: Record<string, number>
  *   gymValidDataLimit: number
  *   settings: Record<string, any>
@@ -96,7 +97,7 @@ export const useMemory = create((set) => ({
   },
   config: {},
   filters: {},
-  menus: undefined,
+  menus: {},
   menuFilters: {},
   userSettings: undefined,
   settings: undefined,

--- a/src/services/Icons.js
+++ b/src/services/Icons.js
@@ -29,7 +29,7 @@ class UAssets {
   /**
    *
    * @param {import("@rm/types").Config['icons']} iconsConfig
-   * @param {import("@rm/types").Masterfile['questRewardTypes']} questRewardTypes
+   * @param {import("@rm/masterfile").Masterfile['questRewardTypes']} questRewardTypes
    * @param {'uicons' | 'uaudio'} assetType
    */
   constructor({ customizable, sizes }, questRewardTypes, assetType) {

--- a/src/services/filtering/genPokemon.js
+++ b/src/services/filtering/genPokemon.js
@@ -1,6 +1,11 @@
 import { t } from 'i18next'
 
-/* eslint-disable no-nested-ternary */
+/**
+ *
+ * @param {import('@rm/masterfile').Masterfile} pokemon
+ * @param {string[]} categories
+ * @returns
+ */
 export default function genPokemon(pokemon, categories) {
   const tempObj = Object.fromEntries(
     categories.map((x) => [
@@ -25,7 +30,10 @@ export default function genPokemon(pokemon, categories) {
         (x) => `poke_type_${x}`,
       )
       const name =
-        form.name && form.name !== 'Normal' && j != 0 && j != pkmn.defaultFormId
+        form.name &&
+        form.name !== 'Normal' &&
+        j !== '0' &&
+        j != pkmn.defaultFormId
           ? formName
           : pokeName
       tempObj.pokemon[id] = {

--- a/src/services/filtering/genPokestops.js
+++ b/src/services/filtering/genPokestops.js
@@ -1,5 +1,12 @@
 import { t } from 'i18next'
 
+/**
+ *
+ * @param {import('@rm/masterfile').Masterfile} pokemon
+ * @param {*} pokestops
+ * @param {*} categories
+ * @returns
+ */
 export default function genPokestops(pokemon, pokestops, categories) {
   const tempObj = Object.fromEntries(categories.map((x) => [x, {}]))
   if (!pokestops?.filter) return {}
@@ -149,9 +156,8 @@ export default function genPokestops(pokemon, pokestops, categories) {
               tempObj.quest_reward_9 &&
               pokemon[monId]
             ) {
-              const category = [
-                id.charAt(0) === 'c' ? 'quest_reward_4' : 'quest_reward_9',
-              ]
+              const category =
+                id.charAt(0) === 'c' ? 'quest_reward_4' : 'quest_reward_9'
               tempObj[category][id] = {
                 name: `${t(`poke_${monId}`)} ${
                   id.charAt(0) === 'c' ? t('candy') : t('xl')

--- a/src/services/functions/checkAdvFilter.js
+++ b/src/services/functions/checkAdvFilter.js
@@ -1,7 +1,13 @@
+// @ts-check
 /* eslint-disable no-plusplus */
 /* eslint-disable no-cond-assign */
 /* eslint-disable default-case */
-export default function checkIVFilterValid(filter, dnf = true) {
+
+/**
+ * @param {string} filter
+ * @param {boolean} [dnf]
+ */
+function checkIVFilterValid(filter, dnf = true) {
   const input = filter.toUpperCase()
   const tokenizer =
     /\s*([()|&!,]|([ADSLXG]?|CP|LC|[GU]L)\s*([0-9]+(?:\.[0-9]*)?)(?:\s*-\s*([0-9]+(?:\.[0-9]*)?))?)/g
@@ -58,3 +64,5 @@ export default function checkIVFilterValid(filter, dnf = true) {
   }
   return true
 }
+
+export default checkIVFilterValid

--- a/src/services/functions/dayCheck.js
+++ b/src/services/functions/dayCheck.js
@@ -1,7 +1,15 @@
-export default function dayCheck(currentStamp, desiredStamp) {
+// @ts-check
+
+/**
+ * @param {number} currentStamp
+ * @param {number} desiredStamp
+ */
+function dayCheck(currentStamp, desiredStamp) {
   const locale = localStorage.getItem('i18nextLng') || 'en'
   if (currentStamp - desiredStamp < 86400) {
     return new Date(desiredStamp * 1000).toLocaleTimeString(locale)
   }
   return new Date(desiredStamp * 1000).toLocaleString(locale)
 }
+
+export default dayCheck

--- a/src/services/functions/deepMerge.js
+++ b/src/services/functions/deepMerge.js
@@ -1,9 +1,16 @@
+// @ts-check
+
+/** @param {any} item */
 function isObject(item) {
   return (
     item && typeof item === 'object' && !Array.isArray(item) && item !== null
   )
 }
 
+/**
+ * @param {Record<string, any>} target
+ * @param {...Record<string, any>} sources
+ */
 export function deepMerge(target, ...sources) {
   if (!sources.length) return target
   const source = sources.shift()

--- a/src/services/functions/formatInterval.js
+++ b/src/services/functions/formatInterval.js
@@ -1,4 +1,7 @@
-export default function formatInterval(intervalMs) {
+// @ts-check
+
+/** @param {number} intervalMs */
+function formatInterval(intervalMs) {
   const diff = Math.floor(intervalMs / 1000)
   const d = Math.floor(diff / 86400)
   const h = Math.floor(diff / 3600)
@@ -16,3 +19,5 @@ export default function formatInterval(intervalMs) {
 
   return { str: str.join(' '), diff }
 }
+
+export default formatInterval

--- a/src/services/functions/fromSearchCategory.js
+++ b/src/services/functions/fromSearchCategory.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  *
  * @param {string} searchCategory

--- a/src/services/functions/fromSnakeCase.js
+++ b/src/services/functions/fromSnakeCase.js
@@ -1,6 +1,10 @@
-/* eslint-disable import/prefer-default-export */
+// @ts-check
 import { capitalize } from '@mui/material'
 
+/**
+ * @param {string} str
+ * @param {string} [separator]
+ */
 export function fromSnakeCase(str, separator = ' ') {
   return capitalize(str)
     .replace(/_/g, separator)

--- a/src/services/functions/getBadge.js
+++ b/src/services/functions/getBadge.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Get rank badge, commonly used for pvp and contests
  * @param {number} rank

--- a/src/services/functions/getGruntReward.js
+++ b/src/services/functions/getGruntReward.js
@@ -1,6 +1,6 @@
 // @ts-check
 /**
- * @typedef {import('@rm/types').Masterfile['invasions']} Invasions
+ * @typedef {import('@rm/masterfile').Masterfile['invasions']} Invasions
  * @param {Invasions[keyof Invasions]} grunt
  * @returns {{ first: number, second: number, third: number }}
  */

--- a/src/services/functions/getProperName.js
+++ b/src/services/functions/getProperName.js
@@ -1,4 +1,10 @@
-export default function getProperName(word) {
+// @ts-check
+/**
+ * @param {string} word
+ */
+function getProperName(word) {
   const capital = `${word.charAt(0).toUpperCase()}${word.slice(1)}`
   return capital.replace(/([a-z0-9])([A-Z])/g, '$1 $2')
 }
+
+export default getProperName

--- a/src/services/functions/isLocalStorageEnabled.js
+++ b/src/services/functions/isLocalStorageEnabled.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 export function isLocalStorageEnabled() {
   const test = 'test'
 

--- a/src/services/functions/offset.js
+++ b/src/services/functions/offset.js
@@ -1,3 +1,4 @@
+// @ts-check
 /* eslint-disable no-bitwise */
 
 /**
@@ -33,9 +34,11 @@ export const cyrb53 = (str, seed = 0) => {
  */
 export const getOffset = (coords, amount, id, seed = 0) => {
   const rand = cyrb53(id, seed)
-  return [0, 1].map((i) => {
-    let offset = rand[i] * (0.0002 / 4294967296) - 0.0001
-    offset += offset >= 0 ? -amount : amount
-    return coords[i] + offset
-  })
+  return /** @type {[number, number]} */ (
+    [0, 1].map((i) => {
+      let offset = rand[i] * (0.0002 / 4294967296) - 0.0001
+      offset += offset >= 0 ? -amount : amount
+      return coords[i] + offset
+    })
+  )
 }

--- a/src/services/functions/parseConditions.js
+++ b/src/services/functions/parseConditions.js
@@ -1,4 +1,7 @@
-export default function parseQuestConditions(conditions) {
+// @ts-check
+
+/** @param {string} conditions */
+function parseQuestConditions(conditions) {
   const [type1, type2] = JSON.parse(conditions)
   const conditionsToReturn = []
   const parseMadRewards = (specifics) => {
@@ -60,3 +63,5 @@ export default function parseQuestConditions(conditions) {
   }
   return conditionsToReturn
 }
+
+export default parseQuestConditions

--- a/vite.config.js
+++ b/vite.config.js
@@ -79,6 +79,9 @@ const viteConfig = defineConfig(({ mode }) => {
               overlay: {
                 initialIsOpen: false,
               },
+              // typescript: {
+              //   tsconfigPath: './jsconfig.json',
+              // },
               eslint: {
                 lintCommand: 'eslint "./src/**/*.{js,jsx}"',
               },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2447,6 +2447,14 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.5.tgz#ec10755e871497bcd83efe927e43ec46e8c0747e"
   integrity sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==
 
+"@types/node-fetch@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.1.tgz#8f127c50481db65886800ef496f20bbf15518975"
+  integrity sha512-oMqjURCaxoSIsHSr1E47QHzbmzNR5rK8McHuNb11BOM9cHcIK3Avy0s/b2JlXHoQGTYS3NsvWzV1M0iK7l0wbA==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node-fetch@^2.6.1", "@types/node-fetch@^2.6.4":
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.9.tgz#15f529d247f1ede1824f7e7acdaa192d5f28071e"
@@ -4837,6 +4845,15 @@ form-data-encoder@1.7.2:
   resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-1.7.2.tgz#1f1ae3dccf58ed4690b86d87e4f57c654fbab040"
   integrity sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==
 
+form-data@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 form-data@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
@@ -6928,17 +6945,17 @@ node-emoji@^1.11.0:
   dependencies:
     lodash "^4.17.21"
 
-node-fetch@2, node-fetch@^2.6.0, node-fetch@^2.6.7:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
-  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
-  dependencies:
-    whatwg-url "^5.0.0"
-
 node-fetch@2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.6.0, node-fetch@^2.6.7:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -9249,7 +9266,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-"typescript@^4.6.4 || ^5.2.2":
+"typescript@^4.6.4 || ^5.2.2", typescript@^5.3.3:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==


### PR DESCRIPTION
Looks like a big PR but is in fact not, just cleans up a handful of things so I can retire in peace:
- Caches most stuff at process exit instead of while the app is running
- Fixes some caching for areas for those not using koji
- Removes any usage of node's native `fetch` and just replaces with `node-fetch`, since it was already being used anyway
- `postinstall` script to ensure a masterfile exists
- try/catch block around the favicon plugin for users who don't understand docker
- The rest are type refinements