### PR TITLE
fix: make Rocket reward filters use one stable key per species

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -541,7 +541,7 @@
       "pokemon": true,
       "invasions": false,
       "allInvasions": true,
-      "invasionPokemon": true,
+      "invasionPokemon": false,
       "baseMegaEnergyAmounts": [],
       "stardust": {
         "min": 100,

--- a/config/default.json
+++ b/config/default.json
@@ -541,7 +541,7 @@
       "pokemon": true,
       "invasions": false,
       "allInvasions": true,
-      "invasionPokemon": false,
+      "invasionPokemon": true,
       "baseMegaEnergyAmounts": [],
       "stardust": {
         "min": 100,

--- a/server/src/filters/builder/base.js
+++ b/server/src/filters/builder/base.js
@@ -115,7 +115,6 @@ function buildDefaultFilters(perms) {
               hasDualQuestLayer && perms.pokestops ? false : undefined,
             standard: new BaseFilter(),
             filter: {
-              ...pokemon.rocket,
               ...buildPokestops(perms, defaultFilters.pokestops),
               ...pokemon.quests,
             },

--- a/server/src/filters/builder/pokemon.js
+++ b/server/src/filters/builder/pokemon.js
@@ -13,7 +13,6 @@ const { getWildFilterKey } = require('../pokemon/getWildFilterKey')
  *  raids: { [key: string]: BaseFilter },
  *  quests: { [key: string]: BaseFilter },
  *  nests: { [key: string]: BaseFilter },
- *  rocket: { [key: string]: BaseFilter },
  *  stations: { [key: string]: BaseFilter },
  * }}
  */
@@ -24,7 +23,6 @@ function buildPokemon(defaults, base, custom) {
     stations: { global: new BaseFilter() },
     quests: { global: new BaseFilter() },
     nests: { global: new BaseFilter() },
-    rocket: { global: new BaseFilter() },
   }
   const energyAmounts = new Set([
     ...defaults.pokestops.baseMegaEnergyAmounts,
@@ -43,11 +41,6 @@ function buildPokemon(defaults, base, custom) {
       pokemon.raids[rawKey] = new BaseFilter(defaults.gyms.pokemon)
       pokemon.stations[rawKey] = new BaseFilter(defaults.stations.pokemon)
       pokemon.quests[rawKey] = new BaseFilter(defaults.pokestops.pokemon)
-      if (state.db.filterContext.Pokestop.hasConfirmedInvasions) {
-        pokemon.rocket[`a${rawKey}`] = new BaseFilter(
-          defaults.pokestops.invasionPokemon,
-        )
-      }
       pokemon.nests[rawKey] = new BaseFilter(defaults.nests.allPokemon)
     })
     if ('family' in pkmn) {

--- a/server/src/filters/builder/pokestop.js
+++ b/server/src/filters/builder/pokestop.js
@@ -83,6 +83,10 @@ function buildPokestops(perms, defaults) {
       if (avail.startsWith('i')) {
         quests[avail] = new BaseFilter(defaults.allInvasions)
       }
+      // Reward filters come only from the canonical available list. Building
+      // an `a` key for every masterfile form creates hidden siblings that the
+      // menu cannot switch off, while reward matching intentionally ignores
+      // form differences between scanner and masterfile data.
       if (
         avail.startsWith('a') &&
         state.db.filterContext.Pokestop.hasConfirmedInvasions

--- a/server/src/filters/pokestop/rocketPokemonKeys.js
+++ b/server/src/filters/pokestop/rocketPokemonKeys.js
@@ -62,7 +62,35 @@ const dedupeRocketPokemonKeys = (availableSet) => {
   })
 }
 
+/**
+ * Resolves the form to use when building a Rocket reward's available key.
+ *
+ * A confirmed grunt's scanner-reported form and the masterfile encounter
+ * pool's form for the same species routinely disagree (Wobbuffet has shown
+ * up as both `602` and `2328` for the same grunt type). Building the key
+ * straight from whichever form the current poll happened to report means the
+ * SAME species can mint a NEW, different key on a later poll — a menu entry
+ * a user already switched off keeps a live twin they never see appear, and
+ * `dedupeRocketPokemonKeys` only reconciles keys within a single poll, not
+ * across separate ones over time.
+ *
+ * Always deriving the form from the masterfile encounter pool - regardless of
+ * whether this reward came from a confirmed scanner slot or the unconfirmed
+ * fallback - makes every poll agree on the same key for a given species, so
+ * there is nothing left to reconcile after the fact.
+ * @param {{id: number, form: number}[] | undefined} encounters the grunt's
+ *   masterfile encounter pool for this slot (e.g. `fullGrunt.encounters.first`)
+ * @param {number} pokemonId
+ * @param {number} fallbackForm used only if `pokemonId` isn't in `encounters`
+ *   (e.g. a masterfile/scanner mismatch on the species itself, not just form)
+ */
+const getCanonicalRewardForm = (encounters, pokemonId, fallbackForm) => {
+  const match = encounters?.find((poke) => poke.id === pokemonId)
+  return match ? match.form : (fallbackForm ?? 0)
+}
+
 module.exports = {
   dedupeRocketPokemonKeys,
+  getCanonicalRewardForm,
   hasRocketPokemonFilter,
 }

--- a/server/src/filters/pokestop/rocketPokemonKeys.js
+++ b/server/src/filters/pokestop/rocketPokemonKeys.js
@@ -1,0 +1,68 @@
+// @ts-check
+
+/** Matches `a<pokemonId>` and the legacy `a<pokemonId>-<formId>` shape. */
+const ROCKET_KEY = /^a(\d+)(?:-(\d+))?$/
+
+/**
+ * True when any enabled filter selects `pokemonId`, whatever form it carries.
+ *
+ * The form cannot be compared. The scanner's `incident` table commonly records
+ * a reward's form as `0`, while the masterfile encounter pool gives it a real
+ * form (Deino is `2291`). An exact comparison drops whichever of the two the
+ * ticked filter did not come from, even though the SQL stage already selected
+ * the stop by Pokemon ID alone. Grunt rewards do not meaningfully vary by
+ * form, so matching on the ID makes every source — confirmed, unconfirmed,
+ * scanner, masterfile — agree at once.
+ * @param {Record<string, any>} filters
+ * @param {number | string} pokemonId
+ */
+const hasRocketPokemonFilter = (filters, pokemonId) => {
+  if (!pokemonId) return false
+  const prefix = `a${pokemonId}`
+  return Object.keys(filters).some(
+    (key) => key === prefix || key.startsWith(`${prefix}-`),
+  )
+}
+
+/**
+ * Collapses Rocket reward keys so a species contributes exactly one filter.
+ *
+ * The available list is fed from the two sources described above, so the same
+ * species can arrive as both `a276-0` and `a276-3163`. The menu renders those
+ * as two identical-looking entries, and only whichever one matches the grunt
+ * in hand actually does anything.
+ *
+ * The non-zero form wins: that is the masterfile shape, which is what existing
+ * saved filters already hold, and it is what the icon renderer expects. Since
+ * `hasRocketPokemonFilter` matches on the ID, the surviving key works for
+ * confirmed and unconfirmed grunts alike. Non-Rocket keys are left untouched.
+ * @param {Set<string>} availableSet mutated in place
+ */
+const dedupeRocketPokemonKeys = (availableSet) => {
+  /** @type {Map<string, { key: string, form: number }>} */
+  const bySpecies = new Map()
+  /** @type {string[]} */
+  const rocketKeys = []
+
+  availableSet.forEach((key) => {
+    const match = ROCKET_KEY.exec(key)
+    if (!match) return
+    rocketKeys.push(key)
+    const [, species, rawForm] = match
+    const form = Number(rawForm ?? 0)
+    const current = bySpecies.get(species)
+    if (!current || (current.form === 0 && form !== 0)) {
+      bySpecies.set(species, { key, form })
+    }
+  })
+
+  const keep = new Set([...bySpecies.values()].map((entry) => entry.key))
+  rocketKeys.forEach((key) => {
+    if (!keep.has(key)) availableSet.delete(key)
+  })
+}
+
+module.exports = {
+  dedupeRocketPokemonKeys,
+  hasRocketPokemonFilter,
+}

--- a/server/src/filters/pokestop/rocketPokemonKeys.test.js
+++ b/server/src/filters/pokestop/rocketPokemonKeys.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict')
 
 const {
   dedupeRocketPokemonKeys,
+  getCanonicalRewardForm,
   hasRocketPokemonFilter,
 } = require('./rocketPokemonKeys')
 
@@ -82,4 +83,40 @@ test('the survivor still matches, so the menu entry works', () => {
   const filters = Object.fromEntries([...available].map((k) => [k, {}]))
   // Confirmed grunt reports form 0, unconfirmed reports 3163 - both match.
   assert.equal(hasRocketPokemonFilter(filters, 276), true)
+})
+
+test('getCanonicalRewardForm prefers the masterfile encounter form', () => {
+  // Wobbuffet (202): scanner reports 602 for this grunt, masterfile says 2328.
+  const encounters = [
+    { id: 202, form: 2328 },
+    { id: 359, form: 830 },
+  ]
+  assert.equal(getCanonicalRewardForm(encounters, 202, 602), 2328)
+})
+
+test('getCanonicalRewardForm falls back when the species is not in the pool', () => {
+  const encounters = [{ id: 359, form: 830 }]
+  assert.equal(getCanonicalRewardForm(encounters, 202, 602), 602)
+})
+
+test('getCanonicalRewardForm falls back to 0 with no encounters and no fallback', () => {
+  assert.equal(getCanonicalRewardForm(undefined, 202, undefined), 0)
+})
+
+test('canonical form keeps repeated polls from minting a second key', () => {
+  // Poll 1: confirmed slot reports scanner form 602 for Wobbuffet.
+  const poll1 = new Set()
+  const form1 = getCanonicalRewardForm([{ id: 202, form: 2328 }], 202, 602)
+  poll1.add(`a202-${form1}`)
+  dedupeRocketPokemonKeys(poll1)
+
+  // Poll 2: a different grunt occurrence, scanner form is 0 this time.
+  const poll2 = new Set()
+  const form2 = getCanonicalRewardForm([{ id: 202, form: 2328 }], 202, 0)
+  poll2.add(`a202-${form2}`)
+  dedupeRocketPokemonKeys(poll2)
+
+  // Both polls must agree on the exact same key - nothing left to reconcile.
+  assert.deepEqual([...poll1], [...poll2])
+  assert.deepEqual([...poll1], ['a202-2328'])
 })

--- a/server/src/filters/pokestop/rocketPokemonKeys.test.js
+++ b/server/src/filters/pokestop/rocketPokemonKeys.test.js
@@ -1,0 +1,85 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+  dedupeRocketPokemonKeys,
+  hasRocketPokemonFilter,
+} = require('./rocketPokemonKeys')
+
+test('matches a reward whichever form the ticked filter carries', () => {
+  // Deino: masterfile says form 2291, the scanner records 0. Both must match.
+  assert.equal(hasRocketPokemonFilter({ 'a633-2291': {} }, 633), true)
+  assert.equal(hasRocketPokemonFilter({ 'a633-0': {} }, 633), true)
+  assert.equal(hasRocketPokemonFilter({ a633: {} }, 633), true)
+})
+
+test('does not match a different species', () => {
+  assert.equal(hasRocketPokemonFilter({ 'a714-3070': {} }, 633), false)
+  assert.equal(hasRocketPokemonFilter({}, 633), false)
+})
+
+test('does not confuse species whose ids share a prefix', () => {
+  // `a1` must not match Pokemon 12, nor `a12` match Pokemon 1.
+  assert.equal(hasRocketPokemonFilter({ a12: {} }, 1), false)
+  assert.equal(hasRocketPokemonFilter({ 'a12-0': {} }, 1), false)
+  assert.equal(hasRocketPokemonFilter({ a1: {} }, 12), false)
+})
+
+test('a falsy pokemon id never matches', () => {
+  assert.equal(hasRocketPokemonFilter({ a0: {} }, 0), false)
+  assert.equal(hasRocketPokemonFilter({ a633: {} }, undefined), false)
+})
+
+test('collapses the Taillow duplicate to the masterfile form', () => {
+  // The scanner contributes `a276-0`, the masterfile fallback `a276-3163`.
+  const available = new Set(['a276-0', 'a276-3163'])
+  dedupeRocketPokemonKeys(available)
+  assert.deepEqual([...available], ['a276-3163'])
+})
+
+test('keeps the form-less key when it is the only one', () => {
+  const available = new Set(['a276'])
+  dedupeRocketPokemonKeys(available)
+  assert.deepEqual([...available], ['a276'])
+})
+
+test('prefers a real form over a zero form regardless of order', () => {
+  const forwards = new Set(['a633-0', 'a633-2291'])
+  dedupeRocketPokemonKeys(forwards)
+  assert.deepEqual([...forwards], ['a633-2291'])
+
+  const backwards = new Set(['a633-2291', 'a633-0'])
+  dedupeRocketPokemonKeys(backwards)
+  assert.deepEqual([...backwards], ['a633-2291'])
+})
+
+test('collapses a form-less key against a form-carrying one', () => {
+  const available = new Set(['a633', 'a633-2291'])
+  dedupeRocketPokemonKeys(available)
+  assert.deepEqual([...available], ['a633-2291'])
+})
+
+test('leaves distinct species and non-Rocket keys untouched', () => {
+  const available = new Set([
+    'a276-0',
+    'a276-3163',
+    'a633-2291',
+    'i12', // grunt type
+    'l501', // lure
+    'q1', // item
+    'f25-0', // showcase
+  ])
+  dedupeRocketPokemonKeys(available)
+  assert.deepEqual(
+    [...available].sort(),
+    ['a276-3163', 'a633-2291', 'f25-0', 'i12', 'l501', 'q1'].sort(),
+  )
+})
+
+test('the survivor still matches, so the menu entry works', () => {
+  const available = new Set(['a276-0', 'a276-3163'])
+  dedupeRocketPokemonKeys(available)
+  const filters = Object.fromEntries([...available].map((k) => [k, {}]))
+  // Confirmed grunt reports form 0, unconfirmed reports 3163 - both match.
+  assert.equal(hasRocketPokemonFilter(filters, 276), true)
+})

--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -29,6 +29,10 @@ const {
   resolveQuestLayerSelection,
 } = require('../utils/questLayerMode')
 const { mapAvailablePokestops } = require('./pokestopAvailableMapper')
+const {
+  dedupeRocketPokemonKeys,
+  hasRocketPokemonFilter,
+} = require('../filters/pokestop/rocketPokemonKeys')
 
 const MEGA_RESOURCE_REWARD_TYPE = 12
 const TEMP_EVO_BRANCH_RESOURCE_REWARD_TYPE = 20
@@ -1044,11 +1048,22 @@ class Pokestop extends Model {
     }
   }
 
-  static hasRocketPokemonFilter(filters, pokemonId, formId) {
-    if (!pokemonId) return false
-    return !!(
-      filters[`a${pokemonId}-${formId ?? 0}`] || filters[`a${pokemonId}`]
-    )
+  /**
+   * Matches a Rocket reward by Pokemon ID, ignoring the form id.
+   *
+   * The form cannot be compared: the scanner's `incident` table commonly
+   * records a reward's form as `0`, while the masterfile encounter pool gives
+   * it a real form (Deino is `2291`). An exact comparison therefore drops
+   * whichever of the two the ticked filter did not come from, even though the
+   * SQL stage already selected the stop by Pokemon ID alone. Grunt rewards do
+   * not meaningfully vary by form, so matching on the ID makes every source
+   * (confirmed, unconfirmed, scanner, masterfile) agree at once.
+   *
+   * Accepts both the `a<id>` and the legacy `a<id>-<form>` key shapes so
+   * existing saved filters keep resolving.
+   */
+  static hasRocketPokemonFilter(filters, pokemonId) {
+    return hasRocketPokemonFilter(filters, pokemonId)
   }
 
   static invasionMatchesFilters(
@@ -1090,13 +1105,9 @@ class Pokestop extends Model {
       if (
         info.firstReward &&
         (hasConfirmed && invasion.confirmed
-          ? this.hasRocketPokemonFilter(
-              filters,
-              invasion.slot_1_pokemon_id,
-              invasion.slot_1_form,
-            )
+          ? this.hasRocketPokemonFilter(filters, invasion.slot_1_pokemon_id)
           : info.encounters.first.some((poke) =>
-              this.hasRocketPokemonFilter(filters, poke.id, poke.form),
+              this.hasRocketPokemonFilter(filters, poke.id),
             ))
       ) {
         return true
@@ -1105,13 +1116,9 @@ class Pokestop extends Model {
       if (
         info.secondReward &&
         (hasConfirmed && invasion.confirmed
-          ? this.hasRocketPokemonFilter(
-              filters,
-              invasion.slot_2_pokemon_id,
-              invasion.slot_2_form,
-            )
+          ? this.hasRocketPokemonFilter(filters, invasion.slot_2_pokemon_id)
           : info.encounters.second.some((poke) =>
-              this.hasRocketPokemonFilter(filters, poke.id, poke.form),
+              this.hasRocketPokemonFilter(filters, poke.id),
             ))
       ) {
         return true
@@ -1120,13 +1127,9 @@ class Pokestop extends Model {
       if (
         info.thirdReward &&
         (hasConfirmed && invasion.confirmed
-          ? this.hasRocketPokemonFilter(
-              filters,
-              invasion.slot_3_pokemon_id,
-              invasion.slot_3_form,
-            )
+          ? this.hasRocketPokemonFilter(filters, invasion.slot_3_pokemon_id)
           : info.encounters.third.some((poke) =>
-              this.hasRocketPokemonFilter(filters, poke.id, poke.form),
+              this.hasRocketPokemonFilter(filters, poke.id),
             ))
       ) {
         return true
@@ -1493,6 +1496,7 @@ class Pokestop extends Model {
           })
           const availableSet = new Set(result.available)
           applyRocketPokemonFallback(availableSet)
+          dedupeRocketPokemonKeys(availableSet)
           log.info(
             TAGS.pokestops,
             `[POKESTOP] loaded available from ${mem}/api/fort/available — ${availableSet.size} filter keys (${res.quests.length} quests, ${res.invasions.length} invasions, ${(res.lures || []).length} lures, ${(res.showcases || []).length} showcases), ${Object.keys(result.conditions).length} reward conditions`,
@@ -2064,6 +2068,7 @@ class Pokestop extends Model {
           }
 
           applyRocketPokemonFallback(finalList)
+          dedupeRocketPokemonKeys(finalList)
           break
         case 'showcase':
           if (hasShowcaseData) {

--- a/server/src/models/Pokestop.js
+++ b/server/src/models/Pokestop.js
@@ -31,6 +31,7 @@ const {
 const { mapAvailablePokestops } = require('./pokestopAvailableMapper')
 const {
   dedupeRocketPokemonKeys,
+  getCanonicalRewardForm,
   hasRocketPokemonFilter,
 } = require('../filters/pokestop/rocketPokemonKeys')
 
@@ -2050,19 +2051,28 @@ class Pokestop extends Model {
 
               const fullGrunt = state.event.invasions[reward.grunt_type]
               if (fullGrunt?.firstReward) {
-                finalList.add(
-                  `a${reward.slot_1_pokemon_id}-${reward.slot_1_form}`,
+                const form = getCanonicalRewardForm(
+                  fullGrunt.encounters?.first,
+                  reward.slot_1_pokemon_id,
+                  reward.slot_1_form,
                 )
+                finalList.add(`a${reward.slot_1_pokemon_id}-${form}`)
               }
               if (fullGrunt?.secondReward) {
-                finalList.add(
-                  `a${reward.slot_2_pokemon_id}-${reward.slot_2_form}`,
+                const form = getCanonicalRewardForm(
+                  fullGrunt.encounters?.second,
+                  reward.slot_2_pokemon_id,
+                  reward.slot_2_form,
                 )
+                finalList.add(`a${reward.slot_2_pokemon_id}-${form}`)
               }
               if (fullGrunt?.thirdReward) {
-                finalList.add(
-                  `a${reward.slot_3_pokemon_id}-${reward.slot_3_form}`,
+                const form = getCanonicalRewardForm(
+                  fullGrunt.encounters?.third,
+                  reward.slot_3_pokemon_id,
+                  reward.slot_3_form,
                 )
+                finalList.add(`a${reward.slot_3_pokemon_id}-${form}`)
               }
             })
           }

--- a/server/src/models/pokestopAvailableMapper.js
+++ b/server/src/models/pokestopAvailableMapper.js
@@ -192,16 +192,42 @@ function mapAvailablePokestops(api, ctx) {
     const isRocketLeaderOrGiovanni = character >= 41 && character <= 44
     if (confirmed && !isRocketLeaderOrGiovanni) {
       // Each slot the event config marks as a reward contributes an `a` key,
-      // mirroring the SQL path which reads confirmed slots 1/2/3.
+      // mirroring the SQL path which reads confirmed slots 1/2/3. The form is
+      // taken from the masterfile encounter pool, not the scanner-reported
+      // slot form: the two disagree often enough (Wobbuffet has shown up as
+      // both 602 and 2328 for the same grunt type) that building the key from
+      // whichever form THIS poll happened to report lets the same species
+      // mint a different key on a later poll, orphaning whatever a user
+      // already switched off. Keeping this in lockstep with the SQL path (see
+      // `getCanonicalRewardForm` there) means both always agree on one key.
       const cfg = ctx.invasions?.[character]
+      const canonicalForm = (encounters, pokemonId, fallbackForm) => {
+        const match = encounters?.find((poke) => poke.id === pokemonId)
+        return match ? match.form : (fallbackForm ?? 0)
+      }
       if (slot1_pokemon_id > 0 && cfg?.firstReward) {
-        available.add(`a${slot1_pokemon_id}-${slot1_form}`)
+        const form = canonicalForm(
+          cfg.encounters?.first,
+          slot1_pokemon_id,
+          slot1_form,
+        )
+        available.add(`a${slot1_pokemon_id}-${form}`)
       }
       if (slot2_pokemon_id > 0 && cfg?.secondReward) {
-        available.add(`a${slot2_pokemon_id}-${slot2_form}`)
+        const form = canonicalForm(
+          cfg.encounters?.second,
+          slot2_pokemon_id,
+          slot2_form,
+        )
+        available.add(`a${slot2_pokemon_id}-${form}`)
       }
       if (slot3_pokemon_id > 0 && cfg?.thirdReward) {
-        available.add(`a${slot3_pokemon_id}-${slot3_form}`)
+        const form = canonicalForm(
+          cfg.encounters?.third,
+          slot3_pokemon_id,
+          slot3_form,
+        )
+        available.add(`a${slot3_pokemon_id}-${form}`)
       }
     }
   })


### PR DESCRIPTION
## What changed

- Match Rocket rewards by Pokémon species ID when scanner and masterfile form IDs disagree.
- Collapse duplicate Rocket reward keys to one canonical key per species.
- Derive confirmed reward keys from the stable masterfile form across SQL and Golbat available-data paths.
- Remove the hidden all-form Rocket filter generator so every active key has a visible switch.
- Preserve the existing default where Rocket reward filters begin enabled.

## Root cause

Scanner incident data and the masterfile can report different form IDs for the same Rocket reward. ReactMap generated both visible and hidden form-specific keys, while reward matching treated them as the same species. A hidden enabled sibling could therefore keep a grunt visible after the displayed filter was turned off.

## Impact

The Invasion type and Rocket Pokémon filters retain their additive OR behavior, but turning off a visible Rocket Pokémon filter now removes the only active key for that species.

## Validation

- `node --test server/src/filters/pokestop/rocketPokemonKeys.test.js` — 14/14 passing
- ESLint on the changed server filter files
- `git diff --check`
- `config/default.json` matches `main` (Rocket rewards still default on)