### PR TITLE
chore: fix docker image steps

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,10 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Set .gitsha
-        if: github.event_name == 'push'
         run: 'echo ${{ github.sha }} > .gitsha'
       - name: Set .gitref
-        if: github.event_name == 'push'
         run: 'echo ${{ github.ref }} > .gitref'
 
       - name: Log in to the Container registry


### PR DESCRIPTION
the condition blocked writing gitsha and gitref to file on PRs

I checked the PR images, all of them contained empty `.gitsha` and `.gitref` files :) 

To-do:
This writes `refs/pull/1068/merge` into .gitref... We might need to change the flow a bit 