### PR TITLE
fix(webhooks): stop GPS ticks overwriting the saved Poracle location

### DIFF
--- a/src/features/webhooks/human/Location.jsx
+++ b/src/features/webhooks/human/Location.jsx
@@ -42,9 +42,19 @@ const Location = () => {
 
   const [save] = useMutation(SET_HUMAN, { fetchPolicy: 'no-cache' })
 
+  // The locate control watches the device position, so `locationfound` keeps
+  // firing for as long as it is active. Only consume the first event after the
+  // user explicitly asks for their location, otherwise a background GPS tick
+  // would silently overwrite a location they set on purpose.
+  const awaitingLocate = React.useRef(false)
+
   /** @param {[number, number]} location */
   const handleLocationChange = (location) => {
     if (location.every((x) => x !== 0)) {
+      // Whatever we are about to save supersedes a locate request that has not
+      // come back yet, otherwise a slow GPS fix would land on top of a pick the
+      // user made while waiting for it.
+      awaitingLocate.current = false
       useWebhookStore.setState((prev) => ({
         location: prev.location.some((x, i) => x !== location[i])
           ? [location[0] ?? 0, location[1] ?? 0]
@@ -63,12 +73,6 @@ const Location = () => {
       })
     }
   }
-
-  // The locate control watches the device position, so `locationfound` keeps
-  // firing for as long as it is active. Only consume the first event after the
-  // user explicitly asks for their location, otherwise a background GPS tick
-  // would silently overwrite a location they set on purpose.
-  const awaitingLocate = React.useRef(false)
 
   const map = useMapEvents({
     locationfound: (newLoc) => {

--- a/src/features/webhooks/human/Location.jsx
+++ b/src/features/webhooks/human/Location.jsx
@@ -64,24 +64,38 @@ const Location = () => {
     }
   }
 
+  // The locate control watches the device position, so `locationfound` keeps
+  // firing for as long as it is active. Only consume the first event after the
+  // user explicitly asks for their location, otherwise a background GPS tick
+  // would silently overwrite a location they set on purpose.
+  const awaitingLocate = React.useRef(false)
+
   const map = useMapEvents({
     locationfound: (newLoc) => {
+      if (!awaitingLocate.current) return
+      awaitingLocate.current = false
       const { location } = useWebhookStore.getState()
       const { lat, lng } = newLoc.latlng
-      if (lat !== location[0] && lng !== location[1]) {
+      if (lat !== location[0] || lng !== location[1]) {
         handleLocationChange([lat, lng])
       }
     },
   })
 
   React.useEffect(() => {
-    if (webhookLocation[0] !== latitude && webhookLocation[1] !== longitude) {
+    if (webhookLocation[0] !== latitude || webhookLocation[1] !== longitude) {
       handleLocationChange(webhookLocation)
     }
   }, [webhookLocation])
 
   React.useEffect(() => {
-    if (webhookLocation.every((x) => x === 0)) {
+    // `human` is empty until the query resolves, so wait for real coordinates
+    // rather than seeding the store with undefined.
+    if (
+      typeof latitude === 'number' &&
+      typeof longitude === 'number' &&
+      webhookLocation.every((x) => x === 0)
+    ) {
       useWebhookStore.setState({ location: [latitude, longitude] })
     }
   }, [latitude, longitude])
@@ -120,7 +134,12 @@ const Location = () => {
           size="small"
           variant="contained"
           color={color}
-          onClick={() => lc._onClick()}
+          onClick={() => {
+            lc._onClick()
+            // `_onClick` toggles: if that turned the control off, no
+            // `locationfound` is coming and the request must not stay armed.
+            awaitingLocate.current = !!lc._active
+          }}
           startIcon={<MyLocation sx={{ color: 'white' }} />}
         >
           {t('my_location')}

--- a/src/features/webhooks/human/Location.jsx
+++ b/src/features/webhooks/human/Location.jsx
@@ -48,6 +48,14 @@ const Location = () => {
   // would silently overwrite a location they set on purpose.
   const awaitingLocate = React.useRef(false)
 
+  // Search, My Location, and the map picker call `handleLocationChange`
+  // directly, which both writes the store and POSTs. That store write also
+  // re-fires the `webhookLocation` sync effect below (which exists for the
+  // drag picker, whose only signal is the store). Remember the coordinates we
+  // are already persisting so the effect can skip a duplicate save.
+  /** @type {React.MutableRefObject<[number, number] | null>} */
+  const savingLocation = React.useRef(null)
+
   /** @param {[number, number]} location */
   const handleLocationChange = (location) => {
     if (location.every((x) => x !== 0)) {
@@ -55,6 +63,7 @@ const Location = () => {
       // come back yet, otherwise a slow GPS fix would land on top of a pick the
       // user made while waiting for it.
       awaitingLocate.current = false
+      savingLocation.current = location
       useWebhookStore.setState((prev) => ({
         location: prev.location.some((x, i) => x !== location[i])
           ? [location[0] ?? 0, location[1] ?? 0]
@@ -66,11 +75,23 @@ const Location = () => {
           data: location,
           status: 'POST',
         },
-      }).then(({ data: newData }) => {
-        if (newData?.webhook) {
-          useWebhookStore.setState({ human: newData.webhook.human })
-        }
       })
+        .then(({ data: newData }) => {
+          if (newData?.webhook) {
+            useWebhookStore.setState({ human: newData.webhook.human })
+          }
+        })
+        .finally(() => {
+          // Only clear if a newer save has not already claimed the ref, so an
+          // in-flight save can't wipe the marker for the location after it.
+          if (
+            savingLocation.current &&
+            savingLocation.current[0] === location[0] &&
+            savingLocation.current[1] === location[1]
+          ) {
+            savingLocation.current = null
+          }
+        })
     }
   }
 
@@ -87,6 +108,18 @@ const Location = () => {
   })
 
   React.useEffect(() => {
+    const saving = savingLocation.current
+    if (
+      saving &&
+      saving[0] === webhookLocation[0] &&
+      saving[1] === webhookLocation[1]
+    ) {
+      // `handleLocationChange` already saved these exact coordinates and only
+      // updated the store, which is what re-triggered this effect. The drag
+      // picker, by contrast, writes the store without saving and relies on the
+      // POST below.
+      return
+    }
     if (webhookLocation[0] !== latitude || webhookLocation[1] !== longitude) {
       handleLocationChange(webhookLocation)
     }

--- a/src/hooks/useLocation.js
+++ b/src/hooks/useLocation.js
@@ -13,7 +13,7 @@ import { RecoveringLocateControl } from '@utils/locateControl'
 
 /**
  * Use location hook
- * @returns {{ lc: import('leaflet.locatecontrol').LocateControl & { _onClick: () => void }, requesting: boolean, color: import('@mui/material').ButtonProps['color'], locationError: { show: boolean, message: string }, hideLocationError: () => void }}
+ * @returns {{ lc: import('leaflet.locatecontrol').LocateControl & { _onClick: () => void, _active?: boolean }, requesting: boolean, color: import('@mui/material').ButtonProps['color'], locationError: { show: boolean, message: string }, hideLocationError: () => void }}
  */
 export function useLocation(dependency = false) {
   const map = useMap()


### PR DESCRIPTION
## Problem

A user reported that their Poracle notification location kept changing to wherever they physically were, rather than staying at the location they had deliberately set:

> Whenever I go into edit my notifications settings, my location auto updates to my current location rather than where I scan from (I scan from a park that I play at, but adjust settings at home). Is there anyway to turn this off/get it to just keep the location I originally assigned?

They had set alerts for a park they play at, then edited a tracking from home — and started getting pings for spawns near their house instead.

This is real, and it isn't user error. `Location.jsx` listened for Leaflet's `locationfound` event and **persisted every one of them** straight to Poracle via the `setLocation` mutation, with no confirmation:

```js
const map = useMapEvents({
  locationfound: (newLoc) => {
    const { location } = useWebhookStore.getState()
    const { lat, lng } = newLoc.latlng
    if (lat !== location[0] && lng !== location[1]) {
      handleLocationChange([lat, lng])   // <- writes to Poracle
    }
  },
})
```

`leaflet.locatecontrol` runs geolocation in **watch** mode, so once the locate control is active it keeps emitting position fixes for as long as it runs. That means merely *opening* the notification panel with locate engaged was enough to silently overwrite a saved location — the user sees their current coordinates in the panel, but by then the write has already happened.

Users tracking by coordinates + distance are hit hardest. Poracle stores a single lat/lng per human (`POST /api/humans/:id/setLocation`), not one per tracking or per profile, so a single stray GPS tick relocates **every** distance-based tracking they have at once.

## Fix

Gate the handler behind a ref that only the **My Location** button arms, and clear it on the first event so a continuing watch can't write a second time. Passive GPS ticks are now ignored; the location only changes when the user asks for it via My Location, the map pin, or the Nominatim search.

`_onClick` toggles the control, so the flag is armed from `lc._active` *after* the call — clicking it while already active *stops* locating, and arming beforehand would leave the flag set with no event coming, letting a later stray tick through.

## Also included

Two adjacent issues found while verifying:

- **`&&` should have been `||`** in both coordinate comparisons. They required *both* latitude and longitude to differ, so moving a pin along a single axis silently didn't save.
- **The init effect could seed the store with `[undefined, undefined]`.** `human` is empty until the query resolves, and the `every(x => x === 0)` guard then never re-fires once real coordinates arrive. Harmless under `&&`, but worth closing now that the save effect is more eager.

`useLocation`'s return typedef gains `_active?: boolean`. The property is real and already relied on in [`useStopFollowingOnFly.js`](https://github.com/WatWowMap/ReactMap/blob/main/src/hooks/useStopFollowingOnFly.js#L16), so widening the typedef seemed cleaner than a cast — though it is the same coupling to `leaflet.locatecontrol` internals that the existing `_onClick` usage already has.

## Testing

⚠️ **Not verified beyond code review** — my checkout had no `node_modules`, so I could not run the linter or a build. Worth a manual pass before merging. Suggested check:

1. Engage the locate control (blue/green), then open the notification panel — the saved location should now stay put.
2. Click **My Location** in the panel — it should still update, once.
3. Drop a pin via **Choose on Map** and change only longitude — it should save (this was broken before).

## Note

This doesn't change the underlying design: location remains one value per user, so distance-based trackings still all share it. This only stops it from moving on its own. Tracking by *area* is still the robust answer for "alert me about this specific place regardless of where I am."
