### PR TITLE
feat: cooldown bypass for scan on demand

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -1466,6 +1466,20 @@
         "__name": "SCANNER_SCAN_NEXT_USER_COOLDOWN_SECONDS",
         "__format": "number"
       },
+      "cooldownBypass": {
+        "discordRoles": {
+          "__name": "SCANNER_SCAN_NEXT_COOLDOWN_BYPASS_DISCORD_ROLES",
+          "__format": "json"
+        },
+        "local": {
+          "__name": "SCANNER_SCAN_NEXT_COOLDOWN_BYPASS_LOCAL",
+          "__format": "json"
+        },
+        "telegramGroups": {
+          "__name": "SCANNER_SCAN_NEXT_COOLDOWN_BYPASS_TELEGRAM_GROUPS",
+          "__format": "json"
+        }
+      },
       "scanNextAreaRestriction": {
         "__name": "SCANNER_SCAN_NEXT_SCAN_NEXT_AREA_RESTRICTION",
         "__format": "json"
@@ -1523,6 +1537,20 @@
       "userCooldownSeconds": {
         "__name": "SCANNER_SCAN_ZONE_USER_COOLDOWN_SECONDS",
         "__format": "number"
+      },
+      "cooldownBypass": {
+        "discordRoles": {
+          "__name": "SCANNER_SCAN_ZONE_COOLDOWN_BYPASS_DISCORD_ROLES",
+          "__format": "json"
+        },
+        "local": {
+          "__name": "SCANNER_SCAN_ZONE_COOLDOWN_BYPASS_LOCAL",
+          "__format": "json"
+        },
+        "telegramGroups": {
+          "__name": "SCANNER_SCAN_ZONE_COOLDOWN_BYPASS_TELEGRAM_GROUPS",
+          "__format": "json"
+        }
       },
       "advancedScanZoneOptions": {
         "__name": "SCANNER_SCAN_ZONE_ADVANCED_SCAN_ZONE_OPTIONS",

--- a/config/default.json
+++ b/config/default.json
@@ -632,6 +632,11 @@
       "scanNextDevice": "Device01",
       "scanNextSleeptime": 5,
       "userCooldownSeconds": 0,
+      "cooldownBypass": {
+        "discordRoles": [],
+        "local": [],
+        "telegramGroups": []
+      },
       "scanNextAreaRestriction": [],
       "discordRoles": [],
       "local": [],
@@ -648,6 +653,11 @@
       "gmf": false,
       "scanZoneMaxSize": 10,
       "userCooldownSeconds": 0,
+      "cooldownBypass": {
+        "discordRoles": [],
+        "local": [],
+        "telegramGroups": []
+      },
       "advancedScanZoneOptions": false,
       "scanZoneRadius": {
         "pokemon": 70,

--- a/packages/types/lib/config.d.ts
+++ b/packages/types/lib/config.d.ts
@@ -136,11 +136,21 @@ export type Config<Client extends boolean = false> = DeepMerge<
         discordRoles: string[]
         telegramGroups: string[]
         local: string[]
+        cooldownBypass: {
+          discordRoles: string[]
+          telegramGroups: string[]
+          local: string[]
+        }
       }
       scanZone: {
         discordRoles: string[]
         telegramGroups: string[]
         local: string[]
+        cooldownBypass: {
+          discordRoles: string[]
+          telegramGroups: string[]
+          local: string[]
+        }
       }
     }
     icons: Icons

--- a/packages/types/lib/server.d.ts
+++ b/packages/types/lib/server.d.ts
@@ -150,6 +150,7 @@ type BasePerms = { [K in keyof Config['authentication']['perms']]: boolean }
 export interface Permissions extends BasePerms {
   blockedGuildNames: string[]
   scanner: string[]
+  scannerCooldownBypass: string[]
   areaRestrictions: string[]
   webhooks: string[]
   trial: boolean

--- a/server/src/routes/rootRouter.js
+++ b/server/src/routes/rootRouter.js
@@ -149,6 +149,7 @@ rootRouter.get('/api/settings', async (req, res, next) => {
             !scanner[key].discordRoles.length &&
             !scanner[key].telegramGroups.length,
         ),
+        scannerCooldownBypass: [],
       }
       authentication.alwaysEnabledPerms.forEach((perm) => {
         if (authentication.perms[perm]) {

--- a/server/src/services/LocalClient.js
+++ b/server/src/services/LocalClient.js
@@ -7,7 +7,7 @@ const config = require('@rm/config')
 
 const { areaPerms } = require('../utils/areaPerms')
 const { webhookPerms } = require('../utils/webhookPerms')
-const { scannerPerms } = require('../utils/scannerPerms')
+const { scannerPerms, scannerCooldownBypass } = require('../utils/scannerPerms')
 const { mergePerms } = require('../utils/mergePerms')
 const { AuthClient } = require('./AuthClient')
 const { state } = require('./state')
@@ -47,6 +47,7 @@ class LocalClient extends AuthClient {
         areaRestrictions: areaPerms(localPerms),
         webhooks: [],
         scanner: [],
+        scannerCooldownBypass: [],
       }),
       rmStrategy: this.rmStrategy,
     }
@@ -119,6 +120,9 @@ class LocalClient extends AuthClient {
               )
               scannerPerms([user.status], 'local', trialActive).forEach((x) =>
                 user.perms.scanner.push(x),
+              )
+              scannerCooldownBypass([user.status], 'local').forEach((x) =>
+                user.perms.scannerCooldownBypass.push(x),
               )
               this.log.info(
                 user.username,

--- a/server/src/services/TelegramClient.js
+++ b/server/src/services/TelegramClient.js
@@ -8,7 +8,7 @@ const config = require('@rm/config')
 const { state } = require('./state')
 const { areaPerms } = require('../utils/areaPerms')
 const { webhookPerms } = require('../utils/webhookPerms')
-const { scannerPerms } = require('../utils/scannerPerms')
+const { scannerPerms, scannerCooldownBypass } = require('../utils/scannerPerms')
 const { mergePerms } = require('../utils/mergePerms')
 const { AuthClient } = require('./AuthClient')
 
@@ -102,6 +102,7 @@ class TelegramClient extends AuthClient {
         areaRestrictions: areaPerms(groups),
         webhooks: webhookPerms(groups, 'telegramGroups', trialActive),
         scanner: scannerPerms(groups, 'telegramGroups', trialActive),
+        scannerCooldownBypass: scannerCooldownBypass(groups, 'telegramGroups'),
       },
     }
     if (newUserObj.perms.trial) {

--- a/server/src/utils/mergePerms.js
+++ b/server/src/utils/mergePerms.js
@@ -6,14 +6,24 @@
  * @param {import("@rm/types").Permissions} incomingPerms
  */
 function mergePerms(existingPerms, incomingPerms) {
+  const keys = new Set([
+    ...Object.keys(existingPerms),
+    ...Object.keys(incomingPerms),
+  ])
+
   return /** @type {import("@rm/types").Permissions} */ (
     Object.fromEntries(
-      Object.keys(existingPerms).map((key) => [
-        key,
-        Array.isArray(existingPerms[key])
-          ? [...new Set([...existingPerms[key], ...incomingPerms[key]])]
-          : existingPerms[key] || incomingPerms[key],
-      ]),
+      [...keys].map((key) => {
+        const existingValue = existingPerms[key]
+        const incomingValue = incomingPerms[key]
+
+        return [
+          key,
+          Array.isArray(existingValue) || Array.isArray(incomingValue)
+            ? [...new Set([...(existingValue || []), ...(incomingValue || [])])]
+            : existingValue || incomingValue,
+        ]
+      }),
     )
   )
 }

--- a/server/src/utils/scannerPerms.js
+++ b/server/src/utils/scannerPerms.js
@@ -28,4 +28,30 @@ function scannerPerms(roles, provider, trialActive = false) {
   return [...new Set(perms)]
 }
 
-module.exports = { scannerPerms }
+/**
+ * Determine which scanner modes should bypass the cooldown for a given role set.
+ *
+ * @param {string[]} roles
+ * @param {'discordRoles' | 'telegramGroups' | 'local'} provider
+ * @returns {string[]}
+ */
+function scannerCooldownBypass(roles, provider) {
+  const scanner = config.getSafe('scanner')
+
+  const bypass = []
+  roles.forEach((role) => {
+    Object.keys(scanner).forEach((mode) => {
+      const bypassRoles = scanner[mode]?.cooldownBypass?.[provider]
+      if (
+        scanner[mode]?.enabled &&
+        Array.isArray(bypassRoles) &&
+        bypassRoles.includes(role)
+      ) {
+        bypass.push(mode)
+      }
+    })
+  })
+  return [...new Set(bypass)]
+}
+
+module.exports = { scannerPerms, scannerCooldownBypass }


### PR DESCRIPTION
Fixes #947. I couldn't test this one either so summoning testers. @kamieniarz @nileplumb @prof-miles0 @Shyvadi 

```
Token usage: total=174,962 input=151,324 (+ 3,689,216 cached) output=23,638 (reasoning 14,912)
To continue this session, run codex resume 01997f21-2a4c-7cc0-b4e5-df3f069eb4fb.
```