### PR TITLE
[Feature Request]: Exclude rocket grunt toggle & exclude rocket leader toggle

### DIFF
--- a/packages/locales/lib/human/de.json
+++ b/packages/locales/lib/human/de.json
@@ -585,6 +585,8 @@
   "delete": "löschen",
   "name": "Name",
   "only_confirmed": "nur bestätigte",
+  "only_exclude_grunts": "Grunzer ausschließen",
+  "only_exclude_leaders": "EAnführer ausschließen",
   "rocket_pokemon": "Crypto-Pokemon",
   "decoy": "Täusch-Rüpel",
   "s2_cell_limit_0": "Sie haben versucht, mehr als 20.000 Zellen zu generieren ({{variable_0}})",

--- a/packages/locales/lib/human/de.json
+++ b/packages/locales/lib/human/de.json
@@ -585,8 +585,6 @@
   "delete": "löschen",
   "name": "Name",
   "only_confirmed": "nur bestätigte",
-  "only_exclude_grunts": "Grunzer ausschließen",
-  "only_exclude_leaders": "EAnführer ausschließen",
   "rocket_pokemon": "Crypto-Pokemon",
   "decoy": "Täusch-Rüpel",
   "s2_cell_limit_0": "Sie haben versucht, mehr als 20.000 Zellen zu generieren ({{variable_0}})",

--- a/packages/locales/lib/human/en.json
+++ b/packages/locales/lib/human/en.json
@@ -615,6 +615,8 @@
   "delete": "Delete",
   "name": "Name",
   "only_confirmed": "Only Confirmed",
+  "only_exclude_grunts": "Exclude  Grunts",
+  "only_exclude_leaders": "Exclude Leaders",
   "rocket_pokemon": "Rocket Pokémon",
   "decoy": "Decoy",
   "s2_cell_limit_0": "You attempted to generate more than 20,000 cells ({{variable_0}})",

--- a/packages/locales/lib/human/es.json
+++ b/packages/locales/lib/human/es.json
@@ -544,6 +544,8 @@
   "delete": "Eliminar",
   "name": "Nombre",
   "only_confirmed": "Solo confirmados",
+  "only_exclude_grunts": "Excluir gruñidos",
+  "only_exclude_leaders": "Excluir a los dirigentes",
   "rocket_pokemon": "Pokémon del Equipo Rocket",
   "decoy": "Señuelo",
   "s2_cell_limit_0": "Has intentado generar más de 20,000 celdas ({{variable_0}})",

--- a/packages/locales/lib/human/es.json
+++ b/packages/locales/lib/human/es.json
@@ -544,8 +544,6 @@
   "delete": "Eliminar",
   "name": "Nombre",
   "only_confirmed": "Solo confirmados",
-  "only_exclude_grunts": "Excluir gruñidos",
-  "only_exclude_leaders": "Excluir a los dirigentes",
   "rocket_pokemon": "Pokémon del Equipo Rocket",
   "decoy": "Señuelo",
   "s2_cell_limit_0": "Has intentado generar más de 20,000 celdas ({{variable_0}})",

--- a/packages/locales/lib/human/fr.json
+++ b/packages/locales/lib/human/fr.json
@@ -571,6 +571,8 @@
   "delete": "Supprimer",
   "name": "Nom",
   "only_confirmed": "Confirmé seulement",
+  "only_exclude_grunts": "Exclure les grognements",
+  "only_exclude_leaders": "Exclure les dirigeants",
   "rocket_pokemon": "Pokémon Rocket",
   "decoy": "Leurre",
   "s2_cell_limit_0": "Vous avez essayé de générer plus de 20 000 cellules ({{variable_0}})",

--- a/packages/locales/lib/human/fr.json
+++ b/packages/locales/lib/human/fr.json
@@ -571,8 +571,6 @@
   "delete": "Supprimer",
   "name": "Nom",
   "only_confirmed": "Confirmé seulement",
-  "only_exclude_grunts": "Exclure les grognements",
-  "only_exclude_leaders": "Exclure les dirigeants",
   "rocket_pokemon": "Pokémon Rocket",
   "decoy": "Leurre",
   "s2_cell_limit_0": "Vous avez essayé de générer plus de 20 000 cellules ({{variable_0}})",

--- a/packages/locales/lib/human/pl.json
+++ b/packages/locales/lib/human/pl.json
@@ -395,6 +395,8 @@
   "online": "Online",
   "only_available": "Dostępne",
   "only_confirmed": "Tylko potwierdzone",
+  "only_exclude_grunts": "Wykluczyć chrząknięcia",
+  "only_exclude_leaders": "Wykluczyć liderów",
   "only_global": "Tylko globalne",
   "only_show_available": "Pokaż tylko dostępne",
   "opacity_five_minutes": "Przezroczystość po 5 minutach",

--- a/packages/locales/lib/human/pl.json
+++ b/packages/locales/lib/human/pl.json
@@ -395,8 +395,6 @@
   "online": "Online",
   "only_available": "Dostępne",
   "only_confirmed": "Tylko potwierdzone",
-  "only_exclude_grunts": "Wykluczyć chrząknięcia",
-  "only_exclude_leaders": "Wykluczyć liderów",
   "only_global": "Tylko globalne",
   "only_show_available": "Pokaż tylko dostępne",
   "opacity_five_minutes": "Przezroczystość po 5 minutach",

--- a/server/src/configs/custom-environment-variables.json
+++ b/server/src/configs/custom-environment-variables.json
@@ -989,6 +989,14 @@
         "__name": "DEFAULT_FILTERS_POKESTOPS_CONFIRMED",
         "__format": "boolean"
       },
+      "excludeGrunts": {
+        "__name": "DEFAULT_FILTERS_POKESTOPS_EXCLUDE_GRUNTS",
+        "__format": "boolean"
+      },
+      "excludeLeaders": {
+        "__name": "DEFAULT_FILTERS_POKESTOPS_EXCLUDE_LEADERS",
+        "__format": "boolean"
+      },
       "items": {
         "__name": "DEFAULT_FILTERS_POKESTOPS_ITEMS",
         "__format": "boolean"

--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -482,6 +482,8 @@
       "showcasePokemon": true,
       "questSet": "both",
       "confirmed": false,
+      "excludeGrunts": false,
+      "excludeLeaders": false,
       "items": true,
       "megaEnergy": true,
       "candy": true,

--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -142,13 +142,6 @@ class Pokestop extends Model {
     const midnight = getUserMidnight(args)
     const ts = Math.floor(Date.now() / 1000)
 
-    const rocketGruntIDs = [
-      4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
-      24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 47, 48,
-      49, 50,
-    ]
-    const rocketLeaderIDs = [41, 42, 43, 44]
-
     const {
       lures: lurePerms,
       quests: questPerms,
@@ -585,14 +578,14 @@ class Pokestop extends Model {
               if (onlyExcludeGrunts) {
                 invasion.whereNotIn(
                   isMad ? 'character_display' : 'character',
-                  rocketGruntIDs,
+                  Event.rocketGruntIDs,
                 )
               }
 
               if (onlyExcludeLeaders) {
                 invasion.whereNotIn(
                   isMad ? 'character_display' : 'character',
-                  rocketLeaderIDs,
+                  Event.rocketLeaderIDs,
                 )
               }
             })
@@ -613,19 +606,6 @@ class Pokestop extends Model {
               }
               if (hasConfirmed) {
                 invasion.andWhere('confirmed', onlyConfirmed)
-              }
-              if (onlyExcludeGrunts) {
-                invasion.whereNotIn(
-                  isMad ? 'character_display' : 'character',
-                  rocketGruntIDs,
-                )
-              }
-
-              if (onlyExcludeLeaders) {
-                invasion.whereNotIn(
-                  isMad ? 'character_display' : 'character',
-                  rocketLeaderIDs,
-                )
               }
             })
           }

--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -579,11 +579,17 @@ class Pokestop extends Model {
                 }
               })
               if (onlyExcludeGrunts) {
-                invasion.whereNotIn('character', rocketGruntIDs)
+                invasion.whereNotIn(
+                  isMad ? 'character_display' : 'character',
+                  rocketGruntIDs
+                )
               }
           
               if (onlyExcludeLeaders) {
-                invasion.whereNotIn('character', rocketLeaderIDs)
+                invasion.whereNotIn(
+                  isMad ? 'character_display' : 'character',
+                  rocketLeaderIDs
+                )
               }
             })
           } else {
@@ -605,11 +611,17 @@ class Pokestop extends Model {
                 invasion.andWhere('confirmed', onlyConfirmed)
               }
               if (onlyExcludeGrunts) {
-                invasion.whereNotIn('character', rocketGruntIDs)
+                invasion.whereNotIn(
+                  isMad ? 'character_display' : 'character',
+                  rocketGruntIDs
+                )
               }
           
               if (onlyExcludeLeaders) {
-                invasion.whereNotIn('character', rocketLeaderIDs)
+                invasion.whereNotIn(
+                  isMad ? 'character_display' : 'character',
+                  rocketLeaderIDs
+                )
               }
             })
           }

--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -142,7 +142,11 @@ class Pokestop extends Model {
     const midnight = getUserMidnight(args)
     const ts = Math.floor(Date.now() / 1000)
 
-    const rocketGruntIDs = [4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,47,48,49,50]
+    const rocketGruntIDs = [
+      4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+      24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 47, 48,
+      49, 50,
+    ]
     const rocketLeaderIDs = [41, 42, 43, 44]
 
     const {
@@ -581,14 +585,14 @@ class Pokestop extends Model {
               if (onlyExcludeGrunts) {
                 invasion.whereNotIn(
                   isMad ? 'character_display' : 'character',
-                  rocketGruntIDs
+                  rocketGruntIDs,
                 )
               }
-          
+
               if (onlyExcludeLeaders) {
                 invasion.whereNotIn(
                   isMad ? 'character_display' : 'character',
-                  rocketLeaderIDs
+                  rocketLeaderIDs,
                 )
               }
             })
@@ -613,14 +617,14 @@ class Pokestop extends Model {
               if (onlyExcludeGrunts) {
                 invasion.whereNotIn(
                   isMad ? 'character_display' : 'character',
-                  rocketGruntIDs
+                  rocketGruntIDs,
                 )
               }
-          
+
               if (onlyExcludeLeaders) {
                 invasion.whereNotIn(
                   isMad ? 'character_display' : 'character',
-                  rocketLeaderIDs
+                  rocketLeaderIDs,
                 )
               }
             })

--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -135,10 +135,15 @@ class Pokestop extends Model {
         onlyEventStops,
         onlyConfirmed,
         onlyAreas = [],
+        onlyExcludeGrunts,
+        onlyExcludeLeaders,
       },
     } = args
     const midnight = getUserMidnight(args)
     const ts = Math.floor(Date.now() / 1000)
+
+    const rocketGruntIDs = [4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,47,48,49,50]
+    const rocketLeaderIDs = [41, 42, 43, 44]
 
     const {
       lures: lurePerms,
@@ -573,6 +578,13 @@ class Pokestop extends Model {
                   )
                 }
               })
+              if (onlyExcludeGrunts) {
+                invasion.whereNotIn('character', rocketGruntIDs)
+              }
+          
+              if (onlyExcludeLeaders) {
+                invasion.whereNotIn('character', rocketLeaderIDs)
+              }
             })
           } else {
             stops.orWhere((invasion) => {
@@ -591,6 +603,13 @@ class Pokestop extends Model {
               }
               if (hasConfirmed) {
                 invasion.andWhere('confirmed', onlyConfirmed)
+              }
+              if (onlyExcludeGrunts) {
+                invasion.whereNotIn('character', rocketGruntIDs)
+              }
+          
+              if (onlyExcludeLeaders) {
+                invasion.whereNotIn('character', rocketLeaderIDs)
               }
             })
           }

--- a/server/src/services/EventManager.js
+++ b/server/src/services/EventManager.js
@@ -325,6 +325,23 @@ class EventManager {
       try {
         const newInvasions = await fetch(endpoint).then((res) => res.json())
         if (newInvasions) {
+          this.rocketGruntIDs = Object.keys(newInvasions)
+            .filter(
+              (key) =>
+                newInvasions[key].grunt &&
+                newInvasions[key].grunt.includes('Grunt'),
+            )
+            .map(Number)
+
+          this.rocketLeaderIDs = Object.keys(newInvasions)
+            .filter(
+              (key) =>
+                newInvasions[key].grunt &&
+                (newInvasions[key].grunt.includes('Executive') ||
+                  newInvasions[key].grunt.includes('Giovanni')),
+            )
+            .map(Number)
+
           this.invasions = newInvasions
         }
       } catch (e) {

--- a/server/src/services/filters/builder/base.js
+++ b/server/src/services/filters/builder/base.js
@@ -91,6 +91,12 @@ function buildDefaultFilters(perms) {
             confirmed: perms.invasions
               ? defaultFilters.pokestops.confirmed
               : undefined,
+            excludeGrunts: perms.invasions
+              ? defaultFilters.pokestops.excludeGrunts
+              : undefined,
+            excludeLeaders: perms.invasions
+              ? defaultFilters.pokestops.excludeLeaders
+              : undefined,
             invasions: perms.invasions
               ? defaultFilters.pokestops.invasions
               : undefined,

--- a/src/features/drawer/pokestops/Invasions.jsx
+++ b/src/features/drawer/pokestops/Invasions.jsx
@@ -24,6 +24,16 @@ const BaseInvasion = () => {
           label="only_confirmed"
         />
       )}
+      <BoolToggle
+        inset
+        field="filters.pokestops.excludeGrunts"
+        label="only_exclude_grunts"
+      />
+      <BoolToggle
+        inset
+        field="filters.pokestops.excludeLeaders"
+        label="only_exclude_leaders"
+      />
       {confirmedEnabled || hasConfirmed ? (
         <MultiSelectorList tabKey="invasions">
           <SelectorListMemo


### PR DESCRIPTION
Adds 2 toggles to further filter Rocket Pokemon: `Exclude Rocket Leaders` & `Exclude Rocket Grunts`.

It should be noted that I've only tested this with a limited data setup (actually just 2 pokestops, one with character ID 16, and one with character ID 41), so it could use a test with a larger set of data. I don't have a scanner set up so I'm unable to do this