### PR TITLE
feat: add role array support

### DIFF
--- a/packages/config/lib/mutations.js
+++ b/packages/config/lib/mutations.js
@@ -279,9 +279,9 @@ const applyMutations = (config) => {
   )
   /** @param {string | string[]} role */
   const replaceAliases = (role) =>
-    Array.isArray(role) 
-      ? role.flatMap((r) => aliasObj[r] ?? r) 
-      : aliasObj[role] ?? role
+    Array.isArray(role)
+      ? role.flatMap((r) => aliasObj[r] ?? r)
+      : (aliasObj[role] ?? role)
 
   const replaceBothAliases = (incomingObj) => ({
     ...incomingObj,

--- a/packages/config/lib/mutations.js
+++ b/packages/config/lib/mutations.js
@@ -277,27 +277,30 @@ const applyMutations = (config) => {
   const aliasObj = Object.fromEntries(
     config.authentication.aliases.map((alias) => [alias.name, alias.role]),
   )
-  /** @param {string} role */
-  const replaceAliases = (role) => aliasObj[role] ?? role
+  /** @param {string | string[]} role */
+  const replaceAliases = (role) =>
+    Array.isArray(role) 
+      ? role.flatMap((r) => aliasObj[r] ?? r) 
+      : aliasObj[role] ?? role
 
   const replaceBothAliases = (incomingObj) => ({
     ...incomingObj,
     discordRoles: Array.isArray(incomingObj.discordRoles)
-      ? incomingObj.discordRoles.map(replaceAliases)
+      ? incomingObj.discordRoles.flatMap(replaceAliases)
       : undefined,
     telegramGroups: Array.isArray(incomingObj.telegramGroups)
-      ? incomingObj.telegramGroups.map(replaceAliases)
+      ? incomingObj.telegramGroups.flatMap(replaceAliases)
       : undefined,
   })
 
   Object.keys(config.authentication.perms).forEach((perm) => {
     config.authentication.perms[perm].roles =
-      config.authentication.perms[perm].roles.map(replaceAliases)
+      config.authentication.perms[perm].roles.flatMap(replaceAliases)
   })
 
   config.authentication.areaRestrictions =
     config.authentication.areaRestrictions.map(({ roles, areas }) => ({
-      roles: roles.map(replaceAliases),
+      roles: roles.flatMap(replaceAliases),
       areas,
     }))
 
@@ -305,21 +308,21 @@ const applyMutations = (config) => {
     (strategy) => ({
       ...strategy,
       allowedGuilds: Array.isArray(strategy.allowedGuilds)
-        ? strategy.allowedGuilds.map(replaceAliases)
+        ? strategy.allowedGuilds.flatMap(replaceAliases)
         : [],
       blockedGuilds: Array.isArray(strategy.blockedGuilds)
-        ? strategy.blockedGuilds.map(replaceAliases)
+        ? strategy.blockedGuilds.flatMap(replaceAliases)
         : [],
       groups: Array.isArray(strategy.groups)
-        ? strategy.groups.map(replaceAliases)
+        ? strategy.groups.flatMap(replaceAliases)
         : [],
       allowedUsers: Array.isArray(strategy.allowedUsers)
-        ? strategy.allowedUsers.map(replaceAliases)
+        ? strategy.allowedUsers.flatMap(replaceAliases)
         : [],
       trialPeriod: {
         ...strategy.trialPeriod,
         roles: Array.isArray(strategy?.trialPeriod?.roles)
-          ? strategy.trialPeriod.roles.map(replaceAliases)
+          ? strategy.trialPeriod.roles.flatMap(replaceAliases)
           : [],
       },
     }),

--- a/packages/types/lib/config.d.ts
+++ b/packages/types/lib/config.d.ts
@@ -59,7 +59,7 @@ export type Config<Client extends boolean = false> = DeepMerge<
       // alwaysEnabledPerms: (keyof BaseConfig['authentication']['perms'])[]
       excludeFromTutorial: string[]
       alwaysEnabledPerms: string[]
-      aliases: { role: string; name: string }[]
+      aliases: { role: string | string[]; name: string }[]
       methods: Strategy[]
       strategies: {
         type: Strategy


### PR DESCRIPTION
Minor change to make it a little better to handle lots of Discord permissions in the local.json file.
Previously we would have to define roles like this:
```json
    "aliases": [
      {
        "role": "123",
        "name": "supporter-bronze"
      },
      {
        "role": "456",
        "name": "supporter-silver"
      },
      {
        "role": "789",
        "name": "supporter-gold"
      }
 ```
Now we can use an array to define a group of roles like this:
```json
    "aliases": [
     {
       "role": ["123", "456", "789"],
       "name": "supporter"
}
 ```

This makes permissions easier to read and handle, especially with many roles across different servers:
```json
"perms": {
      "iv": {
        "enabled": true,
        "trialPeriodEligible": false,
        "roles": ["supporter"]
      }
```

Tested on my own production instance.