### PR TITLE
Add RoleLink info to Blocked page

### DIFF
--- a/src/pages/Blocked.jsx
+++ b/src/pages/Blocked.jsx
@@ -25,6 +25,8 @@ export function BlockedPage() {
   const { info } = useParams()
   const navigate = useNavigate()
   const discordInvite = useMemory((s) => s.config?.links?.discordInvite)
+  const roleLink = useMemory((s) => s.config?.links?.rolesLink)
+  const roleLinkName = useMemory((s) => s.config?.links?.rolesLinkName)
   const queryParams = new URLSearchParams(info)
   const blockedGuilds = queryParams.get('blockedGuilds')
   const username = queryParams.get('username')
@@ -96,6 +98,18 @@ export function BlockedPage() {
           >
             {t('go_back')}
           </Button>
+	  {roleLink && roleLinkName && (
+            <Button
+              variant="contained"
+              color="success"
+              target="_blank"
+              href={roleLink}
+              sx={{ color: 'white' }}
+              size="small"
+            >
+              {roleLinkName}
+            </Button>
+          )}
           {discordInvite && (
             <DiscordButton href={discordInvite} size="small">
               {t('join')}

--- a/src/pages/Blocked.jsx
+++ b/src/pages/Blocked.jsx
@@ -98,7 +98,7 @@ export function BlockedPage() {
           >
             {t('go_back')}
           </Button>
-	  {roleLink && roleLinkName && (
+          {roleLink && roleLinkName && (
             <Button
               variant="contained"
               color="success"


### PR DESCRIPTION
This PR simply adds a button to link to the URL users have set in their config for `rolesLink` with the button text to be `rolesLinkName`.

Default color is `success` and also is set to open in a new tab.