### PR TITLE
fix: quest conditions with similar quest titles

### DIFF
--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -894,7 +894,9 @@ class Pokestop extends Model {
               (filters.onlyAllPokestops ||
                 (filters[newQuest.key] &&
                   (filters[newQuest.key].adv && !filters[newQuest.key].all
-                    ? filters[newQuest.key].adv.includes(quest.quest_title)
+                    ? filters[newQuest.key].adv.includes(
+                        `${quest.quest_title}__${quest.quest_target}`,
+                      )
                     : true)) ||
                 filters[`u${quest.quest_reward_type}`])
             ) {

--- a/src/components/filters/QuestConditions.jsx
+++ b/src/components/filters/QuestConditions.jsx
@@ -26,6 +26,10 @@ export function QuestConditionSelector({ id }) {
 
   const [open, setOpen] = React.useState(false)
 
+  const handleClose = () => setOpen(false)
+
+  const handleOpen = () => setOpen(true)
+
   // Provides a reset if that condition is no longer available
   React.useEffect(() => {
     if (hasQuests) {
@@ -39,7 +43,9 @@ export function QuestConditionSelector({ id }) {
           ? value
               .split(',')
               .filter((each) =>
-                questConditions.find(({ title }) => title === each),
+                questConditions.find(
+                  ({ title, target }) => `${title}__${target}` === each,
+                ),
               )
           : []
         setValue(filtered.length ? filtered.join(',') : '')
@@ -49,14 +55,6 @@ export function QuestConditionSelector({ id }) {
       setValue('')
     }
   }, [questConditions, id, hasQuests])
-
-  const handleClose = () => {
-    setOpen(false)
-  }
-
-  const handleOpen = () => {
-    setOpen(true)
-  }
 
   if (!questConditions) return null
 
@@ -89,6 +87,7 @@ export function QuestConditionSelector({ id }) {
               ? e.target.value.filter(Boolean).join(',')
               : e.target.value,
           )
+          if (e.target.value.length === 0) handleClose()
         }
       }}
       fcSx={{ my: 1 }}
@@ -100,7 +99,7 @@ export function QuestConditionSelector({ id }) {
         .slice()
         .sort((a, b) => a.title.localeCompare(b.title))
         .map(({ title, target }) => (
-          <MenuItem key={`${title}-${target}`} value={title}>
+          <MenuItem key={`${title}-${target}`} value={`${title}__${target}`}>
             <QuestTitle questTitle={title} questTarget={target} />
           </MenuItem>
         ))}

--- a/src/features/drawer/pokestops/Quests.jsx
+++ b/src/features/drawer/pokestops/Quests.jsx
@@ -38,4 +38,5 @@ const BaseQuestQuickSelect = () => {
     </CollapsibleItem>
   )
 }
+
 export const QuestQuickSelect = React.memo(BaseQuestQuickSelect)

--- a/src/hooks/useMapData.js
+++ b/src/hooks/useMapData.js
@@ -104,9 +104,30 @@ export function useMapData(once = false) {
           questConditions,
         },
       }))
-      useStorage.setState((prev) => ({
-        filters: deepMerge({}, filters, prev.filters),
-      }))
+      useStorage.setState((prev) => {
+        const newFilters = deepMerge({}, filters, prev.filters)
+
+        // Migration for quest conditions to use target as well
+        Object.entries(newFilters?.pokestops?.filter || {}).forEach(
+          ([key, filter]) => {
+            if (filter.adv && questConditions[key]) {
+              const newAdv = filter.adv
+                .split(',')
+                .flatMap((each) =>
+                  questConditions[key]
+                    .filter(({ title }) => title === each)
+                    .map(({ target }) => `${each}__${target}`),
+                )
+              if (newAdv.length) {
+                filter.adv = newAdv.join(',')
+              }
+            }
+          },
+        )
+        return {
+          filters: newFilters,
+        }
+      })
     }
   }, [data])
 


### PR DESCRIPTION
This fixes an issue that appeared when a specific quest reward has two quest conditions that have the same quest title but different target amounts. Since this changes the format of the filter it also includes a migration to fix any existing filtering that users are doing by quest conditions at startup.