### PR TITLE
fix(webhooks): normalize Poracle Pokemon payloads

### DIFF
--- a/src/features/webhooks/Manage.jsx
+++ b/src/features/webhooks/Manage.jsx
@@ -91,17 +91,16 @@ export function Manage() {
 
   React.useEffect(() => {
     if (!addNew.open && addNew.save && category !== 'human') {
-      const { tempFilters } = useWebhookStore.getState()
-      const values = Poracle.toLocalState(
-        category,
-        Object.values(tempFilters || {}).filter((x) => x && x.enabled),
-        useWebhookStore.getState().context.ui[category].defaults,
+      const {
+        tempFilters,
+        context: { ui },
+      } = useWebhookStore.getState()
+      const { defaults } = ui[category]
+      const enabledFilters = Object.values(tempFilters || {}).filter(
+        (x) => x && x.enabled,
       )
-      const payload = Poracle.toApiPayload(
-        category,
-        Object.values(tempFilters || {}).filter((x) => x && x.enabled),
-        useWebhookStore.getState().context.ui[category].defaults,
-      )
+      const values = Poracle.toLocalState(category, enabledFilters, defaults)
+      const payload = Poracle.toApiPayload(category, enabledFilters, defaults)
       apolloClient.mutate({
         // @ts-ignore
         mutation: Query.webhook(category.toUpperCase()),

--- a/src/features/webhooks/Manage.jsx
+++ b/src/features/webhooks/Manage.jsx
@@ -99,8 +99,13 @@ export function Manage() {
       const enabledFilters = Object.values(tempFilters || {}).filter(
         (x) => x && x.enabled,
       )
-      const values = Poracle.toLocalState(category, enabledFilters, defaults)
       const payload = Poracle.toApiPayload(category, enabledFilters, defaults)
+      const values = Poracle.toTrackedState(
+        category,
+        enabledFilters,
+        defaults,
+        payload,
+      )
       apolloClient.mutate({
         // @ts-ignore
         mutation: Query.webhook(category.toUpperCase()),

--- a/src/features/webhooks/Manage.jsx
+++ b/src/features/webhooks/Manage.jsx
@@ -97,12 +97,17 @@ export function Manage() {
         Object.values(tempFilters || {}).filter((x) => x && x.enabled),
         useWebhookStore.getState().context.ui[category].defaults,
       )
+      const payload = Poracle.toApiPayload(
+        category,
+        Object.values(tempFilters || {}).filter((x) => x && x.enabled),
+        useWebhookStore.getState().context.ui[category].defaults,
+      )
       apolloClient.mutate({
         // @ts-ignore
         mutation: Query.webhook(category.toUpperCase()),
         variables: {
           category,
-          data: values,
+          data: payload,
           status: 'POST',
         },
         refetchQueries: [ALL_PROFILES],

--- a/src/features/webhooks/Manage.jsx
+++ b/src/features/webhooks/Manage.jsx
@@ -92,7 +92,7 @@ export function Manage() {
   React.useEffect(() => {
     if (!addNew.open && addNew.save && category !== 'human') {
       const { tempFilters } = useWebhookStore.getState()
-      const values = Poracle.processor(
+      const values = Poracle.toLocalState(
         category,
         Object.values(tempFilters || {}).filter((x) => x && x.enabled),
         useWebhookStore.getState().context.ui[category].defaults,

--- a/src/features/webhooks/WebhookAdv.jsx
+++ b/src/features/webhooks/WebhookAdv.jsx
@@ -176,8 +176,8 @@ export function WebhookAdvanced() {
         ...prev,
         [low]: values[0],
         [high]: values[1],
-        pvpEntry: isPvp,
-        noIv: isPvp ? false : prev.noIv,
+        pvpEntry: isPvp ? !!prev.pvp_ranking_league : prev.pvpEntry,
+        noIv: isPvp && prev.pvp_ranking_league ? false : prev.noIv,
       }))
     },
     [],
@@ -244,12 +244,18 @@ export function WebhookAdvanced() {
   const handleSelect = (event) => {
     const { name, value } = event.target
     const newObj = { [name]: value }
+    const hasPvpLeague =
+      name === 'pvp_ranking_league'
+        ? !!value
+        : !!poracleValues.pvp_ranking_league
     if (name === 'pvp_ranking_league') {
       newObj.pvp_ranking_min_cp = pvp === 'ohbem' ? 0 : value - 50
     }
     if (name.startsWith('pvp')) {
-      newObj.pvpEntry = true
-      newObj.noIv = false
+      newObj.pvpEntry = hasPvpLeague
+      if (hasPvpLeague) {
+        newObj.noIv = false
+      }
     }
     if (name === 'move' && value !== 9000) {
       newObj.allMoves = false

--- a/src/features/webhooks/WebhookAdv.jsx
+++ b/src/features/webhooks/WebhookAdv.jsx
@@ -168,23 +168,38 @@ export function WebhookAdvanced() {
     }))
   }, [selectedIds])
 
+  const normalizePokemonPvpValues = React.useCallback(
+    (nextPoracleValues) =>
+      nextPoracleValues.pvpEntry
+        ? nextPoracleValues
+        : {
+            ...nextPoracleValues,
+            ...Poracle.getPokemonPvpDefaults(info?.defaults),
+          },
+    [info?.defaults],
+  )
+
   const handleSlider = React.useCallback(
     (low, high) => (name, values) => {
       const isPvp = name.startsWith('pvp')
-      setFilterValues((prev) => ({ ...prev, [name]: values }))
-      setPoracleValues((prev) => ({
-        ...prev,
+      const nextPoracleValues = normalizePokemonPvpValues({
+        ...poracleValues,
         [low]: values[0],
         [high]: values[1],
         pvpEntry: isPvp
-          ? !!prev.pvp_ranking_league
+          ? !!poracleValues.pvp_ranking_league
           : name === 'size'
-            ? prev.pvpEntry && !!prev.pvp_ranking_league
+            ? poracleValues.pvpEntry && !!poracleValues.pvp_ranking_league
             : false,
-        noIv: isPvp && prev.pvp_ranking_league ? false : prev.noIv,
-      }))
+        noIv:
+          isPvp && poracleValues.pvp_ranking_league
+            ? false
+            : poracleValues.noIv,
+      })
+      setFilterValues(Poracle.reactMapFriendly(nextPoracleValues))
+      setPoracleValues(nextPoracleValues)
     },
-    [],
+    [normalizePokemonPvpValues, poracleValues],
   )
 
   const handleSwitch = (event) => {
@@ -213,20 +228,23 @@ export function WebhookAdvanced() {
         })
         break
       case 'noIv':
-        setPoracleValues({
-          ...poracleValues,
-          [name]: checked,
-          pvpEntry: false,
-        })
+        {
+          const nextPoracleValues = normalizePokemonPvpValues({
+            ...poracleValues,
+            [name]: checked,
+            pvpEntry: false,
+          })
+          setPoracleValues(nextPoracleValues)
+          setFilterValues(Poracle.reactMapFriendly(nextPoracleValues))
+        }
         break
       case 'pvpEntry':
         {
-          const nextPoracleValues = {
+          const nextPoracleValues = normalizePokemonPvpValues({
             ...poracleValues,
-            ...(checked ? {} : Poracle.getPokemonPvpDefaults(info?.defaults)),
             [name]: checked,
             noIv: false,
-          }
+          })
           setPoracleValues(nextPoracleValues)
           setFilterValues(Poracle.reactMapFriendly(nextPoracleValues))
         }
@@ -272,7 +290,16 @@ export function WebhookAdvanced() {
     if (name === 'template') {
       newObj[name] = value?.toString() || ''
     }
-    setPoracleValues({ ...poracleValues, ...newObj })
+    {
+      const nextPoracleValues = normalizePokemonPvpValues({
+        ...poracleValues,
+        ...newObj,
+      })
+      setPoracleValues(nextPoracleValues)
+      if (name.startsWith('pvp')) {
+        setFilterValues(Poracle.reactMapFriendly(nextPoracleValues))
+      }
+    }
   }
 
   const handleChange = (panel) => (_, isExpanded) => {

--- a/src/features/webhooks/WebhookAdv.jsx
+++ b/src/features/webhooks/WebhookAdv.jsx
@@ -171,12 +171,13 @@ export function WebhookAdvanced() {
   const handleSlider = React.useCallback(
     (low, high) => (name, values) => {
       const isPvp = name.startsWith('pvp')
+      const keepsPvp = isPvp || name === 'size'
       setFilterValues((prev) => ({ ...prev, [name]: values }))
       setPoracleValues((prev) => ({
         ...prev,
         [low]: values[0],
         [high]: values[1],
-        pvpEntry: isPvp ? !!prev.pvp_ranking_league : false,
+        pvpEntry: keepsPvp ? !!prev.pvp_ranking_league : false,
         noIv: isPvp && prev.pvp_ranking_league ? false : prev.noIv,
       }))
     },

--- a/src/features/webhooks/WebhookAdv.jsx
+++ b/src/features/webhooks/WebhookAdv.jsx
@@ -40,7 +40,7 @@ const skipFields = new Set([
   'allForms',
   'pvpEntry',
   'noIv',
-  'omitIvBounds',
+  'omittedFields',
   'byDistance',
   'distance',
   'xs',

--- a/src/features/webhooks/WebhookAdv.jsx
+++ b/src/features/webhooks/WebhookAdv.jsx
@@ -170,12 +170,14 @@ export function WebhookAdvanced() {
 
   const handleSlider = React.useCallback(
     (low, high) => (name, values) => {
+      const isPvp = name.startsWith('pvp')
       setFilterValues((prev) => ({ ...prev, [name]: values }))
       setPoracleValues((prev) => ({
         ...prev,
         [low]: values[0],
         [high]: values[1],
-        pvpEntry: name.startsWith('pvp'),
+        pvpEntry: isPvp,
+        noIv: isPvp ? false : prev.noIv,
       }))
     },
     [],
@@ -247,6 +249,7 @@ export function WebhookAdvanced() {
     }
     if (name.startsWith('pvp')) {
       newObj.pvpEntry = true
+      newObj.noIv = false
     }
     if (name === 'move' && value !== 9000) {
       newObj.allMoves = false

--- a/src/features/webhooks/WebhookAdv.jsx
+++ b/src/features/webhooks/WebhookAdv.jsx
@@ -220,11 +220,16 @@ export function WebhookAdvanced() {
         })
         break
       case 'pvpEntry':
-        setPoracleValues({
-          ...poracleValues,
-          [name]: checked,
-          noIv: false,
-        })
+        {
+          const nextPoracleValues = {
+            ...poracleValues,
+            ...(checked ? {} : Poracle.getPokemonPvpDefaults(info?.defaults)),
+            [name]: checked,
+            noIv: false,
+          }
+          setPoracleValues(nextPoracleValues)
+          setFilterValues(Poracle.reactMapFriendly(nextPoracleValues))
+        }
         break
       case 'allMoves':
         setPoracleValues({

--- a/src/features/webhooks/WebhookAdv.jsx
+++ b/src/features/webhooks/WebhookAdv.jsx
@@ -168,38 +168,23 @@ export function WebhookAdvanced() {
     }))
   }, [selectedIds])
 
-  const normalizePokemonPvpValues = React.useCallback(
-    (nextPoracleValues) =>
-      nextPoracleValues.pvpEntry
-        ? nextPoracleValues
-        : {
-            ...nextPoracleValues,
-            ...Poracle.getPokemonPvpDefaults(info?.defaults),
-          },
-    [info?.defaults],
-  )
-
   const handleSlider = React.useCallback(
     (low, high) => (name, values) => {
       const isPvp = name.startsWith('pvp')
-      const nextPoracleValues = normalizePokemonPvpValues({
-        ...poracleValues,
+      setFilterValues((prev) => ({ ...prev, [name]: values }))
+      setPoracleValues((prev) => ({
+        ...prev,
         [low]: values[0],
         [high]: values[1],
         pvpEntry: isPvp
-          ? !!poracleValues.pvp_ranking_league
+          ? !!prev.pvp_ranking_league
           : name === 'size'
-            ? poracleValues.pvpEntry && !!poracleValues.pvp_ranking_league
+            ? prev.pvpEntry && !!prev.pvp_ranking_league
             : false,
-        noIv:
-          isPvp && poracleValues.pvp_ranking_league
-            ? false
-            : poracleValues.noIv,
-      })
-      setFilterValues(Poracle.reactMapFriendly(nextPoracleValues))
-      setPoracleValues(nextPoracleValues)
+        noIv: isPvp && prev.pvp_ranking_league ? false : prev.noIv,
+      }))
     },
-    [normalizePokemonPvpValues, poracleValues],
+    [],
   )
 
   const handleSwitch = (event) => {
@@ -228,26 +213,18 @@ export function WebhookAdvanced() {
         })
         break
       case 'noIv':
-        {
-          const nextPoracleValues = normalizePokemonPvpValues({
-            ...poracleValues,
-            [name]: checked,
-            pvpEntry: false,
-          })
-          setPoracleValues(nextPoracleValues)
-          setFilterValues(Poracle.reactMapFriendly(nextPoracleValues))
-        }
+        setPoracleValues({
+          ...poracleValues,
+          [name]: checked,
+          pvpEntry: false,
+        })
         break
       case 'pvpEntry':
-        {
-          const nextPoracleValues = normalizePokemonPvpValues({
-            ...poracleValues,
-            [name]: checked,
-            noIv: false,
-          })
-          setPoracleValues(nextPoracleValues)
-          setFilterValues(Poracle.reactMapFriendly(nextPoracleValues))
-        }
+        setPoracleValues({
+          ...poracleValues,
+          [name]: checked,
+          noIv: false,
+        })
         break
       case 'allMoves':
         setPoracleValues({
@@ -290,16 +267,7 @@ export function WebhookAdvanced() {
     if (name === 'template') {
       newObj[name] = value?.toString() || ''
     }
-    {
-      const nextPoracleValues = normalizePokemonPvpValues({
-        ...poracleValues,
-        ...newObj,
-      })
-      setPoracleValues(nextPoracleValues)
-      if (name.startsWith('pvp')) {
-        setFilterValues(Poracle.reactMapFriendly(nextPoracleValues))
-      }
-    }
+    setPoracleValues({ ...poracleValues, ...newObj })
   }
 
   const handleChange = (panel) => (_, isExpanded) => {

--- a/src/features/webhooks/WebhookAdv.jsx
+++ b/src/features/webhooks/WebhookAdv.jsx
@@ -171,13 +171,16 @@ export function WebhookAdvanced() {
   const handleSlider = React.useCallback(
     (low, high) => (name, values) => {
       const isPvp = name.startsWith('pvp')
-      const keepsPvp = isPvp || name === 'size'
       setFilterValues((prev) => ({ ...prev, [name]: values }))
       setPoracleValues((prev) => ({
         ...prev,
         [low]: values[0],
         [high]: values[1],
-        pvpEntry: keepsPvp ? !!prev.pvp_ranking_league : false,
+        pvpEntry: isPvp
+          ? !!prev.pvp_ranking_league
+          : name === 'size'
+            ? prev.pvpEntry && !!prev.pvp_ranking_league
+            : false,
         noIv: isPvp && prev.pvp_ranking_league ? false : prev.noIv,
       }))
     },

--- a/src/features/webhooks/WebhookAdv.jsx
+++ b/src/features/webhooks/WebhookAdv.jsx
@@ -40,6 +40,7 @@ const skipFields = new Set([
   'allForms',
   'pvpEntry',
   'noIv',
+  'omitIvBounds',
   'byDistance',
   'distance',
   'xs',

--- a/src/features/webhooks/WebhookAdv.jsx
+++ b/src/features/webhooks/WebhookAdv.jsx
@@ -176,7 +176,7 @@ export function WebhookAdvanced() {
         ...prev,
         [low]: values[0],
         [high]: values[1],
-        pvpEntry: isPvp ? !!prev.pvp_ranking_league : prev.pvpEntry,
+        pvpEntry: isPvp ? !!prev.pvp_ranking_league : false,
         noIv: isPvp && prev.pvp_ranking_league ? false : prev.noIv,
       }))
     },

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -406,104 +406,14 @@ export class Poracle {
   }
 
   static toApiPayload(category, entries, defaults) {
-    const processed = Poracle.toLocalState(category, entries, defaults)
+    const processed = Poracle.toUpdatePayload(category, entries, defaults)
     if (category !== 'pokemon') {
       return processed
     }
 
-    const requiredFields = ['pokemon_id', 'form', 'profile_no', 'template']
-    const scalarFields = ['clean', 'distance', 'gender', 'min_time']
-    const rangeGroups = [
-      ['min_cp', 'max_cp'],
-      ['min_level', 'max_level'],
-      ['atk', 'max_atk'],
-      ['def', 'max_def'],
-      ['sta', 'max_sta'],
-      ['rarity', 'max_rarity'],
-      ['size', 'max_size'],
-      ['min_weight', 'max_weight'],
-    ]
-    const pvpFields = [
-      'pvp_ranking_league',
-      'pvp_ranking_best',
-      'pvp_ranking_worst',
-      'pvp_ranking_min_cp',
-      'pvp_ranking_cap',
-    ]
-
     return processed.map((pokemon) => {
-      const payload = {}
-
-      requiredFields.forEach((field) => {
-        if (pokemon[field] !== undefined) {
-          payload[field] = pokemon[field]
-        }
-      })
-
-      if (pokemon.ping) {
-        payload.ping = pokemon.ping
-      }
-
-      if (pokemon.noIv) {
-        scalarFields.forEach((field) => {
-          if (
-            pokemon[field] !== undefined &&
-            pokemon[field] !== defaults[field]
-          ) {
-            payload[field] = pokemon[field]
-          }
-        })
-        rangeGroups.forEach(([low, high]) => {
-          if (
-            pokemon[low] !== undefined &&
-            pokemon[high] !== undefined &&
-            (pokemon[low] !== defaults[low] || pokemon[high] !== defaults[high])
-          ) {
-            payload[low] = pokemon[low]
-            payload[high] = pokemon[high]
-          }
-        })
-        payload.min_iv = pokemon.min_iv ?? defaults.min_iv
-        payload.max_iv = pokemon.max_iv ?? defaults.max_iv
-        return payload
-      }
-
-      scalarFields.forEach((field) => {
-        if (
-          pokemon[field] !== undefined &&
-          pokemon[field] !== defaults[field]
-        ) {
-          payload[field] = pokemon[field]
-        }
-      })
-
-      if (
-        pokemon.min_iv !== defaults.min_iv ||
-        pokemon.max_iv !== defaults.max_iv
-      ) {
-        payload.min_iv = pokemon.min_iv
-        payload.max_iv = pokemon.max_iv
-      }
-
-      rangeGroups.forEach(([low, high]) => {
-        if (
-          pokemon[low] !== undefined &&
-          pokemon[high] !== undefined &&
-          (pokemon[low] !== defaults[low] || pokemon[high] !== defaults[high])
-        ) {
-          payload[low] = pokemon[low]
-          payload[high] = pokemon[high]
-        }
-      })
-
-      if (pokemon.pvpEntry && pokemon.pvp_ranking_league) {
-        pvpFields.forEach((field) => {
-          if (pokemon[field] !== undefined) {
-            payload[field] = pokemon[field]
-          }
-        })
-      }
-
+      const payload = { ...pokemon }
+      delete payload.uid
       return payload
     })
   }

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -337,14 +337,70 @@ export class Poracle {
       return processed
     }
 
+    const requiredFields = [
+      'uid',
+      'pokemon_id',
+      'form',
+      'profile_no',
+      'template',
+    ]
+    const scalarFields = ['clean', 'distance', 'gender', 'min_time']
+    const rangeGroups = [
+      ['min_cp', 'max_cp'],
+      ['min_level', 'max_level'],
+      ['atk', 'max_atk'],
+      ['def', 'max_def'],
+      ['sta', 'max_sta'],
+      ['rarity', 'max_rarity'],
+      ['size', 'max_size'],
+      ['min_weight', 'max_weight'],
+    ]
+    const pvpFields = [
+      'pvp_ranking_league',
+      'pvp_ranking_best',
+      'pvp_ranking_worst',
+      'pvp_ranking_min_cp',
+      'pvp_ranking_cap',
+    ]
+
     return processed.map((pokemon) => {
-      const payload = { ...pokemon }
-      delete payload.allForms
-      delete payload.byDistance
-      delete payload.noIv
-      delete payload.pvpEntry
-      delete payload.xs
-      delete payload.xl
+      const payload = {}
+
+      requiredFields.forEach((field) => {
+        if (pokemon[field] !== undefined) {
+          payload[field] = pokemon[field]
+        }
+      })
+
+      if (pokemon.ping !== undefined) {
+        payload.ping = pokemon.ping
+      }
+
+      scalarFields.forEach((field) => {
+        payload[field] =
+          pokemon[field] === undefined ? defaults[field] : pokemon[field]
+      })
+
+      payload.min_iv =
+        pokemon.min_iv === undefined ? defaults.min_iv : pokemon.min_iv
+      payload.max_iv =
+        pokemon.max_iv === undefined ? defaults.max_iv : pokemon.max_iv
+
+      rangeGroups.forEach(([low, high]) => {
+        payload[low] = pokemon[low] === undefined ? defaults[low] : pokemon[low]
+        payload[high] =
+          pokemon[high] === undefined ? defaults[high] : pokemon[high]
+      })
+
+      pvpFields.forEach((field) => {
+        payload[field] =
+          pokemon.pvpEntry && pokemon.pvp_ranking_league
+            ? pokemon[field] === undefined
+              ? defaults[field]
+              : pokemon[field]
+            : defaults[field]
+      })
+
       return payload
     })
   }

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -329,7 +329,7 @@ export class Poracle {
   }
 
   static toApiPayload(category, entries, defaults) {
-    const processed = Poracle.processor(category, entries, defaults)
+    const processed = Poracle.toLocalState(category, entries, defaults)
     if (category !== 'pokemon') {
       return processed
     }
@@ -362,6 +362,10 @@ export class Poracle {
           payload[field] = pokemon[field]
         }
       })
+
+      if (pokemon.ping) {
+        payload.ping = pokemon.ping
+      }
 
       if (pokemon.noIv) {
         scalarFields.forEach((field) => {

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -36,6 +36,16 @@ const POKEMON_RANGE_GROUPS = [
   ['min_weight', 'max_weight'],
 ]
 
+const POKEMON_OMITTABLE_FIELDS = [
+  ...new Set([
+    ...POKEMON_SCALAR_FIELDS,
+    'min_iv',
+    'max_iv',
+    ...POKEMON_RANGE_GROUPS.flat(),
+    ...POKEMON_PVP_FIELDS,
+  ]),
+]
+
 export class Poracle {
   static getMapCategory(poracleCategory) {
     switch (poracleCategory) {
@@ -210,11 +220,51 @@ export class Poracle {
     return reactMapFriendly
   }
 
+  static getPokemonOmittedFields(pokemon) {
+    if (!pokemon) return {}
+
+    const omittedFields = { ...(pokemon?.omittedFields || {}) }
+
+    POKEMON_OMITTABLE_FIELDS.forEach((field) => {
+      if (pokemon?.[field] == null) {
+        omittedFields[field] = true
+      }
+    })
+
+    return omittedFields
+  }
+
+  static getPokemonFieldValue(pokemon, defaults, field) {
+    return pokemon[field] == null ? defaults[field] : pokemon[field]
+  }
+
+  static shouldOmitPokemonField(pokemon, defaults, omittedFields, field) {
+    return (
+      omittedFields[field] &&
+      Poracle.getPokemonFieldValue(pokemon, defaults, field) === defaults[field]
+    )
+  }
+
+  static toTrackedState(category, entries, defaults, payload = []) {
+    if (category !== 'pokemon') {
+      return Poracle.toLocalState(category, entries, defaults)
+    }
+
+    return Poracle.toLocalState(
+      category,
+      entries.map((pokemon, index) => ({
+        ...pokemon,
+        omittedFields: Poracle.getPokemonOmittedFields(payload[index]),
+      })),
+      defaults,
+    )
+  }
+
   static processPokemon(entries, defaults, includeUiState = false) {
     const ignoredFields = [
       'noIv',
       'byDistance',
-      'omitIvBounds',
+      'omittedFields',
       'xs',
       'xl',
       'allForms',
@@ -227,6 +277,7 @@ export class Poracle {
         const normalized = pokemon.allForms
           ? { ...pokemon, form: defaults.form }
           : pokemon
+        const omittedFields = Poracle.getPokemonOmittedFields(normalized)
         const fields = [
           'uid',
           'pokemon_id',
@@ -265,15 +316,18 @@ export class Poracle {
         }
 
         new Set(fields).forEach((field) => {
-          newPokemon[field] =
-            normalized[field] == null ? defaults[field] : normalized[field]
+          newPokemon[field] = Poracle.getPokemonFieldValue(
+            normalized,
+            defaults,
+            field,
+          )
         })
 
         if (includeUiState) {
           newPokemon.allForms = !!pokemon.allForms
           newPokemon.byDistance = !!pokemon.byDistance
           newPokemon.noIv = !!pokemon.noIv
-          newPokemon.omitIvBounds = !!pokemon.omitIvBounds
+          newPokemon.omittedFields = omittedFields
           newPokemon.pvpEntry = !!pokemon.pvpEntry
           newPokemon.xs = !!pokemon.xs
           newPokemon.xl = !!pokemon.xl
@@ -367,12 +421,7 @@ export class Poracle {
 
     return processed.map((pokemon) => {
       const payload = {}
-      const omitIvBounds =
-        pokemon.omitIvBounds &&
-        !pokemon.noIv &&
-        !pokemon.pvpEntry &&
-        pokemon.min_iv === defaults.min_iv &&
-        pokemon.max_iv === defaults.max_iv
+      const omittedFields = Poracle.getPokemonOmittedFields(pokemon)
 
       POKEMON_UPDATE_REQUIRED_FIELDS.forEach((field) => {
         if (pokemon[field] !== undefined) {
@@ -385,31 +434,80 @@ export class Poracle {
       }
 
       POKEMON_SCALAR_FIELDS.forEach((field) => {
-        payload[field] =
-          pokemon[field] === undefined ? defaults[field] : pokemon[field]
+        const value = Poracle.getPokemonFieldValue(pokemon, defaults, field)
+        if (
+          !Poracle.shouldOmitPokemonField(
+            pokemon,
+            defaults,
+            omittedFields,
+            field,
+          )
+        ) {
+          payload[field] = value
+        }
       })
 
-      if (!omitIvBounds) {
-        payload.min_iv =
-          pokemon.min_iv === undefined ? defaults.min_iv : pokemon.min_iv
-        payload.max_iv =
-          pokemon.max_iv === undefined ? defaults.max_iv : pokemon.max_iv
+      if (
+        pokemon.noIv ||
+        !['min_iv', 'max_iv'].every((field) =>
+          Poracle.shouldOmitPokemonField(
+            pokemon,
+            defaults,
+            omittedFields,
+            field,
+          ),
+        )
+      ) {
+        payload.min_iv = Poracle.getPokemonFieldValue(
+          pokemon,
+          defaults,
+          'min_iv',
+        )
+        payload.max_iv = Poracle.getPokemonFieldValue(
+          pokemon,
+          defaults,
+          'max_iv',
+        )
       }
 
       POKEMON_RANGE_GROUPS.forEach(([low, high]) => {
-        payload[low] = pokemon[low] === undefined ? defaults[low] : pokemon[low]
-        payload[high] =
-          pokemon[high] === undefined ? defaults[high] : pokemon[high]
+        if (
+          ![low, high].every((field) =>
+            Poracle.shouldOmitPokemonField(
+              pokemon,
+              defaults,
+              omittedFields,
+              field,
+            ),
+          )
+        ) {
+          payload[low] = Poracle.getPokemonFieldValue(pokemon, defaults, low)
+          payload[high] = Poracle.getPokemonFieldValue(pokemon, defaults, high)
+        }
       })
 
-      POKEMON_PVP_FIELDS.forEach((field) => {
-        payload[field] =
-          pokemon.pvpEntry && pokemon.pvp_ranking_league
-            ? pokemon[field] === undefined
-              ? defaults[field]
-              : pokemon[field]
-            : defaults[field]
-      })
+      if (pokemon.pvpEntry && pokemon.pvp_ranking_league) {
+        POKEMON_PVP_FIELDS.forEach((field) => {
+          payload[field] = Poracle.getPokemonFieldValue(
+            pokemon,
+            defaults,
+            field,
+          )
+        })
+      } else if (
+        !POKEMON_PVP_FIELDS.every((field) =>
+          Poracle.shouldOmitPokemonField(
+            pokemon,
+            defaults,
+            omittedFields,
+            field,
+          ),
+        )
+      ) {
+        POKEMON_PVP_FIELDS.forEach((field) => {
+          payload[field] = defaults[field]
+        })
+      }
 
       return payload
     })

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -177,7 +177,7 @@ export class Poracle {
     return reactMapFriendly
   }
 
-  static processor(category, entries, defaults) {
+  static processPokemon(entries, defaults, includeUiState = false) {
     const pvpFields = [
       'pvp_ranking_league',
       'pvp_ranking_best',
@@ -193,6 +193,70 @@ export class Poracle {
       'allForms',
       'pvpEntry',
     ]
+    const dupes = {}
+
+    return entries
+      .map((pokemon) => {
+        const normalized = pokemon.allForms
+          ? { ...pokemon, form: defaults.form }
+          : pokemon
+        const fields = [
+          'uid',
+          'pokemon_id',
+          'form',
+          'clean',
+          'distance',
+          'min_time',
+          'template',
+          'profile_no',
+          'ping',
+          'gender',
+          'rarity',
+          'max_rarity',
+          'size',
+          'max_size',
+        ]
+        const newPokemon = {}
+
+        if (pokemon.allForms) {
+          if (dupes[pokemon.pokemon_id]) {
+            return null
+          }
+          dupes[pokemon.pokemon_id] = true
+        }
+
+        if (pokemon.pvpEntry) {
+          fields.push(...pvpFields)
+        } else {
+          fields.push(
+            ...Object.keys(normalized).filter(
+              (key) => !pvpFields.includes(key) && !ignoredFields.includes(key),
+            ),
+          )
+        }
+
+        new Set(fields).forEach((field) => {
+          newPokemon[field] =
+            normalized[field] === undefined
+              ? defaults[field]
+              : normalized[field]
+        })
+
+        if (includeUiState) {
+          newPokemon.allForms = !!pokemon.allForms
+          newPokemon.byDistance = !!pokemon.byDistance
+          newPokemon.noIv = !!pokemon.noIv
+          newPokemon.pvpEntry = !!pokemon.pvpEntry
+          newPokemon.xs = !!pokemon.xs
+          newPokemon.xl = !!pokemon.xl
+        }
+
+        return newPokemon
+      })
+      .filter((pokemon) => pokemon)
+  }
+
+  static processor(category, entries, defaults) {
     const dupes = {}
     switch (category) {
       case 'egg':
@@ -255,78 +319,34 @@ export class Poracle {
           })
           .filter((quest) => quest)
       default:
-        return entries
-          .map((pkmn) => {
-            const fields = [
-              'uid',
-              'pokemon_id',
-              'form',
-              'clean',
-              'distance',
-              'min_time',
-              'template',
-              'profile_no',
-              'ping',
-              'gender',
-              'rarity',
-              'max_rarity',
-              'size',
-              'max_size',
-            ]
-            const newPokemon = {}
-            if (pkmn.allForms) {
-              pkmn.form = 0
-              if (dupes[pkmn.pokemon_id]) {
-                return null
-              }
-              dupes[pkmn.pokemon_id] = true
-            }
-            if (pkmn.pvpEntry) {
-              fields.push(...pvpFields)
-            } else {
-              fields.push(
-                ...Object.keys(pkmn).filter(
-                  (key) =>
-                    !pvpFields.includes(key) && !ignoredFields.includes(key),
-                ),
-              )
-            }
-            new Set(fields).forEach(
-              (field) =>
-                (newPokemon[field] =
-                  pkmn[field] === undefined ? defaults[field] : pkmn[field]),
-            )
-            return newPokemon
-          })
-          .filter((pokemon) => pokemon)
+        return Poracle.processPokemon(entries, defaults)
     }
   }
 
   static toLocalState(category, entries, defaults) {
-    const processed = Poracle.processor(category, entries, defaults)
+    if (category !== 'pokemon') {
+      return Poracle.processor(category, entries, defaults)
+    }
+
+    return Poracle.processPokemon(entries, defaults, true)
+  }
+
+  static toUpdatePayload(category, entries, defaults) {
+    const processed = Poracle.toLocalState(category, entries, defaults)
     if (category !== 'pokemon') {
       return processed
     }
 
-    const uiState = new Map()
-    entries.forEach((pokemon) => {
-      const key = `${pokemon.pokemon_id}-${pokemon.form}`
-      if (!uiState.has(key)) {
-        uiState.set(key, {
-          allForms: !!pokemon.allForms,
-          byDistance: !!pokemon.byDistance,
-          noIv: !!pokemon.noIv,
-          pvpEntry: !!pokemon.pvpEntry,
-          xs: !!pokemon.xs,
-          xl: !!pokemon.xl,
-        })
-      }
+    return processed.map((pokemon) => {
+      const payload = { ...pokemon }
+      delete payload.allForms
+      delete payload.byDistance
+      delete payload.noIv
+      delete payload.pvpEntry
+      delete payload.xs
+      delete payload.xl
+      return payload
     })
-
-    return processed.map((pokemon) => ({
-      ...pokemon,
-      ...uiState.get(`${pokemon.pokemon_id}-${pokemon.form}`),
-    }))
   }
 
   static toApiPayload(category, entries, defaults) {

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -296,16 +296,36 @@ export class Poracle {
                 (newPokemon[field] =
                   pkmn[field] === undefined ? defaults[field] : pkmn[field]),
             )
-            newPokemon.allForms = !!pkmn.allForms
-            newPokemon.byDistance = !!pkmn.byDistance
-            newPokemon.noIv = !!pkmn.noIv
-            newPokemon.pvpEntry = !!pkmn.pvpEntry
-            newPokemon.xs = !!pkmn.xs
-            newPokemon.xl = !!pkmn.xl
             return newPokemon
           })
           .filter((pokemon) => pokemon)
     }
+  }
+
+  static toLocalState(category, entries, defaults) {
+    const processed = Poracle.processor(category, entries, defaults)
+    if (category !== 'pokemon') {
+      return processed
+    }
+
+    const uiState = new Map(
+      entries.map((pokemon) => [
+        `${pokemon.pokemon_id}-${pokemon.form}`,
+        {
+          allForms: !!pokemon.allForms,
+          byDistance: !!pokemon.byDistance,
+          noIv: !!pokemon.noIv,
+          pvpEntry: !!pokemon.pvpEntry,
+          xs: !!pokemon.xs,
+          xl: !!pokemon.xl,
+        },
+      ]),
+    )
+
+    return processed.map((pokemon) => ({
+      ...pokemon,
+      ...uiState.get(`${pokemon.pokemon_id}-${pokemon.form}`),
+    }))
   }
 
   static toApiPayload(category, entries, defaults) {

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -307,19 +307,13 @@ export class Poracle {
     }
   }
 
-  static toApiPayload(category, entries, defaults) {
+  static toApiPayload(category, entries, defaults, options = {}) {
     const processed = Poracle.processor(category, entries, defaults)
     if (category !== 'pokemon') {
       return processed
     }
 
-    const requiredFields = [
-      'uid',
-      'pokemon_id',
-      'form',
-      'profile_no',
-      'template',
-    ]
+    const requiredFields = ['pokemon_id', 'form', 'profile_no', 'template']
     const scalarFields = ['clean', 'distance', 'gender', 'min_time']
     const rangeGroups = [
       ['min_cp', 'max_cp'],
@@ -341,6 +335,10 @@ export class Poracle {
 
     return processed.map((pokemon) => {
       const payload = {}
+
+      if (options.includeUid && pokemon.uid !== undefined) {
+        payload.uid = pokemon.uid
+      }
 
       requiredFields.forEach((field) => {
         if (pokemon[field] !== undefined) {

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -430,7 +430,7 @@ export class Poracle {
 
     return processed.map((pokemon) => {
       const payload = {}
-      const omittedFields = Poracle.getPokemonOmittedFields(pokemon)
+      const omittedFields = { ...(pokemon.omittedFields || {}) }
 
       POKEMON_UPDATE_REQUIRED_FIELDS.forEach((field) => {
         if (pokemon[field] !== undefined) {

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -308,19 +308,20 @@ export class Poracle {
       return processed
     }
 
-    const uiState = new Map(
-      entries.map((pokemon) => [
-        `${pokemon.pokemon_id}-${pokemon.form}`,
-        {
+    const uiState = new Map()
+    entries.forEach((pokemon) => {
+      const key = `${pokemon.pokemon_id}-${pokemon.form}`
+      if (!uiState.has(key)) {
+        uiState.set(key, {
           allForms: !!pokemon.allForms,
           byDistance: !!pokemon.byDistance,
           noIv: !!pokemon.noIv,
           pvpEntry: !!pokemon.pvpEntry,
           xs: !!pokemon.xs,
           xl: !!pokemon.xl,
-        },
-      ]),
-    )
+        })
+      }
+    })
 
     return processed.map((pokemon) => ({
       ...pokemon,

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -214,6 +214,7 @@ export class Poracle {
     const ignoredFields = [
       'noIv',
       'byDistance',
+      'omitIvBounds',
       'xs',
       'xl',
       'allForms',
@@ -274,6 +275,7 @@ export class Poracle {
           newPokemon.allForms = !!pokemon.allForms
           newPokemon.byDistance = !!pokemon.byDistance
           newPokemon.noIv = !!pokemon.noIv
+          newPokemon.omitIvBounds = !!pokemon.omitIvBounds
           newPokemon.pvpEntry = !!pokemon.pvpEntry
           newPokemon.xs = !!pokemon.xs
           newPokemon.xl = !!pokemon.xl
@@ -367,6 +369,12 @@ export class Poracle {
 
     return processed.map((pokemon) => {
       const payload = {}
+      const omitIvBounds =
+        pokemon.omitIvBounds &&
+        !pokemon.noIv &&
+        !pokemon.pvpEntry &&
+        pokemon.min_iv === defaults.min_iv &&
+        pokemon.max_iv === defaults.max_iv
 
       POKEMON_UPDATE_REQUIRED_FIELDS.forEach((field) => {
         if (pokemon[field] !== undefined) {
@@ -383,10 +391,12 @@ export class Poracle {
           pokemon[field] === undefined ? defaults[field] : pokemon[field]
       })
 
-      payload.min_iv =
-        pokemon.min_iv === undefined ? defaults.min_iv : pokemon.min_iv
-      payload.max_iv =
-        pokemon.max_iv === undefined ? defaults.max_iv : pokemon.max_iv
+      if (!omitIvBounds) {
+        payload.min_iv =
+          pokemon.min_iv === undefined ? defaults.min_iv : pokemon.min_iv
+        payload.max_iv =
+          pokemon.max_iv === undefined ? defaults.max_iv : pokemon.max_iv
+      }
 
       POKEMON_RANGE_GROUPS.forEach(([low, high]) => {
         payload[low] = pokemon[low] === undefined ? defaults[low] : pokemon[low]

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -305,6 +305,15 @@ export class Poracle {
 
         if (pokemon.pvpEntry) {
           fields.push(...POKEMON_PVP_FIELDS)
+          if (includeUiState) {
+            fields.push(
+              ...Object.keys(defaults).filter(
+                (key) =>
+                  !POKEMON_PVP_FIELDS.includes(key) &&
+                  !ignoredFields.includes(key),
+              ),
+            )
+          }
         } else {
           fields.push(
             ...Object.keys(normalized).filter(

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -461,6 +461,13 @@ export class Poracle {
         }
       })
 
+      if (payload.min_weight === undefined) {
+        payload.min_weight = defaults.min_weight
+      }
+      if (payload.max_weight === undefined) {
+        payload.max_weight = defaults.max_weight
+      }
+
       if (pokemon.noIv) {
         return payload
       }

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -52,6 +52,12 @@ const POKEMON_OMITTABLE_FIELDS = [
 ]
 
 export class Poracle {
+  static getPokemonPvpDefaults(defaults = {}) {
+    return Object.fromEntries(
+      POKEMON_PVP_FIELDS.map((field) => [field, defaults[field]]),
+    )
+  }
+
   static getMapCategory(poracleCategory) {
     switch (poracleCategory) {
       case 'gym':

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -3,6 +3,14 @@ import { t } from 'i18next'
 
 import { useWebhookStore } from '@store/useWebhookStore'
 
+const POKEMON_PVP_FIELDS = [
+  'pvp_ranking_league',
+  'pvp_ranking_best',
+  'pvp_ranking_worst',
+  'pvp_ranking_min_cp',
+  'pvp_ranking_cap',
+]
+
 export class Poracle {
   static getMapCategory(poracleCategory) {
     switch (poracleCategory) {
@@ -178,13 +186,6 @@ export class Poracle {
   }
 
   static processPokemon(entries, defaults, includeUiState = false) {
-    const pvpFields = [
-      'pvp_ranking_league',
-      'pvp_ranking_best',
-      'pvp_ranking_worst',
-      'pvp_ranking_min_cp',
-      'pvp_ranking_cap',
-    ]
     const ignoredFields = [
       'noIv',
       'byDistance',
@@ -226,11 +227,13 @@ export class Poracle {
         }
 
         if (pokemon.pvpEntry) {
-          fields.push(...pvpFields)
+          fields.push(...POKEMON_PVP_FIELDS)
         } else {
           fields.push(
             ...Object.keys(normalized).filter(
-              (key) => !pvpFields.includes(key) && !ignoredFields.includes(key),
+              (key) =>
+                !POKEMON_PVP_FIELDS.includes(key) &&
+                !ignoredFields.includes(key),
             ),
           )
         }
@@ -355,14 +358,6 @@ export class Poracle {
       ['size', 'max_size'],
       ['min_weight', 'max_weight'],
     ]
-    const pvpFields = [
-      'pvp_ranking_league',
-      'pvp_ranking_best',
-      'pvp_ranking_worst',
-      'pvp_ranking_min_cp',
-      'pvp_ranking_cap',
-    ]
-
     return processed.map((pokemon) => {
       const payload = {}
 
@@ -392,7 +387,7 @@ export class Poracle {
           pokemon[high] === undefined ? defaults[high] : pokemon[high]
       })
 
-      pvpFields.forEach((field) => {
+      POKEMON_PVP_FIELDS.forEach((field) => {
         payload[field] =
           pokemon.pvpEntry && pokemon.pvp_ranking_league
             ? pokemon[field] === undefined

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -355,6 +355,16 @@ export class Poracle {
             payload[field] = pokemon[field]
           }
         })
+        rangeGroups.forEach(([low, high]) => {
+          if (
+            pokemon[low] !== undefined &&
+            pokemon[high] !== undefined &&
+            (pokemon[low] !== defaults[low] || pokemon[high] !== defaults[high])
+          ) {
+            payload[low] = pokemon[low]
+            payload[high] = pokemon[high]
+          }
+        })
         payload.min_iv = pokemon.min_iv ?? defaults.min_iv
         payload.max_iv = pokemon.max_iv ?? defaults.max_iv
         return payload

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -294,10 +294,105 @@ export class Poracle {
                 (newPokemon[field] =
                   pkmn[field] === undefined ? defaults[field] : pkmn[field]),
             )
+            newPokemon.allForms = !!pkmn.allForms
+            newPokemon.byDistance = !!pkmn.byDistance
+            newPokemon.noIv = !!pkmn.noIv
+            newPokemon.pvpEntry = !!pkmn.pvpEntry
+            newPokemon.xs = !!pkmn.xs
+            newPokemon.xl = !!pkmn.xl
             return newPokemon
           })
           .filter((pokemon) => pokemon)
     }
+  }
+
+  static toApiPayload(category, entries, defaults) {
+    const processed = Poracle.processor(category, entries, defaults)
+    if (category !== 'pokemon') {
+      return processed
+    }
+
+    const requiredFields = ['pokemon_id', 'form', 'profile_no', 'template']
+    const scalarFields = ['clean', 'distance', 'gender', 'min_time']
+    const rangeGroups = [
+      ['min_cp', 'max_cp'],
+      ['min_level', 'max_level'],
+      ['atk', 'max_atk'],
+      ['def', 'max_def'],
+      ['sta', 'max_sta'],
+      ['rarity', 'max_rarity'],
+      ['size', 'max_size'],
+      ['min_weight', 'max_weight'],
+    ]
+    const pvpFields = [
+      'pvp_ranking_league',
+      'pvp_ranking_best',
+      'pvp_ranking_worst',
+      'pvp_ranking_min_cp',
+      'pvp_ranking_cap',
+    ]
+
+    return processed.map((pokemon) => {
+      const payload = {}
+
+      requiredFields.forEach((field) => {
+        if (pokemon[field] !== undefined) {
+          payload[field] = pokemon[field]
+        }
+      })
+
+      if (pokemon.noIv) {
+        ;['clean', 'distance', 'gender'].forEach((field) => {
+          if (
+            pokemon[field] !== undefined &&
+            pokemon[field] !== defaults[field]
+          ) {
+            payload[field] = pokemon[field]
+          }
+        })
+        payload.min_iv = pokemon.min_iv ?? defaults.min_iv
+        payload.max_iv = pokemon.max_iv ?? defaults.max_iv
+        return payload
+      }
+
+      scalarFields.forEach((field) => {
+        if (
+          pokemon[field] !== undefined &&
+          pokemon[field] !== defaults[field]
+        ) {
+          payload[field] = pokemon[field]
+        }
+      })
+
+      if (
+        pokemon.min_iv !== defaults.min_iv ||
+        pokemon.max_iv !== defaults.max_iv
+      ) {
+        payload.min_iv = pokemon.min_iv
+        payload.max_iv = pokemon.max_iv
+      }
+
+      rangeGroups.forEach(([low, high]) => {
+        if (
+          pokemon[low] !== undefined &&
+          pokemon[high] !== undefined &&
+          (pokemon[low] !== defaults[low] || pokemon[high] !== defaults[high])
+        ) {
+          payload[low] = pokemon[low]
+          payload[high] = pokemon[high]
+        }
+      })
+
+      if (pokemon.pvpEntry && pokemon.pvp_ranking_league) {
+        pvpFields.forEach((field) => {
+          if (pokemon[field] !== undefined) {
+            payload[field] = pokemon[field]
+          }
+        })
+      }
+
+      return payload
+    })
   }
 
   /**

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -325,6 +325,9 @@ export class Poracle {
                 !ignoredFields.includes(key),
             ),
           )
+          if (includeUiState) {
+            fields.push(...POKEMON_PVP_FIELDS)
+          }
         }
 
         new Set(fields).forEach((field) => {

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -266,6 +266,7 @@ export class Poracle {
               'min_time',
               'template',
               'profile_no',
+              'ping',
               'gender',
               'rarity',
               'max_rarity',
@@ -307,7 +308,7 @@ export class Poracle {
     }
   }
 
-  static toApiPayload(category, entries, defaults, options = {}) {
+  static toApiPayload(category, entries, defaults) {
     const processed = Poracle.processor(category, entries, defaults)
     if (category !== 'pokemon') {
       return processed
@@ -335,10 +336,6 @@ export class Poracle {
 
     return processed.map((pokemon) => {
       const payload = {}
-
-      if (options.includeUid && pokemon.uid !== undefined) {
-        payload.uid = pokemon.uid
-      }
 
       requiredFields.forEach((field) => {
         if (pokemon[field] !== undefined) {

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -36,6 +36,11 @@ const POKEMON_RANGE_GROUPS = [
   ['min_weight', 'max_weight'],
 ]
 
+const POKEMON_PVP_RANGE_GROUPS = [
+  ['rarity', 'max_rarity'],
+  ['size', 'max_size'],
+]
+
 const POKEMON_OMITTABLE_FIELDS = [
   ...new Set([
     ...POKEMON_SCALAR_FIELDS,
@@ -431,6 +436,9 @@ export class Poracle {
       const omittedFields = { ...(pokemon.omittedFields || {}) }
       const hasPvpEntry = pokemon.pvpEntry && pokemon.pvp_ranking_league
       const includeNoIv = pokemon.noIv && !hasPvpEntry
+      const rangeGroups = hasPvpEntry
+        ? POKEMON_PVP_RANGE_GROUPS
+        : POKEMON_RANGE_GROUPS
       const setPokemonField = (field) => {
         if (
           !Poracle.shouldOmitPokemonField(
@@ -460,7 +468,9 @@ export class Poracle {
 
       POKEMON_SCALAR_FIELDS.forEach(setPokemonField)
 
-      if (includeNoIv) {
+      if (hasPvpEntry) {
+        // PvP alerts intentionally ignore regular IV/stat ranges.
+      } else if (includeNoIv) {
         payload.min_iv = Poracle.getPokemonFieldValue(
           pokemon,
           defaults,
@@ -475,7 +485,7 @@ export class Poracle {
         ;['min_iv', 'max_iv'].forEach(setPokemonField)
       }
 
-      POKEMON_RANGE_GROUPS.forEach(([low, high]) => {
+      rangeGroups.forEach(([low, high]) => {
         setPokemonField(low)
         setPokemonField(high)
       })
@@ -496,6 +506,9 @@ export class Poracle {
       const payload = {}
       const hasPvpEntry = pokemon.pvpEntry && pokemon.pvp_ranking_league
       const includeNoIv = pokemon.noIv && !hasPvpEntry
+      const rangeGroups = hasPvpEntry
+        ? POKEMON_PVP_RANGE_GROUPS
+        : POKEMON_RANGE_GROUPS
 
       POKEMON_CREATE_REQUIRED_FIELDS.forEach((field) => {
         if (pokemon[field] !== undefined) {
@@ -516,7 +529,9 @@ export class Poracle {
         }
       })
 
-      if (includeNoIv) {
+      if (hasPvpEntry) {
+        // PvP alerts intentionally ignore regular IV/stat ranges.
+      } else if (includeNoIv) {
         payload.min_iv =
           pokemon.min_iv === undefined ? defaults.min_iv : pokemon.min_iv
         payload.max_iv =
@@ -531,7 +546,7 @@ export class Poracle {
         payload.max_iv = pokemon.max_iv
       }
 
-      POKEMON_RANGE_GROUPS.forEach(([low, high]) => {
+      rangeGroups.forEach(([low, high]) => {
         if (
           pokemon[low] !== undefined &&
           pokemon[high] !== undefined &&

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -250,13 +250,11 @@ export class Poracle {
       return Poracle.toLocalState(category, entries, defaults)
     }
 
-    return Poracle.toLocalState(
-      category,
-      entries.map((pokemon, index) => ({
+    return Poracle.toLocalState(category, entries, defaults).map(
+      (pokemon, index) => ({
         ...pokemon,
         omittedFields: Poracle.getPokemonOmittedFields(payload[index]),
-      })),
-      defaults,
+      }),
     )
   }
 
@@ -431,6 +429,8 @@ export class Poracle {
     return processed.map((pokemon) => {
       const payload = {}
       const omittedFields = { ...(pokemon.omittedFields || {}) }
+      const hasPvpEntry = pokemon.pvpEntry && pokemon.pvp_ranking_league
+      const includeNoIv = pokemon.noIv && !hasPvpEntry
       const setPokemonField = (field) => {
         if (
           !Poracle.shouldOmitPokemonField(
@@ -460,7 +460,7 @@ export class Poracle {
 
       POKEMON_SCALAR_FIELDS.forEach(setPokemonField)
 
-      if (pokemon.noIv) {
+      if (includeNoIv) {
         payload.min_iv = Poracle.getPokemonFieldValue(
           pokemon,
           defaults,
@@ -494,6 +494,8 @@ export class Poracle {
 
     return processed.map((pokemon) => {
       const payload = {}
+      const hasPvpEntry = pokemon.pvpEntry && pokemon.pvp_ranking_league
+      const includeNoIv = pokemon.noIv && !hasPvpEntry
 
       POKEMON_CREATE_REQUIRED_FIELDS.forEach((field) => {
         if (pokemon[field] !== undefined) {
@@ -514,7 +516,7 @@ export class Poracle {
         }
       })
 
-      if (pokemon.noIv) {
+      if (includeNoIv) {
         payload.min_iv =
           pokemon.min_iv === undefined ? defaults.min_iv : pokemon.min_iv
         payload.max_iv =
@@ -547,11 +549,11 @@ export class Poracle {
         payload.max_weight = defaults.max_weight
       }
 
-      if (pokemon.noIv) {
+      if (includeNoIv) {
         return payload
       }
 
-      if (pokemon.pvpEntry && pokemon.pvp_ranking_league) {
+      if (hasPvpEntry) {
         POKEMON_PVP_FIELDS.forEach((field) => {
           if (pokemon[field] !== undefined) {
             payload[field] = pokemon[field]

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -52,12 +52,6 @@ const POKEMON_OMITTABLE_FIELDS = [
 ]
 
 export class Poracle {
-  static getPokemonPvpDefaults(defaults = {}) {
-    return Object.fromEntries(
-      POKEMON_PVP_FIELDS.map((field) => [field, defaults[field]]),
-    )
-  }
-
   static getMapCategory(poracleCategory) {
     switch (poracleCategory) {
       case 'gym':
@@ -499,7 +493,22 @@ export class Poracle {
         setPokemonField(high)
       })
 
-      POKEMON_PVP_FIELDS.forEach(setPokemonField)
+      if (hasPvpEntry) {
+        POKEMON_PVP_FIELDS.forEach(setPokemonField)
+      } else if (
+        !POKEMON_PVP_FIELDS.every((field) =>
+          Poracle.shouldOmitPokemonField(
+            pokemon,
+            defaults,
+            omittedFields,
+            field,
+          ),
+        )
+      ) {
+        POKEMON_PVP_FIELDS.forEach((field) => {
+          payload[field] = defaults[field]
+        })
+      }
 
       return payload
     })

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -258,6 +258,7 @@ export class Poracle {
         return entries
           .map((pkmn) => {
             const fields = [
+              'uid',
               'pokemon_id',
               'form',
               'clean',
@@ -312,7 +313,13 @@ export class Poracle {
       return processed
     }
 
-    const requiredFields = ['pokemon_id', 'form', 'profile_no', 'template']
+    const requiredFields = [
+      'uid',
+      'pokemon_id',
+      'form',
+      'profile_no',
+      'template',
+    ]
     const scalarFields = ['clean', 'distance', 'gender', 'min_time']
     const rangeGroups = [
       ['min_cp', 'max_cp'],
@@ -342,7 +349,7 @@ export class Poracle {
       })
 
       if (pokemon.noIv) {
-        ;['clean', 'distance', 'gender'].forEach((field) => {
+        scalarFields.forEach((field) => {
           if (
             pokemon[field] !== undefined &&
             pokemon[field] !== defaults[field]

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -431,6 +431,22 @@ export class Poracle {
     return processed.map((pokemon) => {
       const payload = {}
       const omittedFields = { ...(pokemon.omittedFields || {}) }
+      const setPokemonField = (field) => {
+        if (
+          !Poracle.shouldOmitPokemonField(
+            pokemon,
+            defaults,
+            omittedFields,
+            field,
+          )
+        ) {
+          payload[field] = Poracle.getPokemonFieldValue(
+            pokemon,
+            defaults,
+            field,
+          )
+        }
+      }
 
       POKEMON_UPDATE_REQUIRED_FIELDS.forEach((field) => {
         if (pokemon[field] !== undefined) {
@@ -442,31 +458,9 @@ export class Poracle {
         payload.ping = pokemon.ping
       }
 
-      POKEMON_SCALAR_FIELDS.forEach((field) => {
-        const value = Poracle.getPokemonFieldValue(pokemon, defaults, field)
-        if (
-          !Poracle.shouldOmitPokemonField(
-            pokemon,
-            defaults,
-            omittedFields,
-            field,
-          )
-        ) {
-          payload[field] = value
-        }
-      })
+      POKEMON_SCALAR_FIELDS.forEach(setPokemonField)
 
-      if (
-        pokemon.noIv ||
-        !['min_iv', 'max_iv'].every((field) =>
-          Poracle.shouldOmitPokemonField(
-            pokemon,
-            defaults,
-            omittedFields,
-            field,
-          ),
-        )
-      ) {
+      if (pokemon.noIv) {
         payload.min_iv = Poracle.getPokemonFieldValue(
           pokemon,
           defaults,
@@ -477,46 +471,16 @@ export class Poracle {
           defaults,
           'max_iv',
         )
+      } else {
+        ;['min_iv', 'max_iv'].forEach(setPokemonField)
       }
 
       POKEMON_RANGE_GROUPS.forEach(([low, high]) => {
-        if (
-          ![low, high].every((field) =>
-            Poracle.shouldOmitPokemonField(
-              pokemon,
-              defaults,
-              omittedFields,
-              field,
-            ),
-          )
-        ) {
-          payload[low] = Poracle.getPokemonFieldValue(pokemon, defaults, low)
-          payload[high] = Poracle.getPokemonFieldValue(pokemon, defaults, high)
-        }
+        setPokemonField(low)
+        setPokemonField(high)
       })
 
-      if (pokemon.pvpEntry && pokemon.pvp_ranking_league) {
-        POKEMON_PVP_FIELDS.forEach((field) => {
-          payload[field] = Poracle.getPokemonFieldValue(
-            pokemon,
-            defaults,
-            field,
-          )
-        })
-      } else if (
-        !POKEMON_PVP_FIELDS.every((field) =>
-          Poracle.shouldOmitPokemonField(
-            pokemon,
-            defaults,
-            omittedFields,
-            field,
-          ),
-        )
-      ) {
-        POKEMON_PVP_FIELDS.forEach((field) => {
-          payload[field] = defaults[field]
-        })
-      }
+      POKEMON_PVP_FIELDS.forEach(setPokemonField)
 
       return payload
     })

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -11,6 +11,31 @@ const POKEMON_PVP_FIELDS = [
   'pvp_ranking_cap',
 ]
 
+const POKEMON_CREATE_REQUIRED_FIELDS = [
+  'pokemon_id',
+  'form',
+  'profile_no',
+  'template',
+]
+
+const POKEMON_UPDATE_REQUIRED_FIELDS = [
+  'uid',
+  ...POKEMON_CREATE_REQUIRED_FIELDS,
+]
+
+const POKEMON_SCALAR_FIELDS = ['clean', 'distance', 'gender', 'min_time']
+
+const POKEMON_RANGE_GROUPS = [
+  ['min_cp', 'max_cp'],
+  ['min_level', 'max_level'],
+  ['atk', 'max_atk'],
+  ['def', 'max_def'],
+  ['sta', 'max_sta'],
+  ['rarity', 'max_rarity'],
+  ['size', 'max_size'],
+  ['min_weight', 'max_weight'],
+]
+
 export class Poracle {
   static getMapCategory(poracleCategory) {
     switch (poracleCategory) {
@@ -340,28 +365,10 @@ export class Poracle {
       return processed
     }
 
-    const requiredFields = [
-      'uid',
-      'pokemon_id',
-      'form',
-      'profile_no',
-      'template',
-    ]
-    const scalarFields = ['clean', 'distance', 'gender', 'min_time']
-    const rangeGroups = [
-      ['min_cp', 'max_cp'],
-      ['min_level', 'max_level'],
-      ['atk', 'max_atk'],
-      ['def', 'max_def'],
-      ['sta', 'max_sta'],
-      ['rarity', 'max_rarity'],
-      ['size', 'max_size'],
-      ['min_weight', 'max_weight'],
-    ]
     return processed.map((pokemon) => {
       const payload = {}
 
-      requiredFields.forEach((field) => {
+      POKEMON_UPDATE_REQUIRED_FIELDS.forEach((field) => {
         if (pokemon[field] !== undefined) {
           payload[field] = pokemon[field]
         }
@@ -371,7 +378,7 @@ export class Poracle {
         payload.ping = pokemon.ping
       }
 
-      scalarFields.forEach((field) => {
+      POKEMON_SCALAR_FIELDS.forEach((field) => {
         payload[field] =
           pokemon[field] === undefined ? defaults[field] : pokemon[field]
       })
@@ -381,7 +388,7 @@ export class Poracle {
       payload.max_iv =
         pokemon.max_iv === undefined ? defaults.max_iv : pokemon.max_iv
 
-      rangeGroups.forEach(([low, high]) => {
+      POKEMON_RANGE_GROUPS.forEach(([low, high]) => {
         payload[low] = pokemon[low] === undefined ? defaults[low] : pokemon[low]
         payload[high] =
           pokemon[high] === undefined ? defaults[high] : pokemon[high]
@@ -401,14 +408,70 @@ export class Poracle {
   }
 
   static toApiPayload(category, entries, defaults) {
-    const processed = Poracle.toUpdatePayload(category, entries, defaults)
+    const processed = Poracle.toLocalState(category, entries, defaults)
     if (category !== 'pokemon') {
       return processed
     }
 
     return processed.map((pokemon) => {
-      const payload = { ...pokemon }
-      delete payload.uid
+      const payload = {}
+
+      POKEMON_CREATE_REQUIRED_FIELDS.forEach((field) => {
+        if (pokemon[field] !== undefined) {
+          payload[field] = pokemon[field]
+        }
+      })
+
+      if (pokemon.ping !== undefined) {
+        payload.ping = pokemon.ping
+      }
+
+      POKEMON_SCALAR_FIELDS.forEach((field) => {
+        if (
+          pokemon[field] !== undefined &&
+          pokemon[field] !== defaults[field]
+        ) {
+          payload[field] = pokemon[field]
+        }
+      })
+
+      if (pokemon.noIv) {
+        payload.min_iv =
+          pokemon.min_iv === undefined ? defaults.min_iv : pokemon.min_iv
+        payload.max_iv =
+          pokemon.max_iv === undefined ? defaults.max_iv : pokemon.max_iv
+        return payload
+      }
+
+      if (
+        pokemon.min_iv !== undefined &&
+        pokemon.max_iv !== undefined &&
+        (pokemon.min_iv !== defaults.min_iv ||
+          pokemon.max_iv !== defaults.max_iv)
+      ) {
+        payload.min_iv = pokemon.min_iv
+        payload.max_iv = pokemon.max_iv
+      }
+
+      POKEMON_RANGE_GROUPS.forEach(([low, high]) => {
+        if (
+          pokemon[low] !== undefined &&
+          pokemon[high] !== undefined &&
+          (pokemon[low] !== defaults[low] || pokemon[high] !== defaults[high])
+        ) {
+          payload[low] = pokemon[low]
+          payload[high] = pokemon[high]
+        }
+      })
+
+      if (pokemon.pvpEntry && pokemon.pvp_ranking_league) {
+        POKEMON_PVP_FIELDS.forEach((field) => {
+          if (pokemon[field] !== undefined) {
+            payload[field] = pokemon[field]
+          }
+        })
+      }
+
       return payload
     })
   }

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -440,10 +440,7 @@ export class Poracle {
           pokemon.min_iv === undefined ? defaults.min_iv : pokemon.min_iv
         payload.max_iv =
           pokemon.max_iv === undefined ? defaults.max_iv : pokemon.max_iv
-        return payload
-      }
-
-      if (
+      } else if (
         pokemon.min_iv !== undefined &&
         pokemon.max_iv !== undefined &&
         (pokemon.min_iv !== defaults.min_iv ||
@@ -463,6 +460,10 @@ export class Poracle {
           payload[high] = pokemon[high]
         }
       })
+
+      if (pokemon.noIv) {
+        return payload
+      }
 
       if (pokemon.pvpEntry && pokemon.pvp_ranking_league) {
         POKEMON_PVP_FIELDS.forEach((field) => {

--- a/src/features/webhooks/services/Poracle.js
+++ b/src/features/webhooks/services/Poracle.js
@@ -266,9 +266,7 @@ export class Poracle {
 
         new Set(fields).forEach((field) => {
           newPokemon[field] =
-            normalized[field] === undefined
-              ? defaults[field]
-              : normalized[field]
+            normalized[field] == null ? defaults[field] : normalized[field]
         })
 
         if (includeUiState) {

--- a/src/features/webhooks/tiles/TrackedTile.jsx
+++ b/src/features/webhooks/tiles/TrackedTile.jsx
@@ -29,10 +29,21 @@ export function TrackedTile({ index }) {
 
   React.useEffect(() => {
     if (advOpen.open && advOpen.id === id && advOpen.uid === item.uid) {
+      const omitIvBounds =
+        item.omitIvBounds ||
+        (category === 'pokemon' &&
+          item.min_iv === undefined &&
+          item.max_iv === undefined &&
+          !item.pvpEntry)
       useWebhookStore.setState((prev) => ({
         tempFilters: {
           ...prev.tempFilters,
-          [id]: { ...defaults, ...item, byDistance: !!item.distance },
+          [id]: {
+            ...defaults,
+            ...item,
+            byDistance: !!item.distance,
+            omitIvBounds,
+          },
         },
       }))
     }

--- a/src/features/webhooks/tiles/TrackedTile.jsx
+++ b/src/features/webhooks/tiles/TrackedTile.jsx
@@ -44,9 +44,7 @@ export function TrackedTile({ index }) {
         apolloClient.mutate({
           mutation: webhookNodes[category.toUpperCase()],
           variables: {
-            data: Poracle.toApiPayload(category, [newFilter], defaults, {
-              includeUid: true,
-            }),
+            data: Poracle.processor(category, [newFilter], defaults),
             status: 'POST',
             category,
           },

--- a/src/features/webhooks/tiles/TrackedTile.jsx
+++ b/src/features/webhooks/tiles/TrackedTile.jsx
@@ -44,7 +44,7 @@ export function TrackedTile({ index }) {
         apolloClient.mutate({
           mutation: webhookNodes[category.toUpperCase()],
           variables: {
-            data: Poracle.processor(category, [newFilter], defaults),
+            data: Poracle.toUpdatePayload(category, [newFilter], defaults),
             status: 'POST',
             category,
           },

--- a/src/features/webhooks/tiles/TrackedTile.jsx
+++ b/src/features/webhooks/tiles/TrackedTile.jsx
@@ -29,17 +29,16 @@ export function TrackedTile({ index }) {
 
   React.useEffect(() => {
     if (advOpen.open && advOpen.id === id && advOpen.uid === item.uid) {
-      const omitIvBounds =
-        item.omitIvBounds ||
-        (category === 'pokemon' &&
-          item.min_iv == null &&
-          item.max_iv == null &&
-          !item.pvpEntry)
       const localItem =
         category === 'pokemon'
           ? Poracle.toLocalState(
               category,
-              [{ ...item, omitIvBounds }],
+              [
+                {
+                  ...item,
+                  omittedFields: Poracle.getPokemonOmittedFields(item),
+                },
+              ],
               defaults,
             )[0]
           : { ...defaults, ...item }

--- a/src/features/webhooks/tiles/TrackedTile.jsx
+++ b/src/features/webhooks/tiles/TrackedTile.jsx
@@ -44,7 +44,9 @@ export function TrackedTile({ index }) {
         apolloClient.mutate({
           mutation: webhookNodes[category.toUpperCase()],
           variables: {
-            data: Poracle.toApiPayload(category, [newFilter], defaults),
+            data: Poracle.toApiPayload(category, [newFilter], defaults, {
+              includeUid: true,
+            }),
             status: 'POST',
             category,
           },

--- a/src/features/webhooks/tiles/TrackedTile.jsx
+++ b/src/features/webhooks/tiles/TrackedTile.jsx
@@ -32,17 +32,23 @@ export function TrackedTile({ index }) {
       const omitIvBounds =
         item.omitIvBounds ||
         (category === 'pokemon' &&
-          item.min_iv === undefined &&
-          item.max_iv === undefined &&
+          item.min_iv == null &&
+          item.max_iv == null &&
           !item.pvpEntry)
+      const localItem =
+        category === 'pokemon'
+          ? Poracle.toLocalState(
+              category,
+              [{ ...item, omitIvBounds }],
+              defaults,
+            )[0]
+          : { ...defaults, ...item }
       useWebhookStore.setState((prev) => ({
         tempFilters: {
           ...prev.tempFilters,
           [id]: {
-            ...defaults,
-            ...item,
+            ...localItem,
             byDistance: !!item.distance,
-            omitIvBounds,
           },
         },
       }))

--- a/src/features/webhooks/tiles/TrackedTile.jsx
+++ b/src/features/webhooks/tiles/TrackedTile.jsx
@@ -32,11 +32,11 @@ export function TrackedTile({ index }) {
       useWebhookStore.setState((prev) => ({
         tempFilters: {
           ...prev.tempFilters,
-          [id]: { ...item, byDistance: !!item.distance },
+          [id]: { ...defaults, ...item, byDistance: !!item.distance },
         },
       }))
     }
-  }, [advOpen, id, item])
+  }, [advOpen, defaults, id, item])
 
   const onClose = React.useCallback(
     (newFilter, save) => {
@@ -44,7 +44,7 @@ export function TrackedTile({ index }) {
         apolloClient.mutate({
           mutation: webhookNodes[category.toUpperCase()],
           variables: {
-            data: Poracle.processor(category, [newFilter], defaults),
+            data: Poracle.toApiPayload(category, [newFilter], defaults),
             status: 'POST',
             category,
           },


### PR DESCRIPTION
## Summary

This fixes the ReactMap Poracle Pokemon alert flow so create and edit requests send the correct payload shape without leaking UI-only state.

### What changed

- split local Pokemon UI state from the payload sent to Poracle
- use a normalized create payload for add-new saves
- use a normalized update payload for tracked alert edits
- preserve `uid` on updates so existing Poracle rules are updated instead of duplicated
- preserve `ping` and other editable Pokemon fields across create/edit flows
- keep `allForms` handling stable when multiple forms of the same species are involved
- avoid reusing stale temp state in a way that can turn creates into updates

### Result

- new Pokemon alerts no longer accidentally overwrite existing tracked rules
- edited Pokemon alerts keep targeting the correct Poracle entry
- PoracleWeb and the map stay aligned on the saved Pokemon rule state
- default/full-range values are normalized consistently instead of leaking as noisy UI state

## Testing

- `./node_modules/.bin/eslint src/features/webhooks/services/Poracle.js src/features/webhooks/Manage.jsx src/features/webhooks/tiles/TrackedTile.jsx`
- `yarn build`

`yarn build` completed successfully with the existing offline locale-index fallback warning.

## Notes

There is still a preexisting no-IV summary mismatch on `develop`: the advanced dialog preview can hide some no-IV range constraints even though they may still persist. That behavior was identified during review but is not introduced
by this branch.