### PR TITLE
Fix Waze url for navigation when using CarPlay

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -921,7 +921,7 @@
     },
     {
       "name": "Waze",
-      "url": "https://www.waze.com/ul?ll={x},{y}"
+      "url": "https://www.waze.com/ul?ll={x},{y}&navigate=yes&zoom=17"
     },
     {
       "name": "Intel",


### PR DESCRIPTION
The default url for Waze works fine IIRC when you are not using CarPlay. The Waze app will open to the location and allow you to start navigation.

However, if you have CarPlay, the Waze app just opens to the default 'menu', and doesn't seem to know anything about the location.

This has always worked fine from Poracle notifications. So this adds a couple of extra query params that Poracle uses. This fixes it.