### PR TITLE
fix: helmet middleware opt in

### DIFF
--- a/server/src/configs/default.json
+++ b/server/src/configs/default.json
@@ -15,6 +15,7 @@
   "api": {
     "sessionSecret": "98ki^e72~!@#(85o3kXLI*#c9wu5l!Z",
     "reactMapSecret": "",
+    "enableHelmet": false,
     "showSchemasInConfigApi": false,
     "showStrategiesInConfigApi": false,
     "maxSessions": 5,

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -74,22 +74,28 @@ const startServer = async () => {
         req.bodySize = (req.bodySize || 0) + buf.length
       },
     }),
-    helmet({
-      hidePoweredBy: true,
-      contentSecurityPolicy: {
-        directives: {
-          scriptSrc: [
-            "'self'",
-            'https://cdn.jsdelivr.net',
-            'https://telegram.org',
-            'https://static.cloudflareinsights.com',
-          ],
-          frameSrc: ["'self'", 'https://*.telegram.org'],
-          workerSrc: ["'self'", 'blob:'],
-        },
-      },
-    }),
   )
+
+  if (config.getSafe('api.enableHelmet')) {
+    app.use(
+      helmet({
+        hidePoweredBy: true,
+        contentSecurityPolicy: {
+          directives: {
+            scriptSrc: [
+              "'self'",
+              'https://cdn.jsdelivr.net',
+              'https://telegram.org',
+              'https://static.cloudflareinsights.com',
+            ],
+            frameSrc: ["'self'", 'https://*.telegram.org'],
+            workerSrc: ["'self'", 'blob:'],
+          },
+        },
+      }),
+    )
+  }
+
   initPassport(app)
 
   const sentryErrorMiddleware = initSentry(app)

--- a/server/src/services/functions/reloadConfig.js
+++ b/server/src/services/functions/reloadConfig.js
@@ -20,6 +20,7 @@ const NO_RELOAD = new Set([
   'api.rateLimit.time',
   'api.rateLimit.requests',
   'api.sessionCheckIntervalMs',
+  'api.enableHelmet',
   'database.settings.sessionTableName',
   'sentry',
   'sentry.client',


### PR DESCRIPTION
Add configurable value to opt in to using the `helmet` middleware or not. Disabled by default since the middleware is more disruptive than originally realized.