### PR TITLE
Use `database.settings.gymBadgeTableName` for the migration instead of a static `gymBadges`

### DIFF
--- a/server/src/db/migrations/20240416222131_basicGymBadge.cjs
+++ b/server/src/db/migrations/20240416222131_basicGymBadge.cjs
@@ -1,11 +1,12 @@
 /* eslint-disable no-unused-vars */
+const config = require('@rm/config')
 
 /**
  * @param {import("knex").Knex} knex
  */
 exports.up = async (knex) => {
   // Increment all non-zero badges by 1 (e.g., moving Bronze from value 1 to value 2, making room for a basic badge)
-  await knex('gymBadges')
+  await knex(config.getSafe('database.settings.gymBadgeTableName'))
     .where('badge', '>', 0)
     .update({ badge: knex.raw('?? + 1', ['badge']) })
 }
@@ -15,7 +16,7 @@ exports.up = async (knex) => {
  */
 exports.down = async (knex) => {
   // Decrement all non-zero badges by 1 (e.g., moving Bronze from value 2 to value 1)
-  await knex('gymBadges')
+  await knex(config.getSafe('database.settings.gymBadgeTableName'))
     .where('badge', '>', 0)
     .update({ badge: knex.raw('?? - 1', ['badge']) })
 }


### PR DESCRIPTION
If you are using a custom `gymBadgeTableName`, it was ignored for this migration causing it to fail:
```
6|ReactMap | migration file "20240416222131_basicGymBadge.cjs" failed
6|ReactMap | migration failed with error: update `gymBadges` set `badge` = `badge` + 1 where `badge` > 0 - Table 'pmsfs2.gymBadges' doesn't exist
```