### PR TITLE
Remove flex container behavior from AreaGroups

### DIFF
--- a/src/features/webhooks/human/area/AreaGroup.jsx
+++ b/src/features/webhooks/human/area/AreaGroup.jsx
@@ -43,7 +43,7 @@ const GroupTile = ({ children, group, areas }) => {
   )
   if (children.length === 0) return null
   return (
-    <Grid2 container xs={12}>
+    <Grid2 xs={12}>
       {group ? (
         <BasicAccordion
           title={`${group} - ${count} / ${areas.length}`}


### PR DESCRIPTION
Remove container from AreaGroups, so in case you have Parent area(s) which doesn't fill out the entire Webhook popup width, then it align with the rest of them.

Before:
![image](https://github.com/WatWowMap/ReactMap/assets/5100210/5bcc1317-483a-42e3-b6b5-5fe79f8625fc)

After:
![image](https://github.com/WatWowMap/ReactMap/assets/5100210/9ab8fb20-d4b6-4dce-8301-25fbff617f22)
