### PR TITLE
Change default minCp of Ultra

### DIFF
--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -92,7 +92,7 @@
       "minCp": {
         "little": 400,
         "great": 1400,
-        "ultra": 2400
+        "ultra": 2350
       }
     },
     "portalUpdateLimit": 30,


### PR DESCRIPTION
Skarmory Ultra Rank 1 CP is 2383

![image](https://github.com/WatWowMap/ReactMap/assets/2796788/92c570a1-8fda-486f-b04a-e7caa5eb5766)
[Link to stadiumgaming.gg](https://www.stadiumgaming.gg/rank-checker?min_iv=0&league=great&att_iv=%2715%27&def_iv=%2715%27&hp_iv=%2715%27&pokemon=SKARMORY)