### PR TITLE
feat: more nest viewing options

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -474,7 +474,8 @@
       "allPokemon": true,
       "onlyShowAvailable": true,
       "avgFilter": [0, 100],
-      "avgSliderStep": 1
+      "avgSliderStep": 1,
+      "active": "active"
     },
     "pokestops": {
       "enabled": false,

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "nodemonConfig": {
     "watch": [
       "server/src/**/*.js",
-      "server/src/configs/default.json",
+      "config/default.json",
       "packages/**/*"
     ],
     "ignore": [

--- a/server/src/filters/builder/base.js
+++ b/server/src/filters/builder/base.js
@@ -66,10 +66,11 @@ function buildDefaultFilters(perms) {
             enabled: defaultFilters.nests.enabled,
             onlyShowAvailable: defaultFilters.nests.onlyShowAvailable,
             pokemon: defaultFilters.nests.pokemon,
-            polygons: defaultFilters.nests.polygons,
             avgFilter: defaultFilters.nests.avgFilter,
+            polygons: defaultFilters.nests.polygons,
             standard: new BaseFilter(),
             filter: pokemon.nests,
+            active: defaultFilters.nests.active,
           }
         : undefined,
     pokestops:

--- a/server/src/services/DbCheck.js
+++ b/server/src/services/DbCheck.js
@@ -70,7 +70,7 @@ module.exports = class DbCheck extends Logger {
           this.endpoints[i] = schema
           return null
         }
-        const logger = new Logger('knex', schema.database)
+        const { log } = new Logger('knex', schema.database)
         return knex({
           client: 'mysql2',
           connection: {
@@ -88,12 +88,12 @@ module.exports = class DbCheck extends Logger {
               conn.query('SET time_zone="+00:00";', (err) => done(err, conn)),
           },
           log: {
-            warn: (message) => logger.warn(message),
-            error: (message) => logger.error(message),
+            warn: (message) => log.warn(message),
+            error: (message) => log.error(message),
             debug: (message) =>
-              logger[
-                config.getSafe('devOptions.queryDebug') ? 'info' : 'debug'
-              ](message),
+              log[config.getSafe('devOptions.queryDebug') ? 'info' : 'debug'](
+                message,
+              ),
             enableColors: true,
           },
         })

--- a/server/src/ui/primary.js
+++ b/server/src/ui/primary.js
@@ -34,7 +34,6 @@ function generateUi(req, perms) {
       perms.nests && state.db.models.Nest
         ? {
             pokemon: true,
-            polygons: true,
             sliders: {
               secondary: [
                 {
@@ -48,6 +47,8 @@ function generateUi(req, perms) {
                 },
               ],
             },
+            polygons: true,
+            active: true,
           }
         : BLOCKED,
     pokestops:

--- a/server/src/utils/reloadConfig.js
+++ b/server/src/utils/reloadConfig.js
@@ -81,15 +81,21 @@ async function reloadConfig() {
     const invalid = changed.filter((key) => NO_RELOAD.has(key))
 
     /** @param {string} key */
-    const print = (key) =>
-      log.info(
-        TAGS.config,
-        `'${key}' -`,
-        'old:',
-        dlv(oldWithoutAreas, key),
-        'new:',
-        newConfig.getSafe(key),
-      )
+    const print = (key) => {
+      let newValue
+      let oldValue
+      try {
+        oldValue = dlv(oldWithoutAreas, key)
+      } catch {
+        // do nothing
+      }
+      try {
+        newValue = newConfig.get(key)
+      } catch {
+        // do nothing
+      }
+      log.info(TAGS.config, `'${key}' -`, 'old:', oldValue, 'new:', newValue)
+    }
 
     if (valid.length) {
       log.info(TAGS.config, 'updating the following config values:')

--- a/src/components/inputs/MultiSelector.jsx
+++ b/src/components/inputs/MultiSelector.jsx
@@ -36,7 +36,7 @@ export function MultiSelector({ items, value, disabled, onClick, tKey }) {
  * @param {{
  *  field: T,
  *  defaultValue?: V,
- *  onClick?: (oldValue: ReturnType<typeof useDeepStore>[0], newValue: V) => void
+ *  onClick?: (oldValue: V, newValue: V) => void
  *  allowNone?: boolean
  * } & Omit<import('@rm/types').MultiSelectorProps<V>, 'value' | 'onClick'>} props
  * @returns
@@ -50,7 +50,7 @@ export function MultiSelectorStore({
 }) {
   const [value, setValue] = useDeepStore(field, defaultValue)
 
-  /** @type {(o: typeof value, n: V) => import('@mui/material').ButtonProps['onClick']} */
+  /** @type {(o: V, n: V) => import('@mui/material').ButtonProps['onClick']} */
   const onClickWrapper = React.useCallback(
     (oldValue, newValue) => () => {
       // @ts-ignore // TODO: fix this

--- a/src/features/drawer/S2Cells.jsx
+++ b/src/features/drawer/S2Cells.jsx
@@ -29,7 +29,7 @@ const S2Cells = () => {
         sx={{ mx: 'auto', width: '90%' }}
         value={safe}
         renderValue={(selected) =>
-          Array.isArray(selected) ? selected.join(', ') : selected
+          Array.isArray(selected) ? selected.join(', ') : `${selected}`
         }
         multiple
         onChange={({ target }) =>

--- a/src/features/drawer/components/Section.jsx
+++ b/src/features/drawer/components/Section.jsx
@@ -72,7 +72,10 @@ const DrawerSection = ({ category }) => {
                 category === 'wayfarer' || category === 'admin'
               return (
                 <React.Fragment key={`${category}${subItem}`}>
-                  {!(category === 'nests' && subItem === 'sliders') && (
+                  {!(
+                    category === 'nests' &&
+                    (subItem === 'sliders' || subItem === 'active')
+                  ) && (
                     <BoolToggle
                       // @ts-ignore
                       field={`filters.${

--- a/src/features/drawer/nests/ActiveNests.jsx
+++ b/src/features/drawer/nests/ActiveNests.jsx
@@ -1,0 +1,19 @@
+import * as React from 'react'
+import ListItem from '@mui/material/ListItem'
+
+import { MultiSelectorStore } from '@components/inputs/MultiSelector'
+import { useStorage } from '@store/useStorage'
+import { CollapsibleItem } from '../components/CollapsibleItem'
+
+const ITEMS = ['active', 'all', 'inactive']
+
+export function ActiveNests() {
+  const show = useStorage((s) => !!s.filters?.nests?.polygons)
+  return (
+    <CollapsibleItem open={show}>
+      <ListItem>
+        <MultiSelectorStore items={ITEMS} field="filters.nests.active" />
+      </ListItem>
+    </CollapsibleItem>
+  )
+}

--- a/src/features/drawer/nests/AvgSlider.jsx
+++ b/src/features/drawer/nests/AvgSlider.jsx
@@ -3,21 +3,25 @@ import * as React from 'react'
 import ListItem from '@mui/material/ListItem'
 
 import { useMemory } from '@store/useMemory'
-import { useDeepStore } from '@store/useStorage'
+import { useDeepStore, useStorage } from '@store/useStorage'
 import { SliderTile } from '@components/inputs/SliderTile'
+import { CollapsibleItem } from '../components/CollapsibleItem'
 
 const BaseNestSlider = () => {
   const slider = useMemory((s) => s.ui.nests?.sliders?.secondary?.[0])
+  const show = useStorage((s) => !!s.filters?.nests?.pokemon)
   const [filters, setFilters] = useDeepStore(`filters.nests.avgFilter`)
   if (!filters || !slider) return null
   return (
-    <ListItem>
-      <SliderTile
-        slide={slider}
-        handleChange={(_, values) => setFilters(values)}
-        values={filters}
-      />
-    </ListItem>
+    <CollapsibleItem open={show}>
+      <ListItem>
+        <SliderTile
+          slide={slider}
+          handleChange={(_, values) => setFilters(values)}
+          values={filters}
+        />
+      </ListItem>
+    </CollapsibleItem>
   )
 }
 

--- a/src/features/drawer/nests/index.jsx
+++ b/src/features/drawer/nests/index.jsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 
 import { NestSlider } from './AvgSlider'
 import { NestQuickSelect } from './NestSelector'
+import { ActiveNests } from './ActiveNests'
 
 function BaseNestDrawer({ subItem }) {
   switch (subItem) {
@@ -10,6 +11,8 @@ function BaseNestDrawer({ subItem }) {
       return <NestSlider />
     case 'pokemon':
       return <NestQuickSelect />
+    case 'active':
+      return <ActiveNests />
     default:
       return null
   }

--- a/src/features/nest/NestPopup.jsx
+++ b/src/features/nest/NestPopup.jsx
@@ -13,10 +13,10 @@ import { useTranslation } from 'react-i18next'
 import { useMemory } from '@store/useMemory'
 import { useLayoutStore } from '@store/useLayoutStore'
 import { setDeepStore } from '@store/useStorage'
-import { ErrorBoundary } from '@components/ErrorBoundary'
 import { NestSubmission } from '@components/dialogs/NestSubmission'
 import { getTimeUntil } from '@utils/getTimeUntil'
 import { useAnalytics } from '@hooks/useAnalytics'
+import { Popup } from 'react-leaflet'
 
 /** @param {number} timeSince */
 const getColor = (timeSince) => {
@@ -48,6 +48,8 @@ export function NestPopup({
   updated = 0,
   pokemon_avg = 0,
   submitted_by = '',
+  lat,
+  lon,
 }) {
   const { t } = useTranslation()
   const { perms } = useMemory((s) => s.auth)
@@ -57,14 +59,8 @@ export function NestPopup({
 
   const lastUpdated = getTimeUntil(updated * 1000)
 
-  const handleClick = (event) => {
-    setAnchorEl(event.currentTarget)
-  }
-
-  const handleClose = () => {
-    setAnchorEl(null)
-  }
-
+  const handleClick = (event) => setAnchorEl(event.currentTarget)
+  const handleClose = () => setAnchorEl(null)
   const handleHide = () => {
     setAnchorEl(null)
     useMemory.setState((prev) => ({ hideList: new Set(prev.hideList).add(id) }))
@@ -84,7 +80,7 @@ export function NestPopup({
   ]
 
   return (
-    <ErrorBoundary noRefresh variant="h5">
+    <Popup position={[lat, lon]}>
       <Grid
         container
         justifyContent="center"
@@ -92,7 +88,7 @@ export function NestPopup({
         style={{ width: 200 }}
         spacing={1}
       >
-        <Grid xs={9} textAlign="center">
+        <Grid xs={pokemon_id ? 9 : 12} textAlign="center">
           <Typography
             variant={name.length > 20 ? 'subtitle2' : 'h6'}
             align="center"
@@ -112,11 +108,13 @@ export function NestPopup({
             </Typography>
           )}
         </Grid>
-        <Grid xs={3}>
-          <IconButton aria-haspopup="true" onClick={handleClick} size="large">
-            <MoreVert />
-          </IconButton>
-        </Grid>
+        {!!pokemon_id && (
+          <Grid xs={3}>
+            <IconButton aria-haspopup="true" onClick={handleClick} size="large">
+              <MoreVert />
+            </IconButton>
+          </Grid>
+        )}
         <Menu
           anchorEl={anchorEl}
           keepMounted
@@ -135,19 +133,21 @@ export function NestPopup({
             </MenuItem>
           ))}
         </Menu>
-        <Grid xs={6} textAlign="center">
-          <img
-            src={iconUrl}
-            alt={iconUrl}
-            style={{
-              maxHeight: 75,
-              maxWidth: 75,
-            }}
-          />
-          <br />
-          <Typography variant="caption">{t(`poke_${pokemon_id}`)}</Typography>
-        </Grid>
-        <Grid xs={6} textAlign="center">
+        {!!pokemon_id && (
+          <Grid xs={6} textAlign="center">
+            <img
+              src={iconUrl}
+              alt={iconUrl}
+              style={{
+                maxHeight: 75,
+                maxWidth: 75,
+              }}
+            />
+            <br />
+            <Typography variant="caption">{t(`poke_${pokemon_id}`)}</Typography>
+          </Grid>
+        )}
+        <Grid xs={pokemon_id ? 6 : 12} textAlign="center">
           <Typography variant="subtitle2">{t('last_updated')}</Typography>
           <Typography
             variant={lastUpdated.str.includes('D') ? 'h6' : 'subtitle2'}
@@ -195,6 +195,6 @@ export function NestPopup({
         )}
       </Grid>
       <NestSubmission id={id} name={name} />
-    </ErrorBoundary>
+    </Popup>
   )
 }

--- a/src/features/nest/NestTile.jsx
+++ b/src/features/nest/NestTile.jsx
@@ -1,7 +1,8 @@
-/* eslint-disable react/destructuring-assignment */
 // @ts-check
+/* eslint-disable react/destructuring-assignment */
+
 import * as React from 'react'
-import { GeoJSON, Marker, Popup } from 'react-leaflet'
+import { GeoJSON, Marker } from 'react-leaflet'
 
 import { basicEqualFn, useMemory } from '@store/useMemory'
 import { useStorage } from '@store/useStorage'
@@ -30,6 +31,49 @@ const BaseNestTile = (nest) => {
     ]
   }, basicEqualFn)
 
+  return (
+    <>
+      {nest.pokemon_id && (
+        <NestMarker
+          iconUrl={iconUrl}
+          iconSize={iconSize}
+          recent={recent}
+          nest={nest}
+        >
+          <NestPopup iconUrl={iconUrl} recent={recent} {...nest} />
+        </NestMarker>
+      )}
+      <NestGeoJSON polygon_path={nest.polygon_path}>
+        <NestPopup iconUrl={iconUrl} recent={recent} {...nest} />
+      </NestGeoJSON>
+    </>
+  )
+}
+
+/**
+ *
+ * @param {Omit<import('react-leaflet').MarkerProps, 'position'> & {
+ *  children: React.ReactNode
+ *  iconUrl: string
+ *  iconSize: number
+ *  recent: boolean
+ *  nest: import('@rm/types').Nest
+ * }} props
+ * @returns
+ */
+const NestMarker = ({
+  children,
+  iconSize,
+  iconUrl,
+  recent,
+  nest,
+  ...props
+}) => {
+  const showPokemon = useStorage((s) => s.filters.nests.pokemon)
+  const [markerRef, setMarkerRef] = React.useState(null)
+
+  useForcePopup(nest.id, markerRef)
+
   const icon = React.useMemo(
     () =>
       nestMarker({
@@ -39,42 +83,19 @@ const BaseNestTile = (nest) => {
         formId: nest.pokemon_form,
         recent,
       }),
-    [iconUrl, iconSize, nest.pokemon_id, recent],
+    [iconUrl, iconSize, nest.pokemon_id, nest.pokemon_form, recent],
   )
-
-  return (
-    <>
-      <NestMarker icon={icon} id={nest.id} lat={nest.lat} lon={nest.lon}>
-        <Popup position={[nest.lat, nest.lon]}>
-          <NestPopup iconUrl={iconUrl} recent={recent} {...nest} />
-        </Popup>
-      </NestMarker>
-      <NestGeoJSON polygon_path={nest.polygon_path} />
-    </>
-  )
-}
-
-/**
- *
- * @param {Omit<import('react-leaflet').MarkerProps, 'position'> & {
- *  children: React.ReactNode
- *  id: number
- *  lat: number
- *  lon: number
- * }} props
- * @returns
- */
-const NestMarker = ({ children, icon, id, lat, lon, ...props }) => {
-  const showPokemon = useStorage((s) => s.filters.nests.pokemon)
-  const [markerRef, setMarkerRef] = React.useState(null)
-
-  useForcePopup(id, markerRef)
 
   if (!showPokemon) {
     return null
   }
   return (
-    <Marker ref={setMarkerRef} position={[lat, lon]} icon={icon} {...props}>
+    <Marker
+      ref={setMarkerRef}
+      position={[nest.lat, nest.lon]}
+      icon={icon}
+      {...props}
+    >
       {children}
     </Marker>
   )
@@ -82,10 +103,10 @@ const NestMarker = ({ children, icon, id, lat, lon, ...props }) => {
 
 /**
  *
- * @param {{ polygon_path: string }} props
+ * @param {{ polygon_path: string, children?: React.ReactNode }} props
  * @returns
  */
-const NestGeoJSON = ({ polygon_path }) => {
+const NestGeoJSON = ({ polygon_path, children }) => {
   const showPolygons = useStorage((s) => s.filters.nests.polygons)
 
   const geometry = React.useMemo(() => {
@@ -101,7 +122,7 @@ const NestGeoJSON = ({ polygon_path }) => {
   if (!showPolygons) {
     return null
   }
-  return <GeoJSON data={geometry} />
+  return <GeoJSON data={geometry}>{children}</GeoJSON>
 }
 
 export const NestTile = React.memo(

--- a/src/pages/map/components/Layers.jsx
+++ b/src/pages/map/components/Layers.jsx
@@ -8,8 +8,8 @@ import { useStorage } from '@store/useStorage'
 import { useTileLayer } from '../hooks/useTileLayer'
 
 export function ControlledTileLayer() {
-  const layer = useTileLayer()
-  return <TileLayer {...layer} />
+  const { key, ...layer } = useTileLayer()
+  return <TileLayer key={key} {...layer} />
 }
 
 export function ControlledZoomLayer() {


### PR DESCRIPTION
## Main Focus
- Adds a selector to view `inactive` / `active` / `all` nests
- Necessary code to account for nests in the client not having a valid pokemon_id 
- Makes the nest polygons clickable / have a popup too

## Small Bug Fixes
- Config value comparison on hot reload for undefined values
- Query debug logging