### PR TITLE
fix(build): write a trailing newline from the JSON generators

### DIFF
--- a/packages/config/lib/scripts/genEnvConfig.js
+++ b/packages/config/lib/scripts/genEnvConfig.js
@@ -31,7 +31,7 @@ const generateEnvConfig = async () => {
     resolve(
       `${__dirname}/../../../../config/custom-environment-variables.json`,
     ),
-    JSON.stringify(recursiveObjCheck(sourceConfig), null, 2),
+    `${JSON.stringify(recursiveObjCheck(sourceConfig), null, 2)}\n`,
   )
 }
 

--- a/packages/locales/lib/missing.js
+++ b/packages/locales/lib/missing.js
@@ -41,7 +41,7 @@ async function missingAll() {
             ? fileName.replace('.json', '.js')
             : fileName,
         ),
-        JSON.stringify(missingKeys, null, 2),
+        `${JSON.stringify(missingKeys, null, 2)}\n`,
       )
       log.info(TAGS.locales, fileName, 'file saved.')
     }),

--- a/packages/locales/lib/utils.js
+++ b/packages/locales/lib/utils.js
@@ -67,10 +67,11 @@ function readLocaleDirectory(human = false) {
 async function writeJson(translations, ...directories) {
   try {
     const resolved = resolve(...directories)
-    const file =
+    const contents =
       typeof translations === 'string'
         ? translations
         : JSON.stringify(translations, null, 2)
+    const file = contents.endsWith('\n') ? contents : `${contents}\n`
 
     await fs.writeFile(resolved, file, 'utf8')
     log.info(TAGS.locales, 'wrote file', `${resolved.split('/').pop()}`)

--- a/packages/masterfile/lib/index.js
+++ b/packages/masterfile/lib/index.js
@@ -69,7 +69,7 @@ const generate = async (save = false, historicRarity = {}, dbRarity = {}) => {
   if (save) {
     await fs.promises.writeFile(
       resolve(`${__dirname}/data/masterfile.json`),
-      JSON.stringify(newMf, null, 2),
+      `${JSON.stringify(newMf, null, 2)}\n`,
       'utf8',
     )
   }


### PR DESCRIPTION
The config sync job failed on v2 right after #1245 landed, and locales sync was queued behind it with the same bug waiting.

`bun run config:env` rewrites `config/custom-environment-variables.json` through `JSON.stringify`, which does not emit a trailing newline. Biome wants one, the pre-commit hook now runs Biome, so the job's own commit gets rejected and the whole main pipeline stops. Reproduced locally before touching anything, and the failure is exactly the one CI printed.

The interesting part is that this is not new. It has been happening on every push for a long time, and Prettier was quietly cleaning up after it: the generator stripped the newline, the job saw a diff and committed, `lint-staged` put the newline back on the way through, and the commit succeeded. There are 38 `chore: sync config [skip ci]` commits in the history and the most recent one, `90f94e63`, changes exactly one line from `}` to `}`. That is the newline, and that is the entire content of the commit. Swapping Prettier for Biome did not cause the bug, it just stopped covering for it.

Fixed in the generators rather than by adding an ignore rule, because these are text files and should end with a newline no matter who is checking them. Three other generators had the same line, including the locales one, whose job also commits its output and would have failed the same way the first time it got to run.

Once the generated file matches what is committed, `git diff --quiet` passes, `changes_exist` stays false, and the commit step is skipped entirely. That ends the 38-commit churn as a side effect.

## Verification

```
bun run config:env    regenerated file is byte-identical to the committed one
biome check           passes on the regenerated file
bun run masterfile    output now ends with a newline
bun test              76 pass, 0 fail
bun run typecheck     clean
bun run lint          clean
```

The commit in this PR was made through the real husky hook, which runs the same Biome check that failed in CI, so the fix is exercised end to end rather than argued for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
