### PR TITLE
Allign customFloatingIcons icon color with the rest of the icons.

### DIFF
--- a/src/pages/map/components/FloatingBtn.jsx
+++ b/src/pages/map/components/FloatingBtn.jsx
@@ -259,7 +259,7 @@ export function FloatingButtons() {
             target={icon.target || '_blank'}
             disabled={disabled}
           >
-            <I className={icon.icon} size={iconSize} />
+            <I className={icon.icon} size={iconSize} color="white" />
           </Fab>
         ),
       )}


### PR DESCRIPTION
Just simply color the icon when using customFloatingIcons to white, so they match the other icons while using light mode.

Light mode (Changed to white now):
![image](https://github.com/WatWowMap/ReactMap/assets/5100210/8e1ef6fa-4424-44ee-ad66-e12533cf3525)

Dark mode: 
![image](https://github.com/WatWowMap/ReactMap/assets/5100210/955ee6f9-389d-4b43-a573-d586af4aa5bf)
