### PR TITLE
Update default.json

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -916,7 +916,7 @@
     },
     {
       "name": "Apple Maps",
-      "url": "https://maps.apple.com/maps?daddr={x},{y}"
+      "url": "https://maps.apple.com/place?coordinate={x},{y}"
     },
     {
       "name": "Waze",


### PR DESCRIPTION
Fix Apple Maps links by changing `default.json`

Example:

![image](https://github.com/user-attachments/assets/378ba48a-44bb-4cd4-beae-e7637d8944cc)


Please let me know if I did anything wrong and I'll change it.