### PR TITLE
feat: add signpost support

### DIFF
--- a/src/components/popups/Navigation.jsx
+++ b/src/components/popups/Navigation.jsx
@@ -7,17 +7,18 @@ import { useMemory } from '@store/useMemory'
 import { useStorage } from '@store/useStorage'
 
 /**
- * @param {{ lat: number, lon: number, size?: import('@mui/material').IconButtonProps['size'] }} props
+ * @param {{ lat?: number, lon?: number, id?: number, size?: import('@mui/material').IconButtonProps['size'] }} props
  * @returns
  */
-export function Navigation({ lat, lon, size = 'large' }) {
+export function Navigation({ lat, lon, id, size = 'large' }) {
   const nav = useStorage((s) => s.settings.navigation)
   const url = useMemory((s) => s.settings.navigation[nav]?.url)
   return (
     <IconButton
       href={url
         .replaceAll('{x}', lat.toString())
-        .replaceAll('{y}', lon.toString())}
+        .replaceAll('{y}', lon.toString())
+        .replaceAll('{id}', id.toString())}
       target="_blank"
       rel="noreferrer"
       size={size}

--- a/src/features/pokemon/PokemonPopup.jsx
+++ b/src/features/pokemon/PokemonPopup.jsx
@@ -437,7 +437,7 @@ const Footer = ({ pokemon, popups, hasPvp, Icons }) => {
         </Grid>
       )}
       <Grid xs={4} textAlign="center">
-        <Navigation lat={lat} lon={lon} />
+        <Navigation lat={lat} lon={lon} id={pokemon.id} />
       </Grid>
       <Grid xs={4}>
         <IconButton


### PR DESCRIPTION
This change allows for users to configure their Signpost instance as a Navigation option.

Example
```
"navigation": [
    {
      "name": "Signpost",
      "url": "https://signpost.yourdomain.com/pokemon/{id}/google"
    },
    {
      "name": "Google Maps",
      "url": "https://maps.google.com/maps/place/{x},{y}"
    },
    {
      "name": "Apple Maps",
      "url": "https://maps.apple.com/maps?daddr={x},{y}"
    },
    {
      "name": "Waze",
      "url": "https://www.waze.com/ul?ll={x},{y}"
    },
    {
      "name": "Intel",
      "url": "https://intel.ingress.com/intel?pll={x},{y}"
    },
    {
      "name": "GeoURI",
      "url": "geo:{x},{y}?q={x},{y}"
    }
  ],
  ```
  
  And if you remove all other navigation options it would force a user to use your Signpost instance.
  
  NOTE: `/google` can be changed to `apple` or `waze` as well.
  
  Signpost Repo: https://github.com/jfberry/signpost